### PR TITLE
[CP] WIP LRSD-10053 Refactor Zendesk getAccountTickets to JSM for business events

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountsTicketsRestController.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/AccountsTicketsRestController.java
@@ -7,15 +7,20 @@ package com.liferay.customer;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
 import com.liferay.customer.constants.ExternalLinkConstants;
+import com.liferay.customer.constants.JiraIssueConstants;
 import com.liferay.customer.permission.BusinessEventPermission;
+import com.liferay.customer.service.JiraService;
 import com.liferay.customer.service.KoroneikiService;
 import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ExternalLink;
 import com.liferay.osb.spring.boot.client.zendesk.model.ZendeskTicket;
 import com.liferay.osb.spring.boot.client.zendesk.search.SearchHits;
 import com.liferay.osb.spring.boot.client.zendesk.search.ZendeskTicketQuery;
 import com.liferay.osb.spring.boot.client.zendesk.service.ZendeskService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
 
@@ -25,6 +30,7 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,6 +38,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -44,9 +51,80 @@ public class AccountsTicketsRestController extends BaseRestController {
 		method = RequestMethod.GET,
 		path = "/accounts/{externalReferenceCode}/tickets"
 	)
-	public ResponseEntity<String> getZendeskTickets(
+	public ResponseEntity<String> getTickets(
 			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode)
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@RequestParam(defaultValue = "", required = false) String[] tickets)
+		throws Exception {
+
+		if (_featureFlagLRSD_8280) {
+			return _getJSMTickets(jwt, externalReferenceCode, tickets);
+		}
+
+		return _getZendeskTickets(jwt, externalReferenceCode);
+	}
+
+	private long _fetchZendeskOrganizationId(String externalReferenceCode)
+		throws Exception {
+
+		List<ExternalLink> externalLinks = _koroneikiService.fetchExternalLinks(
+			externalReferenceCode, 1, 1000);
+
+		for (ExternalLink externalLink : externalLinks) {
+			String domain = externalLink.getDomain();
+			String entityName = externalLink.getEntityName();
+
+			if (domain.equals(ExternalLinkConstants.DOMAIN_ZENDESK) &&
+				entityName.equals(
+					ExternalLinkConstants.ENTITY_NAME_ZENDESK_ORGANIZATION)) {
+
+				return GetterUtil.getLong(externalLink.getEntityId());
+			}
+		}
+
+		return 0;
+	}
+
+	private ResponseEntity<String> _getJSMTickets(
+			Jwt jwt, String externalReferenceCode, String[] tickets)
+		throws Exception {
+
+		try {
+			_businessEventPermission.check(
+				jwt, externalReferenceCode, ActionKeys.VIEW);
+
+			StringBundler sb = new StringBundler(9);
+
+			sb.append("Organization in aqlFunction('\"External Key\" = ");
+			sb.append(externalReferenceCode);
+			sb.append("') and (status not in ('");
+			sb.append(
+				StringUtil.merge(JiraIssueConstants.STATUSES_CLOSED, "','"));
+			sb.append("')");
+
+			if (ArrayUtil.isNotEmpty(tickets)) {
+				sb.append(" or key in ('");
+				sb.append(StringUtil.merge(tickets, "','"));
+				sb.append("')");
+			}
+
+			sb.append(")");
+
+			JSONArray jsonArray = _jiraService.search(
+				sb.toString(), new String[] {"key", "status", "summary"});
+
+			return new ResponseEntity<>(jsonArray.toString(), HttpStatus.OK);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			return new ResponseEntity(
+				exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	private ResponseEntity<String> _getZendeskTickets(
+			Jwt jwt, String externalReferenceCode)
 		throws Exception {
 
 		try {
@@ -86,32 +164,17 @@ public class AccountsTicketsRestController extends BaseRestController {
 		}
 	}
 
-	private long _fetchZendeskOrganizationId(String externalReferenceCode)
-		throws Exception {
-
-		List<ExternalLink> externalLinks = _koroneikiService.fetchExternalLinks(
-			externalReferenceCode, 1, 1000);
-
-		for (ExternalLink externalLink : externalLinks) {
-			String domain = externalLink.getDomain();
-			String entityName = externalLink.getEntityName();
-
-			if (domain.equals(ExternalLinkConstants.DOMAIN_ZENDESK) &&
-				entityName.equals(
-					ExternalLinkConstants.ENTITY_NAME_ZENDESK_ORGANIZATION)) {
-
-				return GetterUtil.getLong(externalLink.getEntityId());
-			}
-		}
-
-		return 0;
-	}
-
 	private static final Log _log = LogFactory.getLog(
 		AccountsTicketsRestController.class);
 
 	@Autowired
 	private BusinessEventPermission _businessEventPermission;
+
+	@Value("${liferay.customer.feature.flag.LRSD-8280}")
+	private boolean _featureFlagLRSD_8280;
+
+	@Autowired
+	private JiraService _jiraService;
 
 	@Autowired
 	private KoroneikiService _koroneikiService;

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/constants/JiraIssueConstants.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/constants/JiraIssueConstants.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.customer.constants;
+
+/**
+ * @author Jenny Chen
+ */
+public interface JiraIssueConstants {
+
+	public static final String STATUS_CLOSED = "Closed";
+
+	public static final String STATUS_SOLUTION_ACCEPTED = "Solution Accepted";
+
+	public static final String STATUS_SOLUTION_PROPOSED = "Solution Proposed";
+
+	public static final String[] STATUSES_CLOSED = {
+		STATUS_CLOSED, STATUS_SOLUTION_ACCEPTED, STATUS_SOLUTION_PROPOSED
+	};
+
+}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/model/JiraIssue.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/model/JiraIssue.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.customer.model;
+
+import com.liferay.customer.constants.JiraIssueConstants;
+
+import org.json.JSONObject;
+
+/**
+ * @author Jenny Chen
+ */
+public class JiraIssue {
+
+	public JiraIssue(JSONObject jsonObject, String jiraIssueURL) {
+		_key = jsonObject.getString("key");
+		_ticketURL = jiraIssueURL;
+
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+		JSONObject statusJSONObject = fieldsJSONObject.optJSONObject("status");
+
+		_status = statusJSONObject.getString("name");
+
+		_summary = fieldsJSONObject.getString("summary");
+	}
+
+	public String getKey() {
+		return _key;
+	}
+
+	public String getStatus() {
+		return _status;
+	}
+
+	public String getSummary() {
+		return _summary;
+	}
+
+	public boolean isClosed() {
+		if (_status.equals(JiraIssueConstants.STATUS_CLOSED) ||
+			_status.equals(JiraIssueConstants.STATUS_SOLUTION_ACCEPTED) ||
+			_status.equals(JiraIssueConstants.STATUS_SOLUTION_PROPOSED)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public JSONObject toJSONObject() {
+		return new JSONObject(
+		).put(
+			"link", _ticketURL + "/" + _key
+		).put(
+			"status", _status
+		).put(
+			"subject", _summary
+		).put(
+			"ticketId", _key
+		);
+	}
+
+	private final String _key;
+	private final String _status;
+	private final String _summary;
+	private final String _ticketURL;
+
+}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/service/JiraService.java
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/java/com/liferay/customer/service/JiraService.java
@@ -6,6 +6,7 @@
 package com.liferay.customer.service;
 
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.customer.model.JiraIssue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -186,6 +187,48 @@ public class JiraService extends BaseService {
 			jql, pageSize, returnFields, _calculateStartAt(page, pageSize));
 
 		return _transformSearchResults(jsonObject);
+	}
+
+	public JSONArray search(String jql, String[] returnFields)
+		throws Exception {
+
+		int page = 1;
+		int pageSize = 100;
+
+		JSONArray jsonArray = new JSONArray();
+
+		while (true) {
+			JSONObject jsonObject = _search(
+				jql, pageSize, returnFields, _calculateStartAt(page, pageSize));
+
+			JSONArray issuesJSONArray = jsonObject.getJSONArray("issues");
+
+			for (int i = 0; i < issuesJSONArray.length(); i++) {
+				JSONObject issueJSONObject = issuesJSONArray.getJSONObject(i);
+
+				String issueKey = issueJSONObject.getString("key");
+
+				String jiraSupportURL = _jiraSupportCustomerPortalURL;
+
+				if (issueKey.startsWith("LRFLS-")) {
+					jiraSupportURL = _jiraSupportPartnerPortalURL;
+				}
+
+				JiraIssue jiraIssue = new JiraIssue(
+					issueJSONObject, jiraSupportURL);
+
+				jsonArray.put(jiraIssue.toJSONObject());
+			}
+
+			if ((page * pageSize) < jsonObject.getInt("total")) {
+				page++;
+			}
+			else {
+				break;
+			}
+		}
+
+		return jsonArray;
 	}
 
 	@Cacheable("issues")
@@ -652,8 +695,14 @@ public class JiraService extends BaseService {
 	@Value("${liferay.customer.jira.security.vulnerability.project}")
 	private String _jiraSecurityVulnerabilityProject;
 
+	@Value("${liferay.customer.jira.support.customer.portal.url}")
+	private String _jiraSupportCustomerPortalURL;
+
 	@Value("${liferay.customer.jira.support.field.organization}")
 	private String _jiraSupportFieldOrganization;
+
+	@Value("${liferay.customer.jira.support.partner.portal.url}")
+	private String _jiraSupportPartnerPortalURL;
 
 	@Value("${liferay.customer.jira.url}")
 	private String _jiraURL;

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-etc-spring-boot/src/main/resources/application-default.properties
@@ -44,7 +44,9 @@ liferay.customer.jira.security.vulnerability.field.severity=${LIFERAY_CUSTOMER_J
 liferay.customer.jira.security.vulnerability.project=LSV
 liferay.customer.jira.service.affected.versions.cache.eviction.cron=${LIFERAY_CUSTOMER_JIRA_SERVICE_AFFECTED_VERSIONS_CACHE_EVICTION_CRON}
 liferay.customer.jira.service.issues.cache.eviction.cron=${LIFERAY_CUSTOMER_JIRA_SERVICE_ISSUES_CACHE_EVICTION_CRON}
+liferay.customer.jira.support.customer.portal.url=${LIFERAY_CUSTOMER_JIRA_SUPPORT_CUSTOMER_PORTAL_URL}
 liferay.customer.jira.support.field.organization=${LIFERAY_CUSTOMER_JIRA_SUPPORT_FIELD_ORGANIZATION}
+liferay.customer.jira.support.partner.portal.url=${LIFERAY_CUSTOMER_JIRA_SUPPORT_PARTNER_PORTAL_URL}
 liferay.customer.jira.support.projects=${LIFERAY_CUSTOMER_JIRA_SUPPORT_PROJECTS}
 liferay.customer.jira.url=${LIFERAY_CUSTOMER_JIRA_URL}
 liferay.customer.koroneiki.auth.token=${LIFERAY_CUSTOMER_KORONEIKI_AUTH_TOKEN}
@@ -62,6 +64,12 @@ liferay.customer.zendesk.heat.tag.ticket.field.id=${LIFERAY_CUSTOMER_ZENDESK_HEA
 liferay.osb.spring.boot.client.zendesk.api.email.address=${LIFERAY_OSB_SPRING_BOOT_CLIENT_ZENDESK_API_EMAIL_ADDRESS}
 liferay.osb.spring.boot.client.zendesk.api.token=${LIFERAY_OSB_SPRING_BOOT_CLIENT_ZENDESK_API_TOKEN}
 liferay.osb.spring.boot.client.zendesk.url=${LIFERAY_OSB_SPRING_BOOT_CLIENT_ZENDESK_URL}
+
+#
+# Feature Flag
+#
+
+liferay.customer.feature.flag.LRSD-8280=${LIFERAY_CUSTOMER_FEATURE_FLAG_LRSD_8280}
 
 #
 # OAuth


### PR DESCRIPTION
@amosfong  I'm starting to get tunnel vision. Can you let me know if there's any improvements I should make? 🤔  I had to remove custom fields for heat tag and some other logic we might need. Cleanest way I can think of is to make a JiraIssue object similar to how we made one for ZendeskTicket. I also wanted to streamline LSV/JSM tickets but some of the fields like "status" and "summary" actually are structured slightly different from LSV tickets. Normally, how would we do this? Different constructors then? The hard part is I don't think we can set a property in a constructor like we tried last time since the property wouldn't be initialized until later.

Should I just not use the JiraIssue object? 