### PR TITLE
LRSD-9513 Translations for new CP home page

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-code/site-initializer/fragments/group/liferay-customer/customer-portal/fragments/project-card/index.html
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-code/site-initializer/fragments/group/liferay-customer/customer-portal/fragments/project-card/index.html
@@ -140,7 +140,7 @@
 								<use xlink:href="${themeDisplay.getPathThemeImages()}/clay/icons.svg#date" />
 							</svg>
 
-							${languageUtil.get(locale, "business-event")}
+							${languageUtil.get(locale, "business-events")}
 						</a>
 					</div>
 				</div>

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-code/site-initializer/plo-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-code/site-initializer/plo-entries.json
@@ -27,12 +27,12 @@
 		}
 	},
 	{
-		"key": "business-event",
+		"key": "business-events",
 		"value": {
-			"en-US": "Business Event",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"en-US": "Business Events",
+			"es-ES": "Eventos de negocio",
+			"ja-JP": "ビジネスイベント",
+			"pt-BR": "Eventos de Negócios"
 		}
 	},
 	{
@@ -123,18 +123,18 @@
 		"key": "last-created-project",
 		"value": {
 			"en-US": "Last Created Project",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Último proyecto creado",
+			"ja-JP": "最後に作成されたプロジェクト",
+			"pt-BR": "Último projeto criado"
 		}
 	},
 	{
 		"key": "last-viewed-project",
 		"value": {
 			"en-US": "Last Viewed Project",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Último proyecto visualizado",
+			"ja-JP": "最後に見たプロジェクト",
+			"pt-BR": "Último projeto visualizado"
 		}
 	},
 	{
@@ -222,9 +222,9 @@
 		"key": "see-project-details",
 		"value": {
 			"en-US": "See Project Details",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Ver detalles del proyecto",
+			"ja-JP": "プロジェクトの詳細を見る",
+			"pt-BR": "Ver detalhes do projeto"
 		}
 	},
 	{
@@ -249,27 +249,27 @@
 		"key": "starts-on",
 		"value": {
 			"en-US": "Starts on",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Comienza el",
+			"ja-JP": "開始",
+			"pt-BR": "Começa em"
 		}
 	},
 	{
 		"key": "support-region",
 		"value": {
 			"en-US": "Support Region",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Región de soporte",
+			"ja-JP": "サポート地域",
+			"pt-BR": "Região de suporte"
 		}
 	},
 	{
 		"key": "team-members",
 		"value": {
 			"en-US": "Team Members",
-			"es-ES": "",
-			"ja-JP": "",
-			"pt-BR": ""
+			"es-ES": "Miembros del equipo",
+			"ja-JP": "チームメンバー",
+			"pt-BR": "Membros da equipe"
 		}
 	},
 	{
@@ -293,7 +293,10 @@
 	{
 		"key": "welcome-to-customer-portal",
 		"value": {
-			"en-US": "Welcome to Customer Portal"
+			"en-US": "Welcome to Customer Portal",
+			"es-ES": "Te damos la bienvenida al Portal del cliente",
+			"ja-JP": "カスタマーポータルへようこそ",
+			"pt-BR": "Bem vindo ao Portal do cliente"
 		}
 	},
 	{

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-quickstart/site-initializer/segments-experiences/01_logged-in-users/home/page-definition.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-quickstart/site-initializer/segments-experiences/01_logged-in-users/home/page-definition.json
@@ -591,7 +591,10 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "Announcements"
+														"en_US": "Announcements",
+														"es_ES": "Anuncios",
+														"ja_JP": "アナウンスメント",
+														"pt_BR": "Avisos"
 													}
 												}
 											}
@@ -634,7 +637,10 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "View all"
+														"en_US": "View all",
+														"es_ES": "Ver todos",
+														"ja_JP": "全てを見る",
+														"pt_BR": "Ver tudo"
 													}
 												}
 											}
@@ -884,7 +890,10 @@
 																},
 																"text": {
 																	"value_i18n": {
-																		"en_US": "Read more&nbsp;→"
+																		"en_US": "Read more&nbsp;→",
+																		"es_ES": "Lee más&nbsp;→",
+																		"ja_JP": "さらに読む&nbsp;→",
+																		"pt_BR": "Ler mais&nbsp;→"
 																	}
 																}
 															}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-quickstart/site-initializer/segments-experiences/02_customers-and-partners/home/page-definition.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer-quickstart/site-initializer/segments-experiences/02_customers-and-partners/home/page-definition.json
@@ -847,7 +847,10 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "Announcements"
+														"en_US": "Announcements",
+														"es_ES": "Anuncios",
+														"ja_JP": "アナウンスメント",
+														"pt_BR": "Avisos"
 													}
 												}
 											}
@@ -890,7 +893,10 @@
 												},
 												"text": {
 													"value_i18n": {
-														"en_US": "View all"
+														"en_US": "View all",
+														"es_ES": "Ver todos",
+														"ja_JP": "全てを見る",
+														"pt_BR": "Ver tudo"
 													}
 												}
 											}
@@ -1140,7 +1146,10 @@
 																},
 																"text": {
 																	"value_i18n": {
-																		"en_US": "Read more&nbsp;→"
+																		"en_US": "Read more&nbsp;→",
+																		"es_ES": "Lee más&nbsp;→",
+																		"ja_JP": "さらに読む&nbsp;→",
+																		"pt_BR": "Ler mais&nbsp;→"
 																	}
 																}
 															}


### PR DESCRIPTION
Sending this PR to complete task after implementation of [Project Card Fragment](https://github.com/liferay-customer-solutions/liferay-portal/pull/724) and [New CP Home Page: Announcements and Subscribe](https://github.com/liferay-customer-solutions/liferay-portal/pull/727).

Note that I've updated the pt-BR translation for the welcome-to-customer-portal key to correctly translate "Customer Portal".

From: `Bem vindo ao Customer portal`
To: `Bem vindo ao Portal do cliente`

The Portuguese translation was the only one that did not translate the term "Customer Portal", unlike the Spanish and Japanese versions. I checked other language.json files within our projects and confirmed that the established translation for "Customer Portal" is Portal do cliente. This change ensures our translation files are consistent.

[LRSD-9513](https://liferay.atlassian.net/browse/LRSD-9513)

[LRSD-9513]: https://liferay.atlassian.net/browse/LRSD-9513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ