### PR TITLE
LRSD-3996 [PRM] Search Invoices bug

### DIFF
--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html
@@ -41,7 +41,7 @@
 							List of Qualified Leads
 						</h6>
 
-						<a class="align-items-end d-flex mx-2 text-decoration-none" href="${activity.listOfQualifiedLeads.link.href}">
+						<a class="align-items-end d-flex mx-2 text-decoration-none" href="${activity.listOfQualifiedLeadsFile.link.href}">
 							<span class="mr-2 mt-3 text-neutral-5">
 								[@clay.icon class="mr-2 mt-3 text-neutral-5"
 								symbol="document-default" /]
@@ -66,18 +66,18 @@
 					</div>
 				[/#if]
 
-				[#if (activity.telemarketingScript?has_content)!false ]
+				[#if (activity.telemarketingScriptFile?has_content)!false ]
 					<div class="py-3">
 						<h6 class="text-neutral-10">Telemarketing Script</h6>
 
-						<a class="align-items-end d-flex mx-2 text-decoration-none" href="${activity.telemarketingScript.link.href}">
+						<a class="align-items-end d-flex mx-2 text-decoration-none" href="${activity.telemarketingScriptFile.link.href}">
 							<span class="mr-2 mt-3 text-neutral-5">
 								[@clay.icon class="mr-2 mt-3 text-neutral-5" symbol="document-default" /]
 							</span>
 
 							<div>
 								<p class="mb-0 text-neutral-9">
-									${activity.telemarketingScript.name?keep_before("#")}
+									${activity.telemarketingScriptFile.name?keep_before("#")}
 								</p>
 							</div>
 						</a>
@@ -136,13 +136,13 @@
 									</td>
 									<td class="border-0">
 										[#if (budget.invoice?has_content)!false ]
-											<a class="align-items-end d-flex text-decoration-none" href="${budget.invoice.link.href}">
+											<a class="align-items-end d-flex text-decoration-none" href="${budget.invoiceFile.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${budget.invoice.name?keep_before("#")}
+													${budget.invoiceFile.name?keep_before("#")}
 												</div>
 											</a>
 										[/#if]
@@ -174,7 +174,7 @@
 										</div>
 
 										[#if (activity.eventProgram?has_content)!false ]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${activity.eventProgram.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${activity.eventProgramFile.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
@@ -193,13 +193,13 @@
 										</div>
 
 										[#list (activity.mdfClmActToMDFActDocs?filter(document -> document.proofOfPerformanceType.key == "eventInvitations"))![] as document]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFile.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFiles.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${document.proofOfPerformanceFile.name?keep_before("#")}
+													${document.proofOfPerformanceFiles.name?keep_before("#")}
 												</div>
 											</a>
 										[/#list]
@@ -212,13 +212,13 @@
 										</div>
 
 										[#list (activity.mdfClmActToMDFActDocs?filter(document -> document.proofOfPerformanceType.key == "eventPhotos"))![] as document]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFile.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFiles.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${document.proofOfPerformanceFile.name?keep_before("#")}
+													${document.proofOfPerformanceFiles.name?keep_before("#")}
 												</div>
 											</a>
 										[/#list]
@@ -231,13 +231,13 @@
 										</div>
 
 										[#list (activity.mdfClmActToMDFActDocs?filter(document -> document.proofOfPerformanceType.key == "eventCollaterals"))![] as document]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFile.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFiles.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${document.proofOfPerformanceFile.name?keep_before("#")}
+													${document.proofOfPerformanceFiles.name?keep_before("#")}
 												</div>
 											</a>
 										[/#list]
@@ -253,13 +253,13 @@
 										</div>
 
 										[#list (activity.mdfClmActToMDFActDocs?filter(document -> document.proofOfPerformanceType.key == "images"))![] as document]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFile.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFiles.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${document.proofOfPerformanceFile.name?keep_before("#")}
+													${document.proofOfPerformanceFiles.name?keep_before("#")}
 												</div>
 											</a>
 										[/#list]
@@ -275,13 +275,13 @@
 										</div>
 
 										[#list (activity.mdfClmActToMDFActDocs?filter(document -> document.proofOfPerformanceType.key == "allContents"))![] as document]
-											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFile.link.href}">
+											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${document.proofOfPerformanceFiles.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-														${document.proofOfPerformanceFile.name?keep_before("#")}
+														${document.proofOfPerformanceFiles.name?keep_before("#")}
 												</div>
 											</a>
 										[/#list]

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/fragments/group/src/mdf-claim-detail-collection/fragments/claim-detail-activity-list/index.html
@@ -173,14 +173,14 @@
 											Event Program
 										</div>
 
-										[#if (activity.eventProgram?has_content)!false ]
+										[#if (activity.eventProgramFile?has_content)!false ]
 											<a class="align-items-end card-interactive d-flex mb-1 p-3 panel panel-secondary text-decoration-none" href="${activity.eventProgramFile.link.href}">
 												<span class="mr-2 text-neutral-5">
 													[@clay.icon symbol="document-default" /]
 												</span>
 
 												<div class="text-neutral-9">
-													${activity.eventProgram.name?keep_before("#")}
+													${activity.eventProgramFile.name?keep_before("#")}
 												</div>
 											</a>
 										[/#if]

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-definitions/mdf-claim-documents.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-definitions/mdf-claim-documents.json
@@ -32,11 +32,7 @@
 				},
 				{
 					"name": "showFilesInDocumentsAndMedia",
-					"value": "true"
-				},
-				{
-					"name": "storageDLFolderPath",
-					"value": "/MDFClaimFile"
+					"value": "false"
 				}
 			],
 			"required": false,

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/17-mdf-claim-activity-documents.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/17-mdf-claim-activity-documents.json
@@ -36,6 +36,68 @@
 			"type": "Long"
 		},
 		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "MDF-CLAIM-ACT-DOC-PROOF-PERF-FILES",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Proof Of Performance Files"
+			},
+			"name": "proofOfPerformanceFiles",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png, tif, tiff, doc, docx"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": "3"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": "false"
+				}
+			],
+			"required": false,
+			"type": "Long"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "MDF-CLAIM-ACT-DOC-ALL-CONT-FILES",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "All Contents File"
+			},
+			"name": "allContentsFile",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "doc, docx, jpeg, jpg, pdf, tif, tiff, txt"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": "3"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": "false"
+				}
+			],
+			"required": false,
+			"type": "Long"
+		},
+		{
 			"DBType": "String",
 			"businessType": "Picklist",
 			"externalReferenceCode": "1ec07d25-6732-4c32-a193-a5ad78c0804d",

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/3-mdf-claim-budget.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/3-mdf-claim-budget.json
@@ -59,6 +59,37 @@
 			],
 			"required": false,
 			"type": "Long"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "MDF-CLAIM-BUDGET-INVOICE-FILE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Invoice File"
+			},
+			"name": "invoiceFile",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png, tif, tiff, doc, docx"
+				},
+				{
+					"name": "maximumFileSize",
+					"value": "3"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": "false"
+				}
+			],
+			"required": false,
+			"type": "Long"
 		}
 	],
 	"objectDefinitionId": "[$OBJECT_DEFINITION_ID:MDFClaimBudget$]"

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
@@ -139,7 +139,7 @@
 				},
 				{
 					"name": "showFilesInDocumentsAndMedia",
-					"value": "true"
+					"value": "false"
 				},
 				{
 					"name": "storageDLFolderPath",

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
@@ -77,11 +77,38 @@
 				},
 				{
 					"name": "showFilesInDocumentsAndMedia",
-					"value": "true"
+					"value": "false"
+				}
+			],
+			"required": false,
+			"type": "Long"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "MDF-CLAIM-ACT-LIST-QUALI-LEADS-FILE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "List of Qualified Leads File"
+			},
+			"name": "listOfQualifiedLeadsFile",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "csv, xlsx, xls"
 				},
 				{
-					"name": "storageDLFolderPath",
-					"value": "/MDFClaimActivity"
+					"name": "maximumFileSize",
+					"value": "3"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": "false"
 				}
 			],
 			"required": false,
@@ -125,13 +152,13 @@
 		{
 			"DBType": "Long",
 			"businessType": "Attachment",
-			"externalReferenceCode": "625cecf7-ed42-4758-9b0d-ee7ff7e9e345",
+			"externalReferenceCode": "MDF-CLAIM-ACT-EVENT-PROG-FILE",
 			"indexed": true,
 			"indexedAsKeyword": false,
 			"label": {
-				"en_US": "Telemarketing Script"
+				"en_US": "Event Program File"
 			},
-			"name": "telemarketingScript",
+			"name": "eventProgramFile",
 			"objectFieldSettings": [
 				{
 					"name": "acceptedFileExtensions",
@@ -147,11 +174,38 @@
 				},
 				{
 					"name": "showFilesInDocumentsAndMedia",
-					"value": "true"
+					"value": "false"
+				}
+			],
+			"required": false,
+			"type": "Long"
+		},
+		{
+			"DBType": "Long",
+			"businessType": "Attachment",
+			"externalReferenceCode": "MDF-CLAIM-ACT-TEL-SCRIPT-FILE",
+			"indexed": true,
+			"indexedAsKeyword": false,
+			"label": {
+				"en_US": "Telemarketing Script File"
+			},
+			"name": "telemarketingScriptFile",
+			"objectFieldSettings": [
+				{
+					"name": "acceptedFileExtensions",
+					"value": "jpeg, jpg, pdf, png, tif, tiff, doc, docx"
 				},
 				{
-					"name": "storageDLFolderPath",
-					"value": "/MDFClaimActivityTelemarketingScript"
+					"name": "maximumFileSize",
+					"value": "3"
+				},
+				{
+					"name": "fileSource",
+					"value": "userComputer"
+				},
+				{
+					"name": "showFilesInDocumentsAndMedia",
+					"value": "false"
 				}
 			],
 			"required": false,

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-partner-portal/src/main/resources/site-initializer/object-fields/4-mdf-claim-activity.json
@@ -139,7 +139,7 @@
 				},
 				{
 					"name": "showFilesInDocumentsAndMedia",
-					"value": "false"
+					"value": "true"
 				},
 				{
 					"name": "storageDLFolderPath",

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/dto/mdfClaimActivityDocumentDTO.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/dto/mdfClaimActivityDocumentDTO.ts
@@ -21,7 +21,7 @@ export default interface MDFClaimActivityDocumentDTO
 	eventPhotos?: LiferayFile & number;
 	id?: number;
 	images?: LiferayFile & number;
-	proofOfPerformanceFile?: LiferayFile & number;
+	proofOfPerformanceFiles?: LiferayFile & number;
 	r_accToMDFClmActDocs_accountEntryId?: number;
 	r_mdfClmActToMDFActDocs_c_mdfClaimActivityId?: number;
 }

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimActivity.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimActivity.ts
@@ -14,8 +14,8 @@ export default interface MDFClaimActivity extends Partial<LiferayObject> {
 	budgets?: MDFClaimBudget[];
 	claimed?: boolean;
 	currency?: LiferayPicklist;
-	eventProgram?: LiferayFile & number;
-	listOfQualifiedLeads?: LiferayFile & number;
+	eventProgramFile?: LiferayFile & number;
+	listOfQualifiedLeadsFile?: LiferayFile & number;
 	metrics: string;
 	name?: string;
 	proofOfPerformance?: MDFClaimActivityDocument;
@@ -23,7 +23,7 @@ export default interface MDFClaimActivity extends Partial<LiferayObject> {
 	r_mdfClmToMDFClmActs_c_mdfClaimId?: number;
 	selected: boolean;
 	telemarketingMetrics?: string;
-	telemarketingScript?: LiferayFile & number;
+	telemarketingScriptFile?: LiferayFile & number;
 	totalCost: number;
 	typeActivity: LiferayPicklist;
 	videoLink?: string;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimBudget.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimBudget.ts
@@ -8,7 +8,7 @@ import LiferayObject from './liferayObject';
 
 export default interface MDFClaimBudget extends Partial<LiferayObject> {
 	expenseName?: string;
-	invoice?: LiferayFile & number;
+	invoiceFile?: LiferayFile & number;
 	invoiceAmount: number;
 	r_bgtToMDFClmBgts_c_budgetId?: number;
 	selected: boolean;

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimBudget.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/interfaces/mdfClaimBudget.ts
@@ -8,8 +8,8 @@ import LiferayObject from './liferayObject';
 
 export default interface MDFClaimBudget extends Partial<LiferayObject> {
 	expenseName?: string;
-	invoiceFile?: LiferayFile & number;
 	invoiceAmount: number;
+	invoiceFile?: LiferayFile & number;
 	r_bgtToMDFClmBgts_c_budgetId?: number;
 	selected: boolean;
 }

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity-document/getDocumentDTOFromLiferayFile.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity-document/getDocumentDTOFromLiferayFile.ts
@@ -15,7 +15,7 @@ export default function getDocumentDTOFromLiferayFile(
 ): MDFClaimActivityDocumentDTO {
 	return {
 		id: liferayFile.objectId,
-		proofOfPerformanceFile: liferayFile.documentId,
+		proofOfPerformanceFiles: liferayFile.documentId,
 		proofOfPerformanceType,
 		r_accToMDFClmActDocs_accountEntryId: companyId,
 		r_mdfClmActToMDFActDocs_c_mdfClaimActivityId: dtoMDFClaimActivityId,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity/getDTOFromMDFClaimActivity.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity/getDTOFromMDFClaimActivity.ts
@@ -13,8 +13,8 @@ export default function getDTOFromMDFClaimActivity(
 ): MDFClaimActivityDTO {
 	return {
 		currency: mdfClaimActivity.currency,
-		eventProgram: mdfClaimActivity.eventProgram?.documentId,
-		listOfQualifiedLeads: mdfClaimActivity.listOfQualifiedLeads?.documentId,
+		eventProgramFile: mdfClaimActivity.eventProgramFile?.documentId,
+		listOfQualifiedLeadsFile: mdfClaimActivity.listOfQualifiedLeadsFile?.documentId,
 		metrics: mdfClaimActivity.metrics,
 		name: mdfClaimActivity.name,
 		r_accToMDFClmActs_accountEntryId: companyId,
@@ -23,7 +23,7 @@ export default function getDTOFromMDFClaimActivity(
 		r_mdfClmToMDFClmActs_c_mdfClaimId: mdfClaimId,
 		selected: mdfClaimActivity.selected,
 		telemarketingMetrics: mdfClaimActivity.telemarketingMetrics,
-		telemarketingScript: mdfClaimActivity.telemarketingScript?.documentId,
+		telemarketingScriptFile: mdfClaimActivity.telemarketingScriptFile?.documentId,
 		totalCost: mdfClaimActivity.totalCost,
 		typeActivity: mdfClaimActivity.typeActivity,
 		videoLink: mdfClaimActivity.videoLink,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity/getDTOFromMDFClaimActivity.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-activity/getDTOFromMDFClaimActivity.ts
@@ -14,7 +14,8 @@ export default function getDTOFromMDFClaimActivity(
 	return {
 		currency: mdfClaimActivity.currency,
 		eventProgramFile: mdfClaimActivity.eventProgramFile?.documentId,
-		listOfQualifiedLeadsFile: mdfClaimActivity.listOfQualifiedLeadsFile?.documentId,
+		listOfQualifiedLeadsFile:
+			mdfClaimActivity.listOfQualifiedLeadsFile?.documentId,
 		metrics: mdfClaimActivity.metrics,
 		name: mdfClaimActivity.name,
 		r_accToMDFClmActs_accountEntryId: companyId,
@@ -23,7 +24,8 @@ export default function getDTOFromMDFClaimActivity(
 		r_mdfClmToMDFClmActs_c_mdfClaimId: mdfClaimId,
 		selected: mdfClaimActivity.selected,
 		telemarketingMetrics: mdfClaimActivity.telemarketingMetrics,
-		telemarketingScriptFile: mdfClaimActivity.telemarketingScriptFile?.documentId,
+		telemarketingScriptFile:
+			mdfClaimActivity.telemarketingScriptFile?.documentId,
 		totalCost: mdfClaimActivity.totalCost,
 		typeActivity: mdfClaimActivity.typeActivity,
 		videoLink: mdfClaimActivity.videoLink,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-budget/getDTOFromMDFClaimBudget.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-budget/getDTOFromMDFClaimBudget.ts
@@ -13,7 +13,7 @@ export default function getDTOFromMDFClaimBudget(
 ): MDFClaimBudgetDTO {
 	return {
 		expenseName: mdfClaimBudget.expenseName,
-		invoice: mdfClaimBudget.invoice?.documentId,
+		invoiceFile: mdfClaimBudget.invoiceFile?.documentId,
 		invoiceAmount: mdfClaimBudget.invoiceAmount,
 		r_accToMDFClmBgts_accountEntryId: companyId,
 		r_bgtToMDFClmBgts_c_budgetId:

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-budget/getDTOFromMDFClaimBudget.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim-budget/getDTOFromMDFClaimBudget.ts
@@ -13,8 +13,8 @@ export default function getDTOFromMDFClaimBudget(
 ): MDFClaimBudgetDTO {
 	return {
 		expenseName: mdfClaimBudget.expenseName,
-		invoiceFile: mdfClaimBudget.invoiceFile?.documentId,
 		invoiceAmount: mdfClaimBudget.invoiceAmount,
+		invoiceFile: mdfClaimBudget.invoiceFile?.documentId,
 		r_accToMDFClmBgts_accountEntryId: companyId,
 		r_bgtToMDFClmBgts_c_budgetId:
 			mdfClaimBudget.r_bgtToMDFClmBgts_c_budgetId,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim/getMDFClaimFromDTO.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim/getMDFClaimFromDTO.ts
@@ -16,16 +16,16 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 			mdfClaim?.mdfClmToMDFClmActs?.map((activityItem) => {
 				const {
 					currency,
-					eventProgram,
+					eventProgramFile,
 					externalReferenceCode,
 					id,
-					listOfQualifiedLeads,
+					listOfQualifiedLeadsFile,
 					metrics,
 					r_actToMDFClmActs_c_activityId,
 					r_mdfClmToMDFClmActs_c_mdfClaimId,
 					selected,
 					telemarketingMetrics,
-					telemarketingScript,
+					telemarketingScriptFile,
 					totalCost,
 					typeActivity,
 					videoLink,
@@ -38,7 +38,7 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 								expenseName,
 								externalReferenceCode,
 								id,
-								invoice,
+								invoiceFile,
 								invoiceAmount,
 								r_bgtToMDFClmBgts_c_budgetId,
 								selected,
@@ -48,9 +48,9 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 								expenseName,
 								externalReferenceCode,
 								id,
-								invoice:
-									invoice &&
-									getLiferayFileFromAttachment(invoice),
+								invoiceFile:
+									invoiceFile &&
+									getLiferayFileFromAttachment(invoiceFile),
 								invoiceAmount,
 								r_bgtToMDFClmBgts_c_budgetId,
 								selected,
@@ -58,23 +58,23 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 						}
 					),
 					currency,
-					eventProgram:
-						eventProgram &&
-						getLiferayFileFromAttachment(eventProgram),
+					eventProgramFile:
+						eventProgramFile &&
+						getLiferayFileFromAttachment(eventProgramFile),
 					externalReferenceCode,
 					id,
-					listOfQualifiedLeads:
-						listOfQualifiedLeads &&
-						getLiferayFileFromAttachment(listOfQualifiedLeads),
+					listOfQualifiedLeadsFile:
+						listOfQualifiedLeadsFile &&
+						getLiferayFileFromAttachment(listOfQualifiedLeadsFile),
 					metrics,
 					proofOfPerformance: getPOPFromMDFActDocs(activityItem),
 					r_actToMDFClmActs_c_activityId,
 					r_mdfClmToMDFClmActs_c_mdfClaimId,
 					selected,
 					telemarketingMetrics,
-					telemarketingScript:
-						telemarketingScript &&
-						getLiferayFileFromAttachment(telemarketingScript),
+					telemarketingScriptFile:
+					telemarketingScriptFile &&
+						getLiferayFileFromAttachment(telemarketingScriptFile),
 					totalCost,
 					typeActivity,
 					videoLink,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim/getMDFClaimFromDTO.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/dto/mdf-claim/getMDFClaimFromDTO.ts
@@ -38,8 +38,8 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 								expenseName,
 								externalReferenceCode,
 								id,
-								invoiceFile,
 								invoiceAmount,
+								invoiceFile,
 								r_bgtToMDFClmBgts_c_budgetId,
 								selected,
 							} = budgetItem;
@@ -48,10 +48,10 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 								expenseName,
 								externalReferenceCode,
 								id,
+								invoiceAmount,
 								invoiceFile:
 									invoiceFile &&
 									getLiferayFileFromAttachment(invoiceFile),
-								invoiceAmount,
 								r_bgtToMDFClmBgts_c_budgetId,
 								selected,
 							};
@@ -73,7 +73,7 @@ export function getMDFClaimFromDTO(mdfClaim: MDFClaimDTO): MDFClaim {
 					selected,
 					telemarketingMetrics,
 					telemarketingScriptFile:
-					telemarketingScriptFile &&
+						telemarketingScriptFile &&
 						getLiferayFileFromAttachment(telemarketingScriptFile),
 					totalCost,
 					typeActivity,

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/getInvoiceFromMDFClmDocs.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/getInvoiceFromMDFClmDocs.ts
@@ -10,7 +10,7 @@ import getNameFromMDFClaimDocument from './getNameFromMDFClaimDocument';
 export default function getInvoiceFromMDFClmDocs(mdfClaimDto: MDFClaimDTO) {
 	return mdfClaimDto.mdfClmToMDFClmDocs?.reduce<LiferayFile[]>(
 		(accumulatorDocuments, currentDocument) => {
-			const reimbursementInvoiceFile = {
+			const reimbursementInvoice = {
 				documentId: currentDocument.file?.id,
 				link: currentDocument.file?.link,
 				name:
@@ -19,7 +19,7 @@ export default function getInvoiceFromMDFClmDocs(mdfClaimDto: MDFClaimDTO) {
 				objectId: currentDocument.id,
 			};
 
-			accumulatorDocuments?.push(reimbursementInvoiceFile);
+			accumulatorDocuments?.push(reimbursementInvoice);
 
 			return accumulatorDocuments;
 		},

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/getPOPDocument.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/common/utils/getPOPDocument.ts
@@ -11,12 +11,12 @@ export function getPOPDocument(
 	mdfClaimActivityDocumentDTO: MDFClaimActivityDocumentDTO
 ): LiferayFile {
 	return {
-		documentId: mdfClaimActivityDocumentDTO.proofOfPerformanceFile?.id,
-		link: mdfClaimActivityDocumentDTO.proofOfPerformanceFile?.link,
+		documentId: mdfClaimActivityDocumentDTO.proofOfPerformanceFiles?.id,
+		link: mdfClaimActivityDocumentDTO.proofOfPerformanceFiles?.link,
 		name:
-			mdfClaimActivityDocumentDTO.proofOfPerformanceFile?.name &&
+			mdfClaimActivityDocumentDTO.proofOfPerformanceFiles?.name &&
 			getNameFromMDFClaimDocument(
-				mdfClaimActivityDocumentDTO.proofOfPerformanceFile.name
+				mdfClaimActivityDocumentDTO.proofOfPerformanceFiles.name
 			),
 		objectId: mdfClaimActivityDocumentDTO.id,
 	};

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
@@ -247,21 +247,28 @@ const ActivityClaimPanel = ({
 							/>
 						))}
 
-						{isBudgetSelected &&
+							{isBudgetSelected &&
 							errors?.activities &&
 							!isBudgetSelected.includes(activityIndex) &&
 							(isButtonClicked || isEdit) && (
-								<ClayAlert
-									displayType="danger"
-									hideCloseIcon={true}
-								>
-									{
-										(errors?.activities[activityIndex] as {
-											budgets?: string;
-										})?.budgets
-									}
-								</ClayAlert>
-							)}
+									<>
+										{((errors.activities[activityIndex] as {
+											budgets?: boolean;
+										})?.budgets) && (
+										<ClayAlert
+											displayType="danger"
+											hideCloseIcon={true}
+										>
+											{
+												(errors?.activities[activityIndex] as {
+													budgets?: string;
+												})?.budgets
+											}
+										</ClayAlert>
+										)}
+									</>
+								)
+							}
 
 						<div className="align-items-center d-flex justify-content-between">
 							<PRMFormik.Field
@@ -269,20 +276,20 @@ const ActivityClaimPanel = ({
 								description="You can downloaded the Excel Template, fill it out, and upload it back here"
 								displayType="secondary"
 								label="List of Qualified Leads"
-								name={`activities[${activityIndex}].listOfQualifiedLeads`}
+								name={`activities[${activityIndex}].listOfQualifiedLeadsFile`}
 								onAccept={(liferayFile: LiferayFile) => {
 									if (
-										activity.listOfQualifiedLeads
+										activity.listOfQualifiedLeadsFile
 											?.documentId
 									) {
 										deleteDocument(
-											activity.listOfQualifiedLeads
+											activity.listOfQualifiedLeadsFile
 												?.documentId
 										);
 									}
 
 									setFieldValue(
-										`activities[${activityIndex}].listOfQualifiedLeads`,
+										`activities[${activityIndex}].listOfQualifiedLeadsFile`,
 										liferayFile
 									);
 								}}

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/ActivityClaimPanel.tsx
@@ -247,28 +247,29 @@ const ActivityClaimPanel = ({
 							/>
 						))}
 
-							{isBudgetSelected &&
+						{isBudgetSelected &&
 							errors?.activities &&
 							!isBudgetSelected.includes(activityIndex) &&
 							(isButtonClicked || isEdit) && (
-									<>
-										{((errors.activities[activityIndex] as {
-											budgets?: boolean;
-										})?.budgets) && (
+								<>
+									{(errors.activities[activityIndex] as {
+										budgets?: boolean;
+									})?.budgets && (
 										<ClayAlert
 											displayType="danger"
 											hideCloseIcon={true}
 										>
 											{
-												(errors?.activities[activityIndex] as {
+												(errors?.activities[
+													activityIndex
+												] as {
 													budgets?: string;
 												})?.budgets
 											}
 										</ClayAlert>
-										)}
-									</>
-								)
-							}
+									)}
+								</>
+							)}
 
 						<div className="align-items-center d-flex justify-content-between">
 							<PRMFormik.Field

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/BudgetClaimPanel/BudgetClaimPanel.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/BudgetClaimPanel/BudgetClaimPanel.tsx
@@ -89,14 +89,14 @@ const BudgetClaimPanel = ({
 							component={PRMForm.InputFile}
 							displayType="secondary"
 							label="Third Party Invoice"
-							name={`${budgetFieldName}.invoice`}
+							name={`${budgetFieldName}.invoiceFile`}
 							onAccept={(liferayFile: LiferayFile) => {
-								if (budget.invoice?.documentId) {
-									deleteDocument(budget.invoice?.documentId);
+								if (budget.invoiceFile?.documentId) {
+									deleteDocument(budget.invoiceFile?.documentId);
 								}
 
 								setFieldValue(
-									`${budgetFieldName}.invoice`,
+									`${budgetFieldName}.invoiceFile`,
 									liferayFile
 								);
 							}}

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/BudgetClaimPanel/BudgetClaimPanel.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/BudgetClaimPanel/BudgetClaimPanel.tsx
@@ -92,7 +92,9 @@ const BudgetClaimPanel = ({
 							name={`${budgetFieldName}.invoiceFile`}
 							onAccept={(liferayFile: LiferayFile) => {
 								if (budget.invoiceFile?.documentId) {
-									deleteDocument(budget.invoiceFile?.documentId);
+									deleteDocument(
+										budget.invoiceFile?.documentId
+									);
 								}
 
 								setFieldValue(

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/EventPopFields/EventPopFields.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/EventPopFields/EventPopFields.tsx
@@ -31,13 +31,13 @@ const EventPopFields = ({
 				description="Only files with the following extensions wil be accepted: doc, docx, jpg, jpeg, png, tif, tiff, pdf"
 				displayType="secondary"
 				label="Event Program"
-				name={`activities[${currentActivityIndex}].eventProgram`}
+				name={`activities[${currentActivityIndex}].eventProgramFile`}
 				onAccept={(liferayFile: LiferayFile) => {
-					if (activity.eventProgram?.documentId) {
-						deleteDocument(activity.eventProgram?.documentId);
+					if (activity.eventProgramFile?.documentId) {
+						deleteDocument(activity.eventProgramFile?.documentId);
 					}
 					setFieldValue(
-						`activities[${currentActivityIndex}].eventProgram`,
+						`activities[${currentActivityIndex}].eventProgramFile`,
 						liferayFile
 					);
 				}}

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/MiscellaneousMarketingPopFields/MiscellaneousMarketingPopFields.tsx
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/components/ActivityClaimPanel/components/MiscellaneousMarketingPopFields/MiscellaneousMarketingPopFields.tsx
@@ -39,15 +39,15 @@ const MiscellaneousMarketingPopFields = ({
 				description="Only files with the following extensions wil be accepted: doc, docx, jpg, jpeg, png, tif, tiff, pdf"
 				displayType="secondary"
 				label="Telemarketing Script"
-				name={`activities[${currentActivityIndex}].telemarketingScript`}
+				name={`activities[${currentActivityIndex}].telemarketingScriptFile`}
 				onAccept={async (liferayFile: LiferayFile) => {
-					if (activity.telemarketingScript?.documentId) {
+					if (activity.telemarketingScriptFile?.documentId) {
 						deleteDocument(
-							activity.telemarketingScript?.documentId
+							activity.telemarketingScriptFile?.documentId
 						);
 					}
 					setFieldValue(
-						`activities[${currentActivityIndex}].telemarketingScript`,
+						`activities[${currentActivityIndex}].telemarketingScriptFile`,
 						liferayFile
 					);
 				}}

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/schema/yup.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/schema/yup.ts
@@ -25,7 +25,7 @@ const claimSchema = object({
 						schema
 							.of(
 								object({
-									invoice: mixed().when('selected', {
+									invoiceFile: mixed().when('selected', {
 										is: (selected: boolean) => selected,
 										then: (schema) =>
 											schema
@@ -33,14 +33,14 @@ const claimSchema = object({
 													'fileSize',
 													validateDocument.fileSize
 														.message,
-													(invoice) => {
+													(invoiceFile) => {
 														if (
-															invoice &&
-															!invoice.documentId
+															invoiceFile &&
+															!invoiceFile.documentId
 														) {
 															return (
 																Math.ceil(
-																	invoice.size /
+																	invoiceFile.size /
 																		1000
 																) <=
 																validateDocument
@@ -57,13 +57,13 @@ const claimSchema = object({
 													'fileType',
 													validateDocument.document
 														.message,
-													(invoice) => {
+													(invoiceFile) => {
 														if (
-															invoice &&
-															!invoice.documentId
+															invoiceFile &&
+															!invoiceFile.documentId
 														) {
 															return validateDocument.document.types.includes(
-																invoice.type
+																invoiceFile.type
 															);
 														}
 
@@ -105,7 +105,7 @@ const claimSchema = object({
 									value.some((item: any) => item.selected)
 							),
 				}),
-				eventProgram: mixed().when(['selected', 'typeActivity'], {
+				eventProgramFile: mixed().when(['selected', 'typeActivity'], {
 					is: (selected: boolean, typeActivity: LiferayPicklist) =>
 						selected && typeActivity.key === TypeActivityKey.EVENT,
 					then: (schema) =>
@@ -114,14 +114,14 @@ const claimSchema = object({
 							.test(
 								'fileSize',
 								validateDocument.fileSize.message,
-								(eventProgram) => {
+								(eventProgramFile) => {
 									if (
-										eventProgram &&
-										!eventProgram.documentId
+										eventProgramFile &&
+										!eventProgramFile.documentId
 									) {
 										return (
 											Math.ceil(
-												eventProgram.size / 1000
+												eventProgramFile.size / 1000
 											) <=
 											validateDocument.fileSize.maxSize
 										);
@@ -133,13 +133,13 @@ const claimSchema = object({
 							.test(
 								'fileType',
 								validateDocument.document.message,
-								(eventProgram) => {
+								(eventProgramFile) => {
 									if (
-										eventProgram &&
-										!eventProgram.documentId
+										eventProgramFile &&
+										!eventProgramFile.documentId
 									) {
 										return validateDocument.document.types.includes(
-											eventProgram.type
+											eventProgramFile.type
 										);
 									}
 
@@ -147,7 +147,7 @@ const claimSchema = object({
 								}
 							),
 				}),
-				listOfQualifiedLeads: mixed()
+				listOfQualifiedLeadsFile: mixed()
 					.when('selected', {
 						is: (selected: boolean) => selected,
 						then: (schema) =>
@@ -155,14 +155,14 @@ const claimSchema = object({
 								.test(
 									'fileSize',
 									validateDocument.fileSize.message,
-									(listOfQualifiedLeads) => {
+									(listOfQualifiedLeadsFile) => {
 										if (
-											listOfQualifiedLeads &&
-											!listOfQualifiedLeads.documentId
+											listOfQualifiedLeadsFile &&
+											!listOfQualifiedLeadsFile.documentId
 										) {
 											return (
 												Math.ceil(
-													listOfQualifiedLeads.size /
+													listOfQualifiedLeadsFile.size /
 														1000
 												) <=
 												validateDocument.fileSize
@@ -177,13 +177,13 @@ const claimSchema = object({
 									'fileType',
 									validateDocument.listOfLeadsDocuments
 										.message,
-									(listOfQualifiedLeads) => {
+									(listOfQualifiedLeadsFile) => {
 										if (
-											listOfQualifiedLeads &&
-											!listOfQualifiedLeads.documentId
+											listOfQualifiedLeadsFile &&
+											!listOfQualifiedLeadsFile.documentId
 										) {
 											return validateDocument.listOfLeadsDocuments.types.includes(
-												listOfQualifiedLeads.type
+												listOfQualifiedLeadsFile.type
 											);
 										}
 
@@ -196,7 +196,7 @@ const claimSchema = object({
 							selected: boolean,
 							typeActivity: LiferayPicklist
 						) =>
-							checkRequiredListOfQualifiedLeads(
+						checkRequiredListOfQualifiedLeads(
 								selected,
 								typeActivity
 							),
@@ -265,21 +265,21 @@ const claimSchema = object({
 								),
 					}
 				),
-				telemarketingScript: mixed().when('selected', {
+				telemarketingScriptFile: mixed().when('selected', {
 					is: (selected: boolean) => selected,
 					then: (schema) =>
 						schema
 							.test(
 								'fileSize',
 								validateDocument.fileSize.message,
-								(telemarketingScript) => {
+								(telemarketingScriptFile) => {
 									if (
-										telemarketingScript &&
-										!telemarketingScript.documentId
+										telemarketingScriptFile &&
+										!telemarketingScriptFile.documentId
 									) {
 										return (
 											Math.ceil(
-												telemarketingScript.size / 1000
+												telemarketingScriptFile.size / 1000
 											) <=
 											validateDocument.fileSize.maxSize
 										);
@@ -291,13 +291,13 @@ const claimSchema = object({
 							.test(
 								'fileType',
 								validateDocument.listOfLeadsDocuments.message,
-								(telemarketingScript) => {
+								(telemarketingScriptFile) => {
 									if (
-										telemarketingScript &&
-										!telemarketingScript.documentId
+										telemarketingScriptFile &&
+										!telemarketingScriptFile.documentId
 									) {
 										return validateDocument.document.types.includes(
-											telemarketingScript.type
+											telemarketingScriptFile.type
 										);
 									}
 
@@ -348,7 +348,7 @@ const claimSchema = object({
 				Boolean(
 					activities?.some((activity) =>
 						Boolean(
-							activity.budgets?.some((budget) => budget.invoice)
+							activity.budgets?.some((budget) => budget.invoiceFile)
 						)
 					)
 				)
@@ -359,14 +359,14 @@ const claimSchema = object({
 				.test(
 					'fileSize',
 					validateDocument.fileSize.message,
-					(reimbursementInvoiceFile) => {
+					(reimbursementInvoice) => {
 						if (
-							reimbursementInvoiceFile &&
-							!reimbursementInvoiceFile.documentId
+							reimbursementInvoice &&
+							!reimbursementInvoice.documentId
 						) {
 							return (
 								Math.ceil(
-									reimbursementInvoiceFile.size / 1000
+									reimbursementInvoice.size / 1000
 								) <= validateDocument.fileSize.maxSize
 							);
 						}
@@ -377,13 +377,13 @@ const claimSchema = object({
 				.test(
 					'fileType',
 					validateDocument.document.message,
-					(reimbursementInvoiceFile) => {
+					(reimbursementInvoice) => {
 						if (
-							reimbursementInvoiceFile &&
-							!reimbursementInvoiceFile.documentId
+							reimbursementInvoice &&
+							!reimbursementInvoice.documentId
 						) {
 							return validateDocument.document.types.includes(
-								reimbursementInvoiceFile.type
+								reimbursementInvoice.type
 							);
 						}
 

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/schema/yup.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/components/MDFClaimPage/schema/yup.ts
@@ -25,6 +25,29 @@ const claimSchema = object({
 						schema
 							.of(
 								object({
+									invoiceAmount: number().when('selected', {
+										is: (selected: boolean) => selected,
+										then: (schema) =>
+											schema
+												.moreThan(
+													0,
+													'Need be bigger than 0'
+												)
+												.test(
+													'biggerAmount',
+													'Invoice amount is larger than the MDF requested amount',
+													(
+														invoiceAmount,
+														testContext
+													) =>
+														Number(invoiceAmount) <=
+														Number(
+															testContext.parent
+																.requestAmount
+														)
+												)
+												.required('Required'),
+									}),
 									invoiceFile: mixed().when('selected', {
 										is: (selected: boolean) => selected,
 										then: (schema) =>
@@ -69,29 +92,6 @@ const claimSchema = object({
 
 														return true;
 													}
-												)
-												.required('Required'),
-									}),
-									invoiceAmount: number().when('selected', {
-										is: (selected: boolean) => selected,
-										then: (schema) =>
-											schema
-												.moreThan(
-													0,
-													'Need be bigger than 0'
-												)
-												.test(
-													'biggerAmount',
-													'Invoice amount is larger than the MDF requested amount',
-													(
-														invoiceAmount,
-														testContext
-													) =>
-														Number(invoiceAmount) <=
-														Number(
-															testContext.parent
-																.requestAmount
-														)
 												)
 												.required('Required'),
 									}),
@@ -196,7 +196,7 @@ const claimSchema = object({
 							selected: boolean,
 							typeActivity: LiferayPicklist
 						) =>
-						checkRequiredListOfQualifiedLeads(
+							checkRequiredListOfQualifiedLeads(
 								selected,
 								typeActivity
 							),
@@ -279,7 +279,8 @@ const claimSchema = object({
 									) {
 										return (
 											Math.ceil(
-												telemarketingScriptFile.size / 1000
+												telemarketingScriptFile.size /
+													1000
 											) <=
 											validateDocument.fileSize.maxSize
 										);
@@ -348,7 +349,9 @@ const claimSchema = object({
 				Boolean(
 					activities?.some((activity) =>
 						Boolean(
-							activity.budgets?.some((budget) => budget.invoiceFile)
+							activity.budgets?.some(
+								(budget) => budget.invoiceFile
+							)
 						)
 					)
 				)
@@ -365,9 +368,8 @@ const claimSchema = object({
 							!reimbursementInvoice.documentId
 						) {
 							return (
-								Math.ceil(
-									reimbursementInvoice.size / 1000
-								) <= validateDocument.fileSize.maxSize
+								Math.ceil(reimbursementInvoice.size / 1000) <=
+								validateDocument.fileSize.maxSize
 							);
 						}
 

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/utils/submitDocuments.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/utils/submitDocuments.ts
@@ -20,29 +20,29 @@ const submitDocuments = async (
 
 	if (mdfClaim.activities?.length) {
 		for (const activity of mdfClaim.activities) {
-			if (activity.eventProgram && !activity.eventProgram.documentId) {
-				activity.eventProgram.documentId = await uploadDocument(
-					activity.eventProgram,
+			if (activity.eventProgramFile && !activity.eventProgramFile.documentId) {
+				activity.eventProgramFile.documentId = await uploadDocument(
+					activity.eventProgramFile,
 					claimParentFolderId
 				);
 			}
 
 			if (
-				activity.listOfQualifiedLeads &&
-				!activity.listOfQualifiedLeads.documentId
+				activity.listOfQualifiedLeadsFile &&
+				!activity.listOfQualifiedLeadsFile.documentId
 			) {
-				activity.listOfQualifiedLeads.documentId = await uploadDocument(
-					activity.listOfQualifiedLeads,
+				activity.listOfQualifiedLeadsFile.documentId = await uploadDocument(
+					activity.listOfQualifiedLeadsFile,
 					claimParentFolderId
 				);
 			}
 
 			if (
-				activity.telemarketingScript &&
-				!activity.telemarketingScript.documentId
+				activity.telemarketingScriptFile &&
+				!activity.telemarketingScriptFile.documentId
 			) {
-				activity.telemarketingScript.documentId = await uploadDocument(
-					activity.telemarketingScript,
+				activity.telemarketingScriptFile.documentId = await uploadDocument(
+					activity.telemarketingScriptFile,
 					claimParentFolderId
 				);
 			}
@@ -84,9 +84,9 @@ const submitDocuments = async (
 
 			if (activity.budgets?.length) {
 				for (const budget of activity.budgets) {
-					if (budget.invoice && !budget.invoice.documentId) {
-						budget.invoice.documentId = await uploadDocument(
-							budget.invoice,
+					if (budget.invoiceFile && !budget.invoiceFile.documentId) {
+						budget.invoiceFile.documentId = await uploadDocument(
+							budget.invoiceFile,
 							claimParentFolderId
 						);
 					}

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/utils/submitDocuments.ts
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-custom-element/src/routes/MDFClaimForm/utils/submitDocuments.ts
@@ -20,7 +20,10 @@ const submitDocuments = async (
 
 	if (mdfClaim.activities?.length) {
 		for (const activity of mdfClaim.activities) {
-			if (activity.eventProgramFile && !activity.eventProgramFile.documentId) {
+			if (
+				activity.eventProgramFile &&
+				!activity.eventProgramFile.documentId
+			) {
 				activity.eventProgramFile.documentId = await uploadDocument(
 					activity.eventProgramFile,
 					claimParentFolderId


### PR DESCRIPTION
Context - Users and guests can view and download documents from any account in PRM.

Explaining the name of the new fields:

We created new attachment fields to not show files in documents and media.
To create these new fields, we use the following syntax pattern: current-att-field-name + 'file'. 
There is a field that already has a 'file' as the final word, so we add an 's' to it.

If you have any syntax suggestions for these fields name, please post a suggestion. 
CC: @ryanschuhler @eliasantosf @kylembischof 

For more context: https://liferay.slack.com/archives/C06HDC5NT4Z/p1713964116281889?thread_ts=1713963801.793919&cid=C06HDC5NT4Z

Ticket: https://liferay.atlassian.net/browse/LRSD-3996
