### PR TITLE
[CP] LRSD-7729 Caching jira search results

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/build.gradle
@@ -20,6 +20,7 @@ apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
 dependencies {
+	implementation group: "com.github.ben-manes.caffeine", name: "caffeine", version: "latest.release"
 	implementation group: "com.google.auth", name: "google-auth-library-credentials", version: "1.0.0"
 	implementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "1.0.0"
 	implementation group: "com.google.cloud", name: "google-cloud-bigquery", version: "2.32.0"
@@ -34,6 +35,7 @@ dependencies {
 	implementation group: "com.liferay.osb.koroneiki", name: "com.liferay.osb.koroneiki.rest.client", version: "latest.release"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "org.json", name: "json", version: "20231013"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-cache", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.18"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/CacheConfiguration.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/CacheConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.customer;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Jenny Chen
+ */
+@Configuration
+public class CacheConfiguration {
+
+	@Bean
+	public CacheManager cacheManager() {
+		CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager(
+			"issue", "issues");
+
+		caffeineCacheManager.setCaffeine(
+			Caffeine.newBuilder(
+			).maximumSize(
+				1000
+			));
+
+		return caffeineCacheManager;
+	}
+
+}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/CustomerSpringBootApplication.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/CustomerSpringBootApplication.java
@@ -9,13 +9,17 @@ import com.liferay.client.extension.util.spring.boot.ClientExtensionUtilSpringBo
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * @author Raymond Augé
  * @author Gregory Amerson
  * @author Brian Wing Shun Chan
  */
+@EnableCaching
+@EnableScheduling
 @Import(ClientExtensionUtilSpringBootComponentScan.class)
 @SpringBootApplication
 public class CustomerSpringBootApplication {

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/JiraRestController.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/JiraRestController.java
@@ -7,22 +7,15 @@ package com.liferay.customer;
 
 import com.liferay.client.extension.util.spring.boot.BaseRestController;
 import com.liferay.customer.constants.RoleConstants;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
+import com.liferay.customer.service.JiraService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.Base64;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,10 +23,9 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -42,13 +34,31 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.reactive.function.client.WebClient;
 
 /**
  * @author Jenny Chen
  */
 @RestController
 public class JiraRestController extends BaseRestController {
+
+	@RequestMapping(method = RequestMethod.DELETE, path = "/jira/delete-cache")
+	public ResponseEntity<String> delete(@AuthenticationPrincipal Jwt jwt) {
+		try {
+			if (!_hasAdministrator(jwt)) {
+				throw new PrincipalException();
+			}
+
+			_jiraService.cacheEvict();
+
+			return new ResponseEntity<>(HttpStatus.OK);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			return new ResponseEntity(
+				exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 
 	@RequestMapping(
 		method = RequestMethod.GET,
@@ -60,7 +70,8 @@ public class JiraRestController extends BaseRestController {
 				(_affectedVersionsExpirationTime <=
 					System.currentTimeMillis())) {
 
-				_affectedVersionsJSONArray = _getAffectedVersionsJSONArray();
+				_affectedVersionsJSONArray =
+					_jiraService.getAffectedVersionsJSONArray();
 
 				_affectedVersionsExpirationTime =
 					System.currentTimeMillis() + Time.DAY;
@@ -88,13 +99,11 @@ public class JiraRestController extends BaseRestController {
 				throw new PrincipalException();
 			}
 
-			JSONObject jsonObject = _getIssueJSONObject(issueKey);
+			JSONObject jsonObject = _jiraService.getIssueJSONObject(issueKey);
 
-			JSONObject responseJSONObject = _transformIssue(jsonObject);
-
-			if (_hasIssuePermission(jwt, responseJSONObject)) {
+			if (_hasIssuePermission(jwt, jsonObject)) {
 				return new ResponseEntity<>(
-					responseJSONObject.toString(), HttpStatus.OK);
+					jsonObject.toString(), HttpStatus.OK);
 			}
 
 			return new ResponseEntity<>(
@@ -132,141 +141,12 @@ public class JiraRestController extends BaseRestController {
 		throws Exception {
 
 		try {
-			StringBundler sb = new StringBundler(49);
+			JSONObject jsonObject = _jiraService.search(
+				filterAffectedVersions, filterCategories, filterClassifications,
+				filterFixVersions, filterSeverities, keywords, page, pageSize,
+				sortOrder, _hasEarlyPublishAccess(jwt));
 
-			sb.append("project = '");
-			sb.append(_jiraSecurityVulnerabilityProject);
-			sb.append("' AND ");
-			sb.append(
-				_getJQLCustomField(
-					_jiraSecurityVulnerabilityFieldPublishingStatus));
-			sb.append(" = 'Ready for Publishing'");
-
-			if (_hasEarlyPublishAccess(jwt)) {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
-				sb.append(" <= now()");
-			}
-			else {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldCustomerPublishingDate));
-				sb.append(" <= now()");
-			}
-
-			if (ArrayUtil.isNotEmpty(filterAffectedVersions)) {
-				sb.append(" AND ");
-				sb.append(_FIELD_AFFECTED_VERSION);
-				sb.append(" in ('");
-				sb.append(StringUtil.merge(filterAffectedVersions, "','"));
-				sb.append("')");
-			}
-
-			if (ArrayUtil.isNotEmpty(filterCategories)) {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldCategories));
-				sb.append(" in ('");
-				sb.append(StringUtil.merge(filterCategories, "','"));
-				sb.append("')");
-			}
-
-			if (ArrayUtil.isNotEmpty(filterClassifications)) {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldIssueClassification));
-				sb.append(" in ('");
-				sb.append(StringUtil.merge(filterClassifications, "','"));
-				sb.append("')");
-			}
-
-			if (ArrayUtil.isNotEmpty(filterFixVersions)) {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldFixVersions));
-				sb.append(" in ('");
-				sb.append(StringUtil.merge(filterFixVersions, "','"));
-				sb.append("')");
-			}
-
-			if (ArrayUtil.isNotEmpty(filterSeverities)) {
-				sb.append(" AND ");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldSeverity));
-				sb.append(" in ('");
-				sb.append(StringUtil.merge(filterSeverities, "','"));
-				sb.append("')");
-			}
-
-			if (Validator.isNotNull(keywords)) {
-				sb.append(" AND (");
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldCustomerPortalSummary));
-				sb.append(" ~ ");
-				sb.append(StringUtil.quote(keywords));
-				sb.append(" OR ");
-				sb.append(
-					_getJQLCustomField(_jiraSecurityVulnerabilityFieldCVEIds));
-				sb.append(" ~ ");
-				sb.append(StringUtil.quote(keywords));
-				sb.append(")");
-			}
-
-			sb.append(" ORDER BY ");
-
-			if (_hasEarlyPublishAccess(jwt)) {
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
-			}
-			else {
-				sb.append(
-					_getJQLCustomField(
-						_jiraSecurityVulnerabilityFieldCustomerPublishingDate));
-			}
-
-			sb.append(" ");
-			sb.append(sortOrder);
-			sb.append(", ");
-			sb.append(
-				_getJQLCustomField(_jiraSecurityVulnerabilityFieldSeverity));
-			sb.append(" ASC");
-
-			String[] securityVulnerabilitiesIssueFields = {
-				_FIELD_COMPONENTS, _FIELD_ISSUE_KEY, _FIELD_VERSIONS,
-				_jiraSecurityVulnerabilityFieldAffectedVersionsDetails,
-				_jiraSecurityVulnerabilityFieldAffects,
-				_jiraSecurityVulnerabilityFieldCategories,
-				_jiraSecurityVulnerabilityFieldCustomerPortalDescription,
-				_jiraSecurityVulnerabilityFieldCustomerPortalSummary,
-				_jiraSecurityVulnerabilityFieldCustomerPublishingDate,
-				_jiraSecurityVulnerabilityFieldCVEIds,
-				_jiraSecurityVulnerabilityFieldCVSSBaseScore,
-				_jiraSecurityVulnerabilityFieldCVSSVectorString,
-				_jiraSecurityVulnerabilityFieldCWEIds,
-				_jiraSecurityVulnerabilityFieldFixVersions,
-				_jiraSecurityVulnerabilityFieldIssueClassification,
-				_jiraSecurityVulnerabilityFieldPartnerPublishingDate,
-				_jiraSecurityVulnerabilityFieldPublishingStatus,
-				_jiraSecurityVulnerabilityFieldSeverity
-			};
-
-			JSONObject jsonObject = _search(
-				sb.toString(), pageSize, securityVulnerabilitiesIssueFields,
-				_calculateStartAt(page, pageSize));
-
-			JSONObject responseJSONObject = _transformSearchResults(jsonObject);
-
-			return new ResponseEntity<>(
-				responseJSONObject.toString(), HttpStatus.OK);
+			return new ResponseEntity<>(jsonObject.toString(), HttpStatus.OK);
 		}
 		catch (Exception exception) {
 			_log.error(exception, exception);
@@ -274,148 +154,6 @@ public class JiraRestController extends BaseRestController {
 			return new ResponseEntity<>(
 				exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
 		}
-	}
-
-	private int _calculatePage(int startAt, int maxResults) {
-		return (startAt / maxResults) + 1;
-	}
-
-	private int _calculateStartAt(int page, int pageSize) {
-		return (page - 1) * pageSize;
-	}
-
-	private JSONArray _flattenJSONArray(JSONArray jsonArray) {
-		if (jsonArray == null) {
-			return new JSONArray();
-		}
-
-		JSONArray flattenedJSONArray = new JSONArray();
-
-		for (int i = 0; i < jsonArray.length(); i++) {
-			JSONObject jsonObject = jsonArray.getJSONObject(i);
-
-			String name = jsonObject.optString("name");
-
-			if (Validator.isNotNull(name)) {
-				flattenedJSONArray.put(name);
-			}
-
-			String value = jsonObject.optString("value");
-
-			if (Validator.isNotNull(value)) {
-				flattenedJSONArray.put(value);
-			}
-		}
-
-		return flattenedJSONArray;
-	}
-
-	private JSONArray _getAffectedVersionsJSONArray() throws Exception {
-		try {
-			Set<String> affectedVersions = new TreeSet<>();
-
-			String[] issueFields = {_FIELD_VERSIONS};
-
-			StringBundler sb = new StringBundler(7);
-
-			sb.append("project = '");
-			sb.append(_jiraSecurityVulnerabilityProject);
-			sb.append("' AND ");
-			sb.append(
-				_getJQLCustomField(
-					_jiraSecurityVulnerabilityFieldPublishingStatus));
-			sb.append(" = 'Ready for Publishing' AND ");
-			sb.append(
-				_getJQLCustomField(
-					_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
-			sb.append(" <= now()");
-
-			String jql = sb.toString();
-
-			for (int i = 0; true; i += 100) {
-				JSONObject jsonObject = _search(jql, 100, issueFields, i);
-
-				JSONArray issuesJSONArray = jsonObject.getJSONArray("issues");
-
-				if (issuesJSONArray.length() <= 0) {
-					break;
-				}
-
-				for (int j = 0; j < issuesJSONArray.length(); j++) {
-					JSONObject issueJSONObject = issuesJSONArray.getJSONObject(
-						j);
-
-					JSONObject fieldsJSONObject = issueJSONObject.getJSONObject(
-						"fields");
-
-					JSONArray versionsJSONArray = fieldsJSONObject.getJSONArray(
-						"versions");
-
-					for (int k = 0; k < versionsJSONArray.length(); k++) {
-						JSONObject versionJSONObject =
-							versionsJSONArray.getJSONObject(k);
-
-						affectedVersions.add(
-							versionJSONObject.optString("name"));
-					}
-				}
-			}
-
-			return new JSONArray(affectedVersions);
-		}
-		catch (Exception exception) {
-			_log.error("Unable to get affected versions", exception);
-		}
-
-		return _affectedVersionsJSONArray;
-	}
-
-	private String _getCredentials() {
-		String jiraUserNameAndJiraApiToken =
-			_jiraAPIEmailAddress + StringPool.COLON + _jiraAPIToken;
-
-		return "Basic " + Base64.encode(jiraUserNameAndJiraApiToken.getBytes());
-	}
-
-	private JSONObject _getIssueJSONObject(String issueKey) throws Exception {
-		try {
-			return new JSONObject(
-				WebClient.create(
-					_jiraURL
-				).get(
-				).uri(
-					StringBundler.concat(_URL_REST_API_2, "/issue/", issueKey)
-				).accept(
-					MediaType.APPLICATION_JSON
-				).header(
-					HttpHeaders.AUTHORIZATION, _getCredentials()
-				).retrieve(
-				).bodyToMono(
-					String.class
-				).block());
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to get Jira issue with key " + issueKey, exception);
-			}
-		}
-
-		return null;
-	}
-
-	private String _getJQLCustomField(String customField) {
-		int pos = customField.indexOf(StringPool.UNDERLINE);
-
-		return "cf[" + customField.substring(pos + 1) + "]";
-	}
-
-	private String _getJSONObjectFieldValue(JSONObject jsonObject) {
-		if (jsonObject != null) {
-			return jsonObject.optString("value");
-		}
-
-		return null;
 	}
 
 	private JSONObject _getMyUserAccountJSONObject(Jwt jwt) {
@@ -452,6 +190,16 @@ public class JiraRestController extends BaseRestController {
 		}
 
 		return rolesNames;
+	}
+
+	private boolean _hasAdministrator(Jwt jwt) {
+		List<String> userRoleNames = _getUserRoleNames(jwt);
+
+		if (userRoleNames.contains(RoleConstants.NAME_ADMINISTRATOR)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasEarlyPublishAccess(Jwt jwt) {
@@ -504,248 +252,15 @@ public class JiraRestController extends BaseRestController {
 			dateTimeFormatter);
 	}
 
-	private JSONObject _search(
-			String jql, int maxResults, String[] returnFields, int startAt)
-		throws Exception {
-
-		try {
-			return new JSONObject(
-				WebClient.create(
-					_jiraURL
-				).get(
-				).uri(
-					uriBuilder -> uriBuilder.path(
-						_URL_REST_API_2 + "/search"
-					).queryParam(
-						"jql", jql
-					).queryParam(
-						"fields", StringUtil.merge(returnFields)
-					).queryParam(
-						"maxResults", maxResults
-					).queryParam(
-						"startAt", startAt
-					).build()
-				).accept(
-					MediaType.APPLICATION_JSON
-				).header(
-					HttpHeaders.AUTHORIZATION, _getCredentials()
-				).retrieve(
-				).bodyToMono(
-					String.class
-				).block());
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					"Unable to get Jira issues with JQL " + jql, exception);
-			}
-		}
-
-		return null;
-	}
-
-	private JSONObject _transformIssue(JSONObject issueJSONObject) {
-		return new JSONObject(
-		).put(
-			"fields",
-			_transformIssueFields(issueJSONObject.getJSONObject("fields"))
-		).put(
-			"key", issueJSONObject.getString(_FIELD_ISSUE_KEY)
-		);
-	}
-
-	private JSONObject _transformIssueFields(JSONObject issueFieldsJSONObject) {
-		return new JSONObject(
-		).put(
-			"affectedVersionsDetails",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldAffectedVersionsDetails)
-		).put(
-			"affectedVersions",
-			_flattenJSONArray(
-				issueFieldsJSONObject.getJSONArray(_FIELD_VERSIONS))
-		).put(
-			"affects",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldAffects)
-		).put(
-			"categories",
-			_flattenJSONArray(
-				issueFieldsJSONObject.optJSONArray(
-					_jiraSecurityVulnerabilityFieldCategories))
-		).put(
-			"components",
-			_flattenJSONArray(
-				issueFieldsJSONObject.getJSONArray(_FIELD_COMPONENTS))
-		).put(
-			"customerPortalDescription",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCustomerPortalDescription)
-		).put(
-			"customerPortalSummary",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCustomerPortalSummary)
-		).put(
-			"customerPublishingDate",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCustomerPublishingDate)
-		).put(
-			"cveIds",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCVEIds)
-		).put(
-			"cvssBaseScore",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCVSSBaseScore)
-		).put(
-			"cvssVectorString",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCVSSVectorString)
-		).put(
-			"cweIds",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldCWEIds)
-		).put(
-			"fixVersions",
-			_flattenJSONArray(
-				issueFieldsJSONObject.optJSONArray(
-					_jiraSecurityVulnerabilityFieldFixVersions))
-		).put(
-			"issueClassification",
-			_getJSONObjectFieldValue(
-				issueFieldsJSONObject.optJSONObject(
-					_jiraSecurityVulnerabilityFieldIssueClassification))
-		).put(
-			"partnerPublishingDate",
-			issueFieldsJSONObject.optString(
-				_jiraSecurityVulnerabilityFieldPartnerPublishingDate)
-		).put(
-			"publishingStatus",
-			_getJSONObjectFieldValue(
-				issueFieldsJSONObject.optJSONObject(
-					_jiraSecurityVulnerabilityFieldPublishingStatus))
-		).put(
-			"severity",
-			_getJSONObjectFieldValue(
-				issueFieldsJSONObject.optJSONObject(
-					_jiraSecurityVulnerabilityFieldSeverity))
-		);
-	}
-
-	private JSONObject _transformSearchResults(JSONObject resultsJSONObject) {
-		JSONArray jsonArray = new JSONArray();
-
-		JSONArray issuesJSONArray = resultsJSONObject.getJSONArray("issues");
-
-		for (int i = 0; i < issuesJSONArray.length(); i++) {
-			JSONObject issueJSONObject = issuesJSONArray.getJSONObject(i);
-
-			jsonArray.put(_transformIssue(issueJSONObject));
-		}
-
-		return new JSONObject(
-		).put(
-			"issues", jsonArray
-		).put(
-			"page",
-			_calculatePage(
-				resultsJSONObject.getInt("startAt"),
-				resultsJSONObject.getInt("maxResults"))
-		).put(
-			"pageSize", resultsJSONObject.getInt("maxResults")
-		).put(
-			"total", resultsJSONObject.getInt("total")
-		);
-	}
-
-	private static final String _FIELD_AFFECTED_VERSION = "affectedVersion";
-
-	private static final String _FIELD_COMPONENTS = "components";
-
-	private static final String _FIELD_ISSUE_KEY = "key";
-
-	private static final String _FIELD_VERSIONS = "versions";
-
-	private static final String _URL_REST_API_2 = "/rest/api/2";
-
 	private static final Log _log = LogFactory.getLog(JiraRestController.class);
 
 	private long _affectedVersionsExpirationTime;
 	private JSONArray _affectedVersionsJSONArray;
 
-	@Value("${liferay.customer.jira.api.email.address}")
-	private String _jiraAPIEmailAddress;
-
-	@Value("${liferay.customer.jira.api.token}")
-	private String _jiraAPIToken;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.affected.versions.details}"
-	)
-	private String _jiraSecurityVulnerabilityFieldAffectedVersionsDetails;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.affects}")
-	private String _jiraSecurityVulnerabilityFieldAffects;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.categories}")
-	private String _jiraSecurityVulnerabilityFieldCategories;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.customer.portal.description}"
-	)
-	private String _jiraSecurityVulnerabilityFieldCustomerPortalDescription;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.customer.portal.summary}"
-	)
-	private String _jiraSecurityVulnerabilityFieldCustomerPortalSummary;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.customer.publishing.date}"
-	)
-	private String _jiraSecurityVulnerabilityFieldCustomerPublishingDate;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.cve.ids}")
-	private String _jiraSecurityVulnerabilityFieldCVEIds;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.cvss.base.score}"
-	)
-	private String _jiraSecurityVulnerabilityFieldCVSSBaseScore;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.cvss.vector.string}"
-	)
-	private String _jiraSecurityVulnerabilityFieldCVSSVectorString;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.cwe.ids}")
-	private String _jiraSecurityVulnerabilityFieldCWEIds;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.fix.versions}")
-	private String _jiraSecurityVulnerabilityFieldFixVersions;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.issue.classification}"
-	)
-	private String _jiraSecurityVulnerabilityFieldIssueClassification;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.partner.publishing.date}"
-	)
-	private String _jiraSecurityVulnerabilityFieldPartnerPublishingDate;
-
-	@Value(
-		"${liferay.customer.jira.security.vulnerability.field.publishing.status}"
-	)
-	private String _jiraSecurityVulnerabilityFieldPublishingStatus;
-
-	@Value("${liferay.customer.jira.security.vulnerability.field.severity}")
-	private String _jiraSecurityVulnerabilityFieldSeverity;
-
 	@Value("${liferay.customer.jira.security.vulnerability.project}")
 	private String _jiraSecurityVulnerabilityProject;
 
-	@Value("${liferay.customer.jira.url}")
-	private String _jiraURL;
+	@Autowired
+	private JiraService _jiraService;
 
 }

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/service/JiraService.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/service/JiraService.java
@@ -1,0 +1,578 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.customer.service;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * @author Jenny Chen
+ */
+@Component
+public class JiraService {
+
+	@CacheEvict(allEntries = true, value = {"issue", "issues"})
+	@Scheduled(cron = "0 0 0 * * *")
+	public void cacheEvict() throws Exception {
+	}
+
+	public JSONArray getAffectedVersionsJSONArray() throws Exception {
+		try {
+			Set<String> affectedVersions = new TreeSet<>();
+
+			String[] issueFields = {_FIELD_VERSIONS};
+
+			StringBundler sb = new StringBundler(7);
+
+			sb.append("project = '");
+			sb.append(_jiraSecurityVulnerabilityProject);
+			sb.append("' AND ");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldPublishingStatus));
+			sb.append(" = 'Ready for Publishing' AND ");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
+			sb.append(" <= now()");
+
+			String jql = sb.toString();
+
+			for (int i = 0; true; i += 100) {
+				JSONObject jsonObject = _search(jql, 100, issueFields, i);
+
+				JSONArray issuesJSONArray = jsonObject.getJSONArray("issues");
+
+				if (issuesJSONArray.length() <= 0) {
+					break;
+				}
+
+				for (int j = 0; j < issuesJSONArray.length(); j++) {
+					JSONObject issueJSONObject = issuesJSONArray.getJSONObject(
+						j);
+
+					JSONObject fieldsJSONObject = issueJSONObject.getJSONObject(
+						"fields");
+
+					JSONArray versionsJSONArray = fieldsJSONObject.getJSONArray(
+						"versions");
+
+					for (int k = 0; k < versionsJSONArray.length(); k++) {
+						JSONObject versionJSONObject =
+							versionsJSONArray.getJSONObject(k);
+
+						affectedVersions.add(
+							versionJSONObject.optString("name"));
+					}
+				}
+			}
+
+			return new JSONArray(affectedVersions);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to get affected versions", exception);
+		}
+
+		return null;
+	}
+
+	@Cacheable("issue")
+	public JSONObject getIssueJSONObject(String issueKey) throws Exception {
+		try {
+			JSONObject jsonObject = new JSONObject(
+				WebClient.create(
+					_jiraURL
+				).get(
+				).uri(
+					StringBundler.concat(_URL_REST_API_2, "/issue/", issueKey)
+				).accept(
+					MediaType.APPLICATION_JSON
+				).header(
+					HttpHeaders.AUTHORIZATION, _getCredentials()
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block());
+
+			return _transformIssue(jsonObject);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to get Jira issue with key " + issueKey, exception);
+			}
+		}
+
+		return null;
+	}
+
+	@Cacheable("issues")
+	public JSONObject search(
+			String[] filterAffectedVersions, String[] filterCategories,
+			String[] filterClassifications, String[] filterFixVersions,
+			String[] filterSeverities, String keywords, int page, int pageSize,
+			String sortOrder, boolean hasEarlyPublishAccess)
+		throws Exception {
+
+		StringBundler sb = new StringBundler(51);
+
+		sb.append("project = '");
+		sb.append(_jiraSecurityVulnerabilityProject);
+		sb.append("' AND ");
+		sb.append(
+			_getJQLCustomField(
+				_jiraSecurityVulnerabilityFieldPublishingStatus));
+		sb.append(" = 'Ready for Publishing'");
+
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(
+			"yyyy-MM-dd 00:00");
+
+		if (hasEarlyPublishAccess) {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
+			sb.append(" <= '");
+			sb.append(dateTimeFormatter.format(LocalDateTime.now()));
+			sb.append("'");
+		}
+		else {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldCustomerPublishingDate));
+			sb.append(" <= '");
+			sb.append(dateTimeFormatter.format(LocalDateTime.now()));
+			sb.append("'");
+		}
+
+		if (ArrayUtil.isNotEmpty(filterAffectedVersions)) {
+			sb.append(" AND ");
+			sb.append(_FIELD_AFFECTED_VERSION);
+			sb.append(" in ('");
+			sb.append(StringUtil.merge(filterAffectedVersions, "','"));
+			sb.append("')");
+		}
+
+		if (ArrayUtil.isNotEmpty(filterCategories)) {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(_jiraSecurityVulnerabilityFieldCategories));
+			sb.append(" in ('");
+			sb.append(StringUtil.merge(filterCategories, "','"));
+			sb.append("')");
+		}
+
+		if (ArrayUtil.isNotEmpty(filterClassifications)) {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldIssueClassification));
+			sb.append(" in ('");
+			sb.append(StringUtil.merge(filterClassifications, "','"));
+			sb.append("')");
+		}
+
+		if (ArrayUtil.isNotEmpty(filterFixVersions)) {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(_jiraSecurityVulnerabilityFieldFixVersions));
+			sb.append(" in ('");
+			sb.append(StringUtil.merge(filterFixVersions, "','"));
+			sb.append("')");
+		}
+
+		if (ArrayUtil.isNotEmpty(filterSeverities)) {
+			sb.append(" AND ");
+			sb.append(
+				_getJQLCustomField(_jiraSecurityVulnerabilityFieldSeverity));
+			sb.append(" in ('");
+			sb.append(StringUtil.merge(filterSeverities, "','"));
+			sb.append("')");
+		}
+
+		if (Validator.isNotNull(keywords)) {
+			sb.append(" AND (");
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldCustomerPortalSummary));
+			sb.append(" ~ ");
+			sb.append(StringUtil.quote(keywords));
+			sb.append(" OR ");
+			sb.append(
+				_getJQLCustomField(_jiraSecurityVulnerabilityFieldCVEIds));
+			sb.append(" ~ ");
+			sb.append(StringUtil.quote(keywords));
+			sb.append(")");
+		}
+
+		sb.append(" ORDER BY ");
+
+		if (hasEarlyPublishAccess) {
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldPartnerPublishingDate));
+		}
+		else {
+			sb.append(
+				_getJQLCustomField(
+					_jiraSecurityVulnerabilityFieldCustomerPublishingDate));
+		}
+
+		sb.append(" ");
+		sb.append(sortOrder);
+		sb.append(", ");
+		sb.append(_getJQLCustomField(_jiraSecurityVulnerabilityFieldSeverity));
+		sb.append(" ASC");
+
+		String[] securityVulnerabilitiesIssueFields = {
+			_FIELD_COMPONENTS, _FIELD_ISSUE_KEY, _FIELD_VERSIONS,
+			_jiraSecurityVulnerabilityFieldAffectedVersionsDetails,
+			_jiraSecurityVulnerabilityFieldAffects,
+			_jiraSecurityVulnerabilityFieldCategories,
+			_jiraSecurityVulnerabilityFieldCustomerPortalDescription,
+			_jiraSecurityVulnerabilityFieldCustomerPortalSummary,
+			_jiraSecurityVulnerabilityFieldCustomerPublishingDate,
+			_jiraSecurityVulnerabilityFieldCVEIds,
+			_jiraSecurityVulnerabilityFieldCVSSBaseScore,
+			_jiraSecurityVulnerabilityFieldCVSSVectorString,
+			_jiraSecurityVulnerabilityFieldCWEIds,
+			_jiraSecurityVulnerabilityFieldFixVersions,
+			_jiraSecurityVulnerabilityFieldIssueClassification,
+			_jiraSecurityVulnerabilityFieldPartnerPublishingDate,
+			_jiraSecurityVulnerabilityFieldPublishingStatus,
+			_jiraSecurityVulnerabilityFieldSeverity
+		};
+
+		JSONObject jsonObject = _search(
+			sb.toString(), pageSize, securityVulnerabilitiesIssueFields,
+			_calculateStartAt(page, pageSize));
+
+		return _transformSearchResults(jsonObject);
+	}
+
+	private int _calculatePage(int startAt, int maxResults) {
+		return (startAt / maxResults) + 1;
+	}
+
+	private int _calculateStartAt(int page, int pageSize) {
+		return (page - 1) * pageSize;
+	}
+
+	private JSONArray _flattenJSONArray(JSONArray jsonArray) {
+		if (jsonArray == null) {
+			return new JSONArray();
+		}
+
+		JSONArray flattenedJSONArray = new JSONArray();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject jsonObject = jsonArray.getJSONObject(i);
+
+			String name = jsonObject.optString("name");
+
+			if (Validator.isNotNull(name)) {
+				flattenedJSONArray.put(name);
+			}
+
+			String value = jsonObject.optString("value");
+
+			if (Validator.isNotNull(value)) {
+				flattenedJSONArray.put(value);
+			}
+		}
+
+		return flattenedJSONArray;
+	}
+
+	private String _getCredentials() {
+		String jiraUserNameAndJiraApiToken =
+			_jiraAPIEmailAddress + StringPool.COLON + _jiraAPIToken;
+
+		return "Basic " + Base64.encode(jiraUserNameAndJiraApiToken.getBytes());
+	}
+
+	private String _getJQLCustomField(String customField) {
+		int pos = customField.indexOf(StringPool.UNDERLINE);
+
+		return "cf[" + customField.substring(pos + 1) + "]";
+	}
+
+	private String _getJSONObjectFieldValue(JSONObject jsonObject) {
+		if (jsonObject != null) {
+			return jsonObject.optString("value");
+		}
+
+		return null;
+	}
+
+	private JSONObject _search(
+			String jql, int maxResults, String[] returnFields, int startAt)
+		throws Exception {
+
+		try {
+			return new JSONObject(
+				WebClient.create(
+					_jiraURL
+				).get(
+				).uri(
+					uriBuilder -> uriBuilder.path(
+						_URL_REST_API_2 + "/search"
+					).queryParam(
+						"jql", jql
+					).queryParam(
+						"fields", StringUtil.merge(returnFields)
+					).queryParam(
+						"maxResults", maxResults
+					).queryParam(
+						"startAt", startAt
+					).build()
+				).accept(
+					MediaType.APPLICATION_JSON
+				).header(
+					HttpHeaders.AUTHORIZATION, _getCredentials()
+				).retrieve(
+				).bodyToMono(
+					String.class
+				).block());
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to get Jira issues with JQL " + jql, exception);
+			}
+		}
+
+		return null;
+	}
+
+	private JSONObject _transformIssue(JSONObject issueJSONObject) {
+		return new JSONObject(
+		).put(
+			"fields",
+			_transformIssueFields(issueJSONObject.getJSONObject("fields"))
+		).put(
+			"key", issueJSONObject.getString(_FIELD_ISSUE_KEY)
+		);
+	}
+
+	private JSONObject _transformIssueFields(JSONObject issueFieldsJSONObject) {
+		return new JSONObject(
+		).put(
+			"affectedVersionsDetails",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldAffectedVersionsDetails)
+		).put(
+			"affectedVersions",
+			_flattenJSONArray(
+				issueFieldsJSONObject.getJSONArray(_FIELD_VERSIONS))
+		).put(
+			"affects",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldAffects)
+		).put(
+			"categories",
+			_flattenJSONArray(
+				issueFieldsJSONObject.optJSONArray(
+					_jiraSecurityVulnerabilityFieldCategories))
+		).put(
+			"components",
+			_flattenJSONArray(
+				issueFieldsJSONObject.getJSONArray(_FIELD_COMPONENTS))
+		).put(
+			"customerPortalDescription",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCustomerPortalDescription)
+		).put(
+			"customerPortalSummary",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCustomerPortalSummary)
+		).put(
+			"customerPublishingDate",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCustomerPublishingDate)
+		).put(
+			"cveIds",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCVEIds)
+		).put(
+			"cvssBaseScore",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCVSSBaseScore)
+		).put(
+			"cvssVectorString",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCVSSVectorString)
+		).put(
+			"cweIds",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldCWEIds)
+		).put(
+			"fixVersions",
+			_flattenJSONArray(
+				issueFieldsJSONObject.optJSONArray(
+					_jiraSecurityVulnerabilityFieldFixVersions))
+		).put(
+			"issueClassification",
+			_getJSONObjectFieldValue(
+				issueFieldsJSONObject.optJSONObject(
+					_jiraSecurityVulnerabilityFieldIssueClassification))
+		).put(
+			"partnerPublishingDate",
+			issueFieldsJSONObject.optString(
+				_jiraSecurityVulnerabilityFieldPartnerPublishingDate)
+		).put(
+			"publishingStatus",
+			_getJSONObjectFieldValue(
+				issueFieldsJSONObject.optJSONObject(
+					_jiraSecurityVulnerabilityFieldPublishingStatus))
+		).put(
+			"severity",
+			_getJSONObjectFieldValue(
+				issueFieldsJSONObject.optJSONObject(
+					_jiraSecurityVulnerabilityFieldSeverity))
+		);
+	}
+
+	private JSONObject _transformSearchResults(JSONObject resultsJSONObject) {
+		JSONArray jsonArray = new JSONArray();
+
+		JSONArray issuesJSONArray = resultsJSONObject.getJSONArray("issues");
+
+		for (int i = 0; i < issuesJSONArray.length(); i++) {
+			JSONObject issueJSONObject = issuesJSONArray.getJSONObject(i);
+
+			jsonArray.put(_transformIssue(issueJSONObject));
+		}
+
+		return new JSONObject(
+		).put(
+			"issues", jsonArray
+		).put(
+			"page",
+			_calculatePage(
+				resultsJSONObject.getInt("startAt"),
+				resultsJSONObject.getInt("maxResults"))
+		).put(
+			"pageSize", resultsJSONObject.getInt("maxResults")
+		).put(
+			"total", resultsJSONObject.getInt("total")
+		);
+	}
+
+	private static final String _FIELD_AFFECTED_VERSION = "affectedVersion";
+
+	private static final String _FIELD_COMPONENTS = "components";
+
+	private static final String _FIELD_ISSUE_KEY = "key";
+
+	private static final String _FIELD_VERSIONS = "versions";
+
+	private static final String _URL_REST_API_2 = "/rest/api/2";
+
+	private static final Log _log = LogFactory.getLog(JiraService.class);
+
+	@Value("${liferay.customer.jira.api.email.address}")
+	private String _jiraAPIEmailAddress;
+
+	@Value("${liferay.customer.jira.api.token}")
+	private String _jiraAPIToken;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.affected.versions.details}"
+	)
+	private String _jiraSecurityVulnerabilityFieldAffectedVersionsDetails;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.affects}")
+	private String _jiraSecurityVulnerabilityFieldAffects;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.categories}")
+	private String _jiraSecurityVulnerabilityFieldCategories;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.customer.portal.description}"
+	)
+	private String _jiraSecurityVulnerabilityFieldCustomerPortalDescription;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.customer.portal.summary}"
+	)
+	private String _jiraSecurityVulnerabilityFieldCustomerPortalSummary;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.customer.publishing.date}"
+	)
+	private String _jiraSecurityVulnerabilityFieldCustomerPublishingDate;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.cve.ids}")
+	private String _jiraSecurityVulnerabilityFieldCVEIds;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.cvss.base.score}"
+	)
+	private String _jiraSecurityVulnerabilityFieldCVSSBaseScore;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.cvss.vector.string}"
+	)
+	private String _jiraSecurityVulnerabilityFieldCVSSVectorString;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.cwe.ids}")
+	private String _jiraSecurityVulnerabilityFieldCWEIds;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.fix.versions}")
+	private String _jiraSecurityVulnerabilityFieldFixVersions;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.issue.classification}"
+	)
+	private String _jiraSecurityVulnerabilityFieldIssueClassification;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.partner.publishing.date}"
+	)
+	private String _jiraSecurityVulnerabilityFieldPartnerPublishingDate;
+
+	@Value(
+		"${liferay.customer.jira.security.vulnerability.field.publishing.status}"
+	)
+	private String _jiraSecurityVulnerabilityFieldPublishingStatus;
+
+	@Value("${liferay.customer.jira.security.vulnerability.field.severity}")
+	private String _jiraSecurityVulnerabilityFieldSeverity;
+
+	@Value("${liferay.customer.jira.security.vulnerability.project}")
+	private String _jiraSecurityVulnerabilityProject;
+
+	@Value("${liferay.customer.jira.url}")
+	private String _jiraURL;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-7729

- only re-caches the first page (I was debating if we should paginate and cache all the non-filtered result pages but by default, we'd only list the newer tickets anyway and not many people would really need to check every LSV; also any subsequent calls for the same search results (including filters) would grab the cached results on any user, let me know if you still want me to add it though)
- spring boot has a weird cache issue with their annotation, due to how their proxies work, (1) you can't cache a method within the same class as it only caches once at the start of a request and (2) it was caching the jwt which means every request would be unique due to the user making the call; so in order to cache only partner vs customer results, I moved it out so that it can also be used in the scheduler method to evict the caches by manually using CacheManager
- let me know if you do just want to update the caches once a day, I can update the cron (if any of you have a preferred time as well)
- also, do you think it might be beneficial to make the cache evict method accessible so we can manually run it (depending on when security team wants to release an LSV update)
