### PR TITLE
LPD-88257 Update admin sidebar to Figma design and enable Vite HMR

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.dev.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.dev.yaml
@@ -1,0 +1,5 @@
+liferay-one-custom-element:
+    urls:
+        -   http://localhost:5173/@vite/client
+        -   http://localhost:5173/react-refresh-preamble.js
+        -   http://localhost:5173/src/main.tsx

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/SideNav.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/SideNav.tsx
@@ -3,21 +3,25 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Fragment} from 'react';
 import {NavLink} from 'react-router-dom';
 
 export type NavItem = {
 	children?: NavItem[];
+	icon?: string;
 	label: string;
 	path: string;
-	section?: string;
 };
 
-const SIDEBAR_BG = '#f4f5f8';
-const TEXT_INACTIVE = '#444d6d';
-const TEXT_ACTIVE = '#4a6cf7';
-const ACTIVE_BG = 'rgba(74, 108, 247, 0.08)';
-const TEXT_SECTION = '#8892a4';
+const LEXICON_SPRITE = '/o/admin-theme/images/lexicon/icons.svg';
+const CUSTOM_ICONS = new Set(['union']);
+
+const SIDEBAR_BG = '#F7F7F8';
+const TEXT_INACTIVE = '#282934';
+const TEXT_ACTIVE = '#004AD7';
+const ACTIVE_BG = '#E6EDFB';
+const TEXT_SECTION = '#6B6C7E';
+
+const FONT_FAMILY = "'Source Sans 3', sans-serif";
 
 type SideNavItemProps = {
 	depth: number;
@@ -26,26 +30,54 @@ type SideNavItemProps = {
 
 function SideNavItem({depth, item}: SideNavItemProps) {
 	const hasChildren = Boolean(item.children && item.children.length);
+	const icon = item.icon;
+	const iconHref = icon
+		? CUSTOM_ICONS.has(icon)
+			? `#${icon}`
+			: `${LEXICON_SPRITE}#${icon}`
+		: undefined;
 
 	return (
 		<li>
 			<NavLink
-				className="d-block text-decoration-none"
+				className="align-items-center d-flex text-decoration-none w-100"
 				end={!hasChildren}
 				style={({isActive}) => ({
-					backgroundColor: isActive ? ACTIVE_BG : undefined,
-					borderRadius: '6px',
+					backgroundColor: isActive ? ACTIVE_BG : 'transparent',
+					borderRadius: '0.375rem',
 					color: isActive ? TEXT_ACTIVE : TEXT_INACTIVE,
-					fontWeight: isActive ? 600 : undefined,
-					margin: '1px 8px',
-					paddingBottom: '0.5rem',
-					paddingLeft: `${0.75 + depth}rem`,
-					paddingRight: '0.75rem',
-					paddingTop: '0.5rem',
+					fontFamily: FONT_FAMILY,
+					fontSize: '1rem',
+					fontWeight: 600,
+					gap: '0.75rem',
+					lineHeight: '1.5rem',
+					padding: `0.75rem 0.75rem 0.75rem ${0.75 + depth * 0.75}rem`,
 				})}
 				to={item.path}
 			>
-				{item.label}
+				{({isActive}) => (
+					<>
+						{iconHref && (
+							<svg
+								aria-hidden="true"
+								focusable="false"
+								style={{
+									fill: 'currentColor',
+									flexShrink: 0,
+									height: '1rem',
+									opacity: isActive ? 0.8 : 0.5,
+									width: '1rem',
+								}}
+							>
+								<use href={iconHref} />
+							</svg>
+						)}
+
+						<span style={{flex: '1 0 0', textAlign: 'left'}}>
+							{item.label}
+						</span>
+					</>
+				)}
 			</NavLink>
 
 			{hasChildren && (
@@ -63,6 +95,20 @@ function SideNavItem({depth, item}: SideNavItemProps) {
 	);
 }
 
+function CustomIconSprite() {
+	return (
+		<svg
+			aria-hidden="true"
+			style={{display: 'none'}}
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<symbol id="union" viewBox="0 0 16 16">
+				<path d="M4 8C6.20914 8 8 9.79086 8 12C8 14.2091 6.20914 16 4 16C1.79086 16 0 14.2091 0 12C0 9.79086 1.79086 8 4 8ZM11.8955 9.27539C11.9605 9.24633 12.0356 9.24633 12.1006 9.27539C12.1749 9.30882 12.2321 9.40855 12.3457 9.60742L15.6562 15.4014C15.7686 15.5979 15.8242 15.6968 15.8154 15.7773C15.8077 15.8474 15.7709 15.9108 15.7139 15.9521C15.6482 15.9997 15.5349 16 15.3086 16H8.6875C8.46115 16 8.34786 15.9997 8.28223 15.9521C8.22516 15.9108 8.18838 15.8474 8.18066 15.7773C8.17194 15.6968 8.22754 15.5979 8.33984 15.4014L11.6504 9.60742C11.764 9.40855 11.8212 9.30882 11.8955 9.27539ZM4 10C2.89543 10 2 10.8954 2 12C2 13.1046 2.89543 14 4 14C5.10457 14 6 13.1046 6 12C6 10.8954 5.10457 10 4 10ZM12 0C14.2091 0 16 1.79086 16 4C16 6.20914 14.2091 8 12 8C9.79086 8 8 6.20914 8 4C8 1.79086 9.79086 0 12 0ZM5.40039 0C5.96018 0 6.24024 0.000406853 6.4541 0.109375C6.64207 0.205215 6.79478 0.357928 6.89062 0.545898C6.99959 0.75976 7 1.03982 7 1.59961V5.40039C7 5.96018 6.99959 6.24024 6.89062 6.4541C6.79478 6.64207 6.64207 6.79478 6.4541 6.89062C6.24024 6.99959 5.96018 7 5.40039 7H1.59961C1.03982 7 0.75976 6.99959 0.545898 6.89062C0.357928 6.79478 0.205215 6.64207 0.109375 6.4541C0.000406859 6.24024 0 5.96018 0 5.40039V1.59961C0 1.03982 0.000406853 0.75976 0.109375 0.545898C0.205215 0.357928 0.357928 0.205215 0.545898 0.109375C0.75976 0.000406859 1.03982 0 1.59961 0H5.40039ZM12 2C10.8954 2 10 2.89543 10 4C10 5.10457 10.8954 6 12 6C13.1046 6 14 5.10457 14 4C14 2.89543 13.1046 2 12 2Z" />
+			</symbol>
+		</svg>
+	);
+}
+
 type SideNavProps = {
 	items: NavItem[];
 	title?: string;
@@ -71,13 +117,16 @@ type SideNavProps = {
 export default function SideNav({items, title}: SideNavProps) {
 	return (
 		<nav
-			className="align-self-start d-flex flex-column flex-shrink-0 overflow-auto pb-3 pt-3"
+			className="align-self-start d-flex flex-column flex-shrink-0 overflow-auto"
 			style={{
 				backgroundColor: SIDEBAR_BG,
-				borderRadius: '0.75rem',
-				width: '220px',
+				borderRadius: '0.625rem',
+				padding: '0.5rem',
+				width: '18rem',
 			}}
 		>
+			<CustomIconSprite />
+
 			{title && (
 				<div
 					className="font-weight-bold pb-2 px-3 text-uppercase"
@@ -91,34 +140,13 @@ export default function SideNav({items, title}: SideNavProps) {
 				</div>
 			)}
 
-			<ul className="flex-fill list-unstyled m-0">
-				{items.map((item, index) => {
-					const prevSection =
-						index > 0 ? items[index - 1].section : undefined;
-					const showSectionHeader =
-						item.section && item.section !== prevSection;
-
-					return (
-						<Fragment key={item.path}>
-							{showSectionHeader && (
-								<li
-									className="font-weight-bold pb-1 px-3 text-uppercase"
-									style={{
-										color: TEXT_SECTION,
-										fontSize: '0.625rem',
-										letterSpacing: '0.1em',
-										paddingTop:
-											index === 0 ? '0.25rem' : '1.25rem',
-									}}
-								>
-									{item.section}
-								</li>
-							)}
-
-							<SideNavItem depth={0} item={item} />
-						</Fragment>
-					);
-				})}
+			<ul
+				className="d-flex flex-column flex-fill list-unstyled m-0"
+				style={{gap: '0.5rem'}}
+			>
+				{items.map((item) => (
+					<SideNavItem depth={0} item={item} key={item.path} />
+				))}
 			</ul>
 		</nav>
 	);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function ManageSsaSaasUsers() {
+	return <div />;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MySsaSaasDemo/MySsaSaasDemo.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MySsaSaasDemo/MySsaSaasDemo.tsx
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export default function MySsaSaasEnvironments() {
+export default function MySsaSaasDemo() {
 	return <div />;
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
@@ -13,12 +13,13 @@ const Environments = lazy(() => import('./Environments/Environments'));
 const LicenseKeyUploads = lazy(
 	() => import('./LicenseKeyUploads/LicenseKeyUploads')
 );
+const ManageSsaSaasUsers = lazy(
+	() => import('./ManageSsaSaasUsers/ManageSsaSaasUsers')
+);
 const MessageQueue = lazy(() => import('./MessageQueue/MessageQueue'));
 const MPFinanceOrders = lazy(() => import('./MPFinanceOrders/MPFinanceOrders'));
 const MPSummary = lazy(() => import('./MPSummary/MPSummary'));
-const MySsaSaasEnvironments = lazy(
-	() => import('./MySsaSaasEnvironments/MySsaSaasEnvironments')
-);
+const MySsaSaasDemo = lazy(() => import('./MySsaSaasDemo/MySsaSaasDemo'));
 const Orders = lazy(() => import('./Orders/Orders'));
 const Payments = lazy(() => import('./Payments/Payments'));
 const PublisherRequests = lazy(
@@ -33,69 +34,72 @@ export const adminRoutes: AppRoute[] = [
 
 	{
 		element: <MPSummary />,
-		nav: {label: 'Summary', section: 'Marketplace'},
+		nav: {icon: 'polls', label: 'Marketplace Summary'},
 		path: 'mp-summary',
 	},
 	{
 		element: <Orders />,
-		nav: {label: 'Orders', section: 'Marketplace'},
+		nav: {icon: 'order-form', label: 'Marketplace Orders'},
 		path: 'mp-orders',
 	},
 	{
 		element: <Apps />,
-		nav: {label: 'Apps', section: 'Marketplace'},
+		nav: {icon: 'grid', label: 'Marketplace Apps'},
 		path: 'mp-apps',
 	},
 	{
 		element: <Solutions />,
-		nav: {label: 'Solutions', section: 'Marketplace'},
+		nav: {icon: 'union', label: 'Marketplace Solutions'},
 		path: 'mp-solutions',
 	},
 	{
-		element: <Publishers />,
-		nav: {label: 'Publishers', section: 'Marketplace'},
-		path: 'publishers',
-	},
-	{
-		element: <PublisherRequests />,
-		nav: {label: 'Publisher Requests', section: 'Marketplace'},
-		path: 'publisher-requests',
-	},
-	{
-		element: <Trials />,
-		nav: {label: '7 Day Trials', section: 'Marketplace'},
-		path: 'trials',
-	},
-
-	{
-		element: <MySsaSaasEnvironments />,
-		nav: {label: 'My SaaS Environments', section: 'SSA'},
-		path: 'my-ssa-saas-environments',
-	},
-	{
-		element: <Environments />,
-		nav: {label: 'SaaS Environments', section: 'SSA'},
-		path: 'ssa-saas-environments',
-	},
-
-	{
 		element: <MPFinanceOrders />,
-		nav: {label: 'Orders', section: 'Finance'},
+		nav: {icon: 'order-form', label: 'Marketplace Finance Orders'},
 		path: 'mp-finance-orders',
 	},
 	{
 		element: <Payments />,
-		nav: {label: 'Payments', section: 'Finance'},
+		nav: {icon: 'order-form', label: 'Marketplace Payments'},
 		path: 'mp-payments',
 	},
 	{
+		element: <Publishers />,
+		nav: {icon: 'squares-clock', label: 'Publishers'},
+		path: 'publishers',
+	},
+	{
+		element: <PublisherRequests />,
+		nav: {icon: 'order-form', label: 'Publisher Requests'},
+		path: 'publisher-requests',
+	},
+	{
+		element: <Trials />,
+		nav: {icon: 'grid', label: '7 Days Trials'},
+		path: 'trials',
+	},
+	{
+		element: <MySsaSaasDemo />,
+		nav: {icon: 'union', label: 'My SSA SaaS Demo'},
+		path: 'my-ssa-saas-demo',
+	},
+	{
+		element: <Environments />,
+		nav: {icon: 'squares-clock', label: 'SSA SaaS Environments'},
+		path: 'ssa-saas-environments',
+	},
+	{
+		element: <ManageSsaSaasUsers />,
+		nav: {icon: 'users', label: 'Manage SSA SaaS Users'},
+		path: 'manage-ssa-saas-users',
+	},
+	{
 		element: <MessageQueue />,
-		nav: {label: 'Message Queue', section: 'Support'},
+		nav: {icon: 'message-boards', label: 'Message Queue'},
 		path: 'message-queue',
 	},
 	{
 		element: <LicenseKeyUploads />,
-		nav: {label: 'License Key Uploads', section: 'Support'},
+		nav: {icon: 'password-policies', label: 'License Key Uploads'},
 		path: 'license-key-uploads',
 	},
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/routes.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/routes.ts
@@ -20,7 +20,7 @@ type PathRoute = {
 	children?: AppRoute[];
 	element?: ReactNode;
 	index?: never;
-	nav?: {label: string; section?: string};
+	nav?: {icon?: string; label: string};
 	path: string;
 };
 
@@ -57,9 +57,9 @@ export function buildNavItems(routes: AppRoute[], prefix = ''): NavItem[] {
 
 		items.push({
 			children: children?.length ? children : undefined,
+			icon: route.nav.icon,
 			label: route.nav.label,
 			path: fullPath,
-			section: route.nav.section,
 		});
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/vite.config.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/vite.config.ts
@@ -6,15 +6,16 @@
 import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
 
-export default defineConfig({
+export default defineConfig(({command}) => ({
+	base: command === 'build' ? '/o/liferay-one-custom-element/' : '/',
 	build: {
-		assetsDir: 'static',
-		outDir: 'build',
+		assetsDir: '.',
+		outDir: 'build/static',
 		rollupOptions: {
 			output: {
-				assetFileNames: 'static/[name].[hash][extname]',
-				chunkFileNames: 'static/[name].[hash].js',
-				entryFileNames: 'static/[name].[hash].js',
+				assetFileNames: '[name].[hash][extname]',
+				chunkFileNames: '[name].[hash].js',
+				entryFileNames: '[name].[hash].js',
 				manualChunks: {
 					vendor: ['react', 'react-dom', 'react-router-dom'],
 				},
@@ -25,4 +26,4 @@ export default defineConfig({
 	server: {
 		origin: 'http://localhost:5173',
 	},
-});
+}));


### PR DESCRIPTION
Part of epic LPD-88257 (Admin UI migration). First of 9 stacked PRs splitting the original large LPD-88257 PR into reviewable layers.

This PR adds the admin shell: Figma-design sidebar, route map (placeholders for non-migrated pages), Vite HMR, and the SsaSaas page reorg.