### PR TITLE
[CP WIP] LRSD-7716 LRSD-8484 LRSD-9018 Allow account member view, consolidate getTickets to pull solved/closed tickets

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/hooks/useAccountTickets.ts
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/hooks/useAccountTickets.ts
@@ -5,17 +5,29 @@
 
 import {useCallback, useEffect, useState} from 'react';
 import {Liferay} from '~/services/liferay';
+import {IBusinessEvent} from '~/utils/types';
 import {ITicket} from '~/utils/types';
 
-const useAccountTickets = (externalReferenceCode: string) => {
+const useAccountTickets = (
+	externalReferenceCode: string,
+	businessEvent?: IBusinessEvent,
+	getOpenTickets?: boolean
+) => {
 	const [loading, setLoading] = useState(true);
 	const [tickets, setTickets] = useState<ITicket[] | undefined>(undefined);
 
-	const fetchTickets = useCallback(async () => {
+	const fetchTickets = useCallback(async (associatedTicketIds?: string) => {
 		if (!externalReferenceCode) {
 			setTickets(undefined);
 
 			return;
+		}
+
+		if (associatedTicketIds) {
+			associatedTicketIds = `associatedTicketIds=${JSON.parse(
+				associatedTicketIds).map(
+					(id: string) => Number(id)
+			)}`;
 		}
 
 		try {
@@ -23,10 +35,30 @@ const useAccountTickets = (externalReferenceCode: string) => {
 				await Liferay.OAuth2Client.FromUserAgentApplication(
 					'liferay-customer-etc-spring-boot-oaua'
 				)
-					.fetch(`/accounts/${externalReferenceCode}/tickets`)
+					.fetch(
+						`/accounts/${externalReferenceCode}/tickets?${associatedTicketIds}`
+					)
 					.then((response: {json: () => any}) => response.json());
 
-			setTickets(response);
+			if (getOpenTickets) {
+				const openTicketResponse: ITicket[] =
+					await Liferay.OAuth2Client.FromUserAgentApplication(
+						'liferay-customer-etc-spring-boot-oaua'
+					)
+						.fetch(`/accounts/${externalReferenceCode}/tickets`)
+						.then((response: {json: () => any}) => response.json());
+
+				setTickets(
+					openTicketResponse.filter(
+						(openTicket) => !response.some(
+							(ticket) => openTicket.ticketId === ticket.ticketId)
+					).concat(response)
+				);
+			}
+			else {
+				setTickets(response);
+			}
+
 			setLoading(false);
 		}
 		catch (error) {
@@ -35,10 +67,16 @@ const useAccountTickets = (externalReferenceCode: string) => {
 			setTickets(undefined);
 			setLoading(false);
 		}
-	}, [externalReferenceCode]);
+	}, [businessEvent, externalReferenceCode, getOpenTickets]);
 
 	useEffect(() => {
-		fetchTickets();
+		if (businessEvent) {
+			fetchTickets(businessEvent?.associatedTickets);
+		}
+		else {
+			fetchTickets();
+		}
+
 	}, [fetchTickets]);
 
 	return {loading, tickets};

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/pages/BusinessEventsItem/BusinessEventsItemDetails/BusinessEventsItemDetails.tsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/pages/BusinessEventsItem/BusinessEventsItemDetails/BusinessEventsItemDetails.tsx
@@ -38,7 +38,7 @@ const BusinessEventsItemDetails = () => {
 	const {hasAllEventsPermissions} = useHasAllEventsPermissions();
 
 	const {loading: loadingTickets, tickets} = useAccountTickets(
-		accountKey || ''
+		accountKey || '', businessEvent
 	);
 
 	const navigate = useNavigate();

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/pages/BusinessEventsItem/BusinessEventsItemEdit/BusinessEventsItemEdit.tsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/BusinessEvents/pages/BusinessEventsItem/BusinessEventsItemEdit/BusinessEventsItemEdit.tsx
@@ -98,7 +98,7 @@ const BusinessEventsItemEditPage: React.FC<IProps> = ({
 
 	const {isSaasOnly} = useIsSaasOnly(subscriptionGroups);
 
-	const {loading, tickets} = useAccountTickets(project?.accountKey || '');
+	const {loading, tickets} = useAccountTickets(project?.accountKey || '', originalBusinessEvent, true);
 
 	const navigate = useNavigate();
 

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountBusinessEventsRestController.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountBusinessEventsRestController.java
@@ -14,6 +14,7 @@ import com.liferay.osb.spring.boot.client.zendesk.model.ZendeskTicket;
 import com.liferay.osb.spring.boot.client.zendesk.search.SearchHits;
 import com.liferay.osb.spring.boot.client.zendesk.search.ZendeskTicketQuery;
 import com.liferay.osb.spring.boot.client.zendesk.service.ZendeskService;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -61,7 +62,8 @@ public class AccountBusinessEventsRestController extends BaseRestController {
 		throws Exception {
 
 		try {
-			_businessEventPermission.check(jwt, externalReferenceCode);
+			_businessEventPermission.check(
+				jwt, externalReferenceCode, ActionKeys.UPDATE);
 
 			JSONObject jsonObject = new JSONObject(json);
 

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountTicketsRestController.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountTicketsRestController.java
@@ -14,7 +14,7 @@ import com.liferay.osb.spring.boot.client.zendesk.model.ZendeskTicket;
 import com.liferay.osb.spring.boot.client.zendesk.search.SearchHits;
 import com.liferay.osb.spring.boot.client.zendesk.search.ZendeskTicketQuery;
 import com.liferay.osb.spring.boot.client.zendesk.service.ZendeskService;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.List;
@@ -23,7 +23,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONArray;
-import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -33,6 +32,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -43,58 +43,34 @@ public class AccountTicketsRestController extends BaseRestController {
 
 	@RequestMapping(
 		method = RequestMethod.GET,
-		path = "/accounts/{externalReferenceCode}/tickets/{ticketId}"
-	)
-	public ResponseEntity<String> getZendeskTicket(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("ticketId") long ticketId)
-		throws Exception {
-
-		try {
-			_businessEventPermission.check(jwt, externalReferenceCode);
-
-			long zendeskOrganizationId = _fetchZendeskOrganizationId(
-				externalReferenceCode);
-			ZendeskTicket zendeskTicket = _zendeskService.getZendeskTicket(
-				ticketId);
-
-			if (zendeskOrganizationId !=
-					zendeskTicket.getZendeskOrganizationId()) {
-
-				throw new PrincipalException();
-			}
-
-			JSONObject jsonObject = zendeskTicket.toJSONObject();
-
-			return new ResponseEntity<>(jsonObject.toString(), HttpStatus.OK);
-		}
-		catch (Exception exception) {
-			_log.error(exception, exception);
-
-			return new ResponseEntity(
-				exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-		}
-	}
-
-	@RequestMapping(
-		method = RequestMethod.GET,
 		path = "/accounts/{externalReferenceCode}/tickets"
 	)
 	public ResponseEntity<String> getZendeskTickets(
 			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode)
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@RequestParam(defaultValue = "", required = false) long[]
+				associatedTicketIds)
 		throws Exception {
 
 		try {
-			_businessEventPermission.check(jwt, externalReferenceCode);
+			_businessEventPermission.check(
+				jwt, externalReferenceCode, ActionKeys.VIEW);
 
 			ZendeskTicketQuery zendeskTicketQuery = new ZendeskTicketQuery();
 
 			zendeskTicketQuery.addCriterion(
 				"organization:" +
 					_fetchZendeskOrganizationId(externalReferenceCode));
-			zendeskTicketQuery.addCriterion("status<closed");
+
+			if (associatedTicketIds.length > 0) {
+				for (long associatedTicketId : associatedTicketIds) {
+					zendeskTicketQuery.addCriterion(
+						"ticket_id:" + associatedTicketId);
+				}
+			}
+			else {
+				zendeskTicketQuery.addCriterion("status<solved");
+			}
 
 			int page = 1;
 

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/constants/RoleConstants.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/constants/RoleConstants.java
@@ -13,6 +13,8 @@ public class RoleConstants {
 	public static final String NAME_ACCOUNT_ADMINISTRATOR =
 		"Account Administrator";
 
+	public static final String NAME_ACCOUNT_MEMBER = "Account Member";
+
 	public static final String NAME_ADMINISTRATOR = "Administrator";
 
 	public static final String NAME_LIFERAY_STAFF = "Liferay Staff";
@@ -36,6 +38,10 @@ public class RoleConstants {
 	public static final String[] PARTNER_ACCOUNT_ROLES = {
 		NAME_PARTNER_MANAGER, NAME_PARTNER_MARKETING_USER, NAME_PARTNER_MEMBER,
 		NAME_PARTNER_SALES_USER, NAME_PARTNER_TECHNICAL_USER
+	};
+
+	public static final String[] SUPPORT_ACCOUNT_ROLES = {
+		NAME_ACCOUNT_ADMINISTRATOR, NAME_ACCOUNT_MEMBER, NAME_REQUESTER
 	};
 
 	public static final String[] SUPPORT_ACCOUNT_TICKET_ROLES = {

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/permission/BusinessEventPermission.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/permission/BusinessEventPermission.java
@@ -14,6 +14,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.UserAccountResource;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.net.URL;
@@ -29,13 +30,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class BusinessEventPermission {
 
-	public void check(Jwt jwt, String externalReferenceCode) throws Exception {
-		if (!_contains(jwt, externalReferenceCode)) {
+	public void check(Jwt jwt, String externalReferenceCode, String actionId)
+		throws Exception {
+
+		if (!_contains(jwt, externalReferenceCode, actionId)) {
 			throw new PrincipalException();
 		}
 	}
 
-	private boolean _contains(Jwt jwt, String externalReferenceCode)
+	private boolean _contains(
+			Jwt jwt, String externalReferenceCode, String actionId)
 		throws Exception {
 
 		UserAccountResource userAccountResource = UserAccountResource.builder(
@@ -76,7 +80,16 @@ public class BusinessEventPermission {
 				for (RoleBrief roleBrief : accountBrief.getRoleBriefs()) {
 					if (ArrayUtil.contains(
 							RoleConstants.SUPPORT_ACCOUNT_TICKET_ROLES,
-							roleBrief.getName())) {
+							roleBrief.getName()) &&
+						actionId.equals(ActionKeys.UPDATE)) {
+
+						return true;
+					}
+
+					if (ArrayUtil.contains(
+							RoleConstants.SUPPORT_ACCOUNT_ROLES,
+							roleBrief.getName()) &&
+						actionId.equals(ActionKeys.VIEW)) {
 
 						return true;
 					}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-7716
https://liferay.atlassian.net/browse/LRSD-8484
https://liferay.atlassian.net/browse/LRSD-9018

Hi @ryanschuhler 
I still couldn't figure out how to resolve the flickering on the Business Events details page. I also tried to manually format the frontend code while I'm trying to figure out why my frontend source formatter isn't working. 

For the list, there doesn't seem to be a way to make it one Zendesk request as Zendesk's search is more like an AND filter especially since we're using it to get closed tickets. Let me know if I shouldn't be using concat().

Steps:
1. create a business event with two associated tickets (may need to make them on Zendesk)
2. close one of the Zendesk tickets by setting that ticket status to solved and adding the "auto_closed" tag
3. navigate back to the business event details page and refresh

It doesn't happen consistently but usually when I refresh 3-4 times, I would at least see it once on my end.