### PR TITLE
LPD-88257 Add Admin shared UI primitives and form components

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ButtonWithIcon.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ButtonWithIcon.tsx
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import React, {ComponentProps, ForwardedRef, ReactNode} from 'react';
+
+type ButtonWithIconProps = {
+	children?: ReactNode;
+	iconProps?: Omit<ComponentProps<typeof ClayIcon>, 'symbol'>;
+	symbol: string;
+} & React.ComponentProps<typeof ClayButton>;
+
+const ButtonWithIcon = React.forwardRef<HTMLButtonElement, ButtonWithIconProps>(
+	(
+		{children, iconProps, symbol = 'plus', ...props},
+		ref: ForwardedRef<HTMLButtonElement>
+	) => {
+		return (
+			<ClayButton {...props} ref={ref}>
+				<ClayIcon className="mr-2" symbol={symbol} {...iconProps} />
+
+				{children}
+			</ClayButton>
+		);
+	}
+);
+
+export default ButtonWithIcon;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/EmptyState/EmptyState.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayEmptyState from '@clayui/empty-state';
+import React, {ReactNode} from 'react';
+
+import i18n from '../../i18n';
+import {Liferay} from '../../liferay/liferay';
+export const States = {
+	BLANK: '',
+
+	/**
+	 * When the filters or search results return zero results.
+	 */
+
+	EMPTY_SEARCH: `${Liferay.ThemeDisplay.getPathThemeImages()}/states/search_state.gif`,
+
+	/**
+	 * When there are no elements in the data set at a certain level
+	 */
+
+	EMPTY_STATE: `${Liferay.ThemeDisplay.getPathThemeImages()}/states/empty_state.gif`,
+
+	/**
+	 * When there no permission to access the module
+	 */
+
+	NO_ACCESS: `${Liferay.ThemeDisplay.getPathThemeImages()}/app_builder/illustration_locker.svg`,
+
+	NOT_FOUND:
+		'https://www.liferay.com/documents/10182/501717/404-Illustration-v2.svg',
+
+	/**
+	 * The user has emptied the dataset for a good cause.
+	 * For example, all the notifications have been addressed, resulting in a clean state.
+	 */
+	SUCCESS: `${Liferay.ThemeDisplay.getPathThemeImages()}/states/success_state.gif`,
+};
+
+export type EmptyStateProps = {
+	children?: ReactNode;
+	className?: string;
+	description?: ReactNode | string;
+	imgSrc?: string;
+	title?: string;
+	type?: keyof typeof States;
+};
+
+const EmptyState: React.FC<EmptyStateProps> = ({
+	children,
+	className,
+	description,
+	imgSrc,
+	title,
+	type,
+}) => (
+	<ClayEmptyState
+		className={className}
+		description={
+			(description as string) ??
+			i18n.translate('sorry-there-are-no-results-found')
+		}
+		imgSrc={imgSrc ?? (type ? States[type] : States.EMPTY_STATE)}
+		title={title || i18n.translate('no-results-found')}
+	>
+		{children}
+	</ClayEmptyState>
+);
+
+export default EmptyState;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/EmptyState/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/EmptyState/index.tsx
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import EmptyState, {EmptyStateProps, States} from './EmptyState';
+
+export type {EmptyStateProps};
+
+export {States};
+
+export default EmptyState;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/BaseWrapper.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/BaseWrapper.tsx
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayForm from '@clayui/form';
+import classNames from 'classnames';
+import {ReactNode} from 'react';
+
+import BaseWarning from './InputWarning';
+
+type BaseWrapperProps = {
+	children: ReactNode;
+	description?: string;
+	disabled?: boolean;
+	error?: string;
+	id?: string;
+	label?: string;
+	required?: boolean;
+};
+
+const BaseWrapper: React.FC<BaseWrapperProps> = ({
+	children,
+	description,
+	disabled,
+	error,
+	id,
+	label,
+	required,
+}) => {
+	return (
+		<ClayForm.Group
+			className={classNames({
+				'has-error': error,
+			})}
+		>
+			{label && (
+				<label
+					className={classNames(
+						'font-weight-bold mb-1 mx-0 text-paragraph',
+						{
+							disabled,
+							required,
+						}
+					)}
+					htmlFor={id}
+				>
+					{label}
+				</label>
+			)}
+
+			{children}
+
+			{description && (
+				<small className="form-text text-muted" id="Help">
+					{description}
+				</small>
+			)}
+
+			{error && <BaseWarning>{error}</BaseWarning>}
+		</ClayForm.Group>
+	);
+};
+
+export default BaseWrapper;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Checkbox.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Checkbox.tsx
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import {useState} from 'react';
+
+type CheckboxProps = {
+	inline?: boolean;
+	label?: string;
+} & React.InputHTMLAttributes<HTMLInputElement>;
+
+const Checkbox: React.FC<CheckboxProps> = (props) => {
+	const [value, setValue] = useState(false);
+
+	return (
+		<ClayCheckbox
+			checked={value}
+			onChange={() => setValue(!value)}
+			{...props}
+		/>
+	);
+};
+
+export default Checkbox;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/DateRange.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/DateRange.tsx
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import DatePicker from '@clayui/date-picker';
+import {useEffect, useState} from 'react';
+
+type DateRangeProps = {
+	label?: string;
+	onChange: (event: any, setValue: any) => void;
+	value: string;
+};
+
+const DateRange: React.FC<DateRangeProps> = ({label, onChange, value}) => {
+	const [currentDate, setCurrentDate] = useState(value);
+
+	useEffect(() => {
+		setCurrentDate(value);
+	}, [value]);
+
+	return (
+		<div>
+			{label && <label>{label}</label>}
+			<DatePicker
+				onChange={(event: string) => onChange(event, setCurrentDate)}
+				placeholder="YYYY-MM-DD - YYYY-MM-DD"
+				range
+				value={currentDate}
+				years={{end: new Date().getFullYear(), start: 2020}}
+			/>
+		</div>
+	);
+};
+
+export default DateRange;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Input.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Input.tsx
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import {InputHTMLAttributes, forwardRef} from 'react';
+
+import BaseWrapper from './BaseWrapper';
+
+type InputProps = {
+	disabled?: boolean;
+	errors?: any;
+	id?: string;
+	label?: string;
+	name: string;
+	register?: any;
+	required?: boolean;
+	type?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+	(
+		{
+			disabled = false,
+			errors = {},
+			label,
+			name,
+			register = () => {},
+			id = name,
+			type,
+			value,
+			required = false,
+			onBlur,
+			...otherProps
+		},
+		ref
+	) => (
+		<BaseWrapper
+			disabled={disabled}
+			error={errors[name]?.message}
+			id={id}
+			label={label}
+			required={required}
+		>
+			<ClayInput
+				className="rounded-xs"
+				component={type === 'textarea' ? 'textarea' : 'input'}
+				disabled={disabled}
+				id={id}
+				name={name}
+				ref={ref}
+				type={type}
+				value={value}
+				{...otherProps}
+				{...register(name, {onBlur, required})}
+			/>
+		</BaseWrapper>
+	)
+);
+
+export default Input;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/InputWarning.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/InputWarning.tsx
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import React, {ReactNode} from 'react';
+
+const BaseWarning: React.FC<{children: ReactNode}> = ({children}) => {
+	return (
+		<ClayLabel className="label-tonal-danger mt-1 mx-0 p-0 rounded w-100">
+			<div className="align-items-center badge d-flex m-0 warning">
+				<span className="inline-item inline-item-before">
+					<ClayIcon
+						className="c-ml-2 c-mr-2"
+						symbol="exclamation-full"
+					/>
+				</span>
+
+				<span className="font-weight-normal text-paragraph">
+					{children}
+				</span>
+			</div>
+		</ClayLabel>
+	);
+};
+
+export default BaseWarning;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/MultiSelect.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/MultiSelect.tsx
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {InputHTMLAttributes, useEffect, useRef, useState} from 'react';
+import ReactSelect, {PropsValue} from 'react-select';
+
+import Form from './index';
+
+type Option = {label: string; value: string};
+
+type MultiSelectProps = {
+	isLoading: boolean;
+	label?: string;
+	options: Option[];
+} & InputHTMLAttributes<HTMLSelectElement>;
+
+const MultiSelect: React.FC<MultiSelectProps> = ({
+	disabled,
+	isLoading,
+	label,
+	name = '',
+	onChange,
+	options,
+	value,
+}) => {
+	const [visible, setVisible] = useState(false);
+	const multiselectRef = useRef<any>(null);
+
+	useEffect(() => {
+		const current = multiselectRef.current;
+
+		if (!visible) {
+			current?.blur();
+		}
+	}, [visible]);
+
+	return (
+		<Form.BaseWrapper label={label}>
+			<ReactSelect
+				classNamePrefix="marketplace-multi-select"
+				closeMenuOnSelect
+				isDisabled={disabled}
+				isLoading={isLoading}
+				isMulti
+				menuIsOpen={visible}
+				menuPosition="fixed"
+				menuShouldBlockScroll
+				name={name}
+				onBlur={() => setVisible(false)}
+				onChange={(value) => {
+					if (onChange) {
+						onChange({target: {name, value}} as any);
+					}
+				}}
+				onFocus={() => !visible && setVisible(true)}
+				onKeyDown={(event) => {
+					if (event.key === 'Escape' && visible === true) {
+						event.stopPropagation();
+						setVisible(false);
+					}
+
+					return;
+				}}
+				onMenuClose={() => setVisible(false)}
+				openMenuOnClick
+				options={options}
+				ref={multiselectRef}
+				tabSelectsValue={false}
+				value={value as PropsValue<unknown>}
+			/>
+		</Form.BaseWrapper>
+	);
+};
+
+export default MultiSelect;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Renderer.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Renderer.tsx
@@ -1,0 +1,247 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {memo} from 'react';
+import {Params} from 'react-router-dom';
+
+import {Operators} from '../../core/SearchBuilder';
+import i18n from '../../i18n';
+import Form from './index';
+
+type AutoCompleteProps = {
+	label?: string;
+	onSearch: (keyword: string) => any;
+	resource?: ((params: Readonly<Params<string>>) => string) | string;
+	transformData?: (item: any) => any;
+};
+
+type RenderedFieldOptions = string[] | {label: string; value: string}[];
+
+export type RendererFields = {
+	disabled?: boolean;
+	isCustomFilter?: boolean;
+	label: string;
+	name: string;
+	operator?: Operators;
+	optionalOperator?: Operators;
+	options?: RenderedFieldOptions;
+	placeholder?: string;
+	removeQuoteMark?: boolean;
+	requestOperator?: string;
+	type:
+		| 'autocomplete'
+		| 'checkbox'
+		| 'date'
+		| 'date-range'
+		| 'multiselect'
+		| 'number'
+		| 'select'
+		| 'text'
+		| 'textarea';
+} & Partial<AutoCompleteProps>;
+
+export type Options = {
+	label: string;
+	value: string;
+};
+
+export type FieldOptions = {[key: string]: any[]};
+
+type RendererProps = {
+	fieldOptions?: FieldOptions;
+	fields: RendererFields[];
+	filterSchema: string;
+	form: any;
+	isLoading?: boolean;
+	onApply: () => void;
+	onChange: (event: any) => void;
+};
+
+const RenderField = ({
+	field,
+	fieldOptions,
+	form,
+	isLoading = false,
+	onApply,
+	onChange,
+}: Omit<RendererProps, 'fields'> & {field: RendererFields}) => {
+	const {disabled, label, name, options = [], type} = field;
+
+	const currentValue = form[name];
+
+	const isFieldDisabled = () =>
+		disabled ?? currentValue.includes(i18n.sub('no-x', field.label));
+
+	const getFieldValue = () =>
+		currentValue === i18n.sub('no-x', field.label) ? '' : currentValue;
+
+	const getOptions = () =>
+		fieldOptions?.[name] ||
+		(options || []).map((option) =>
+			typeof option === 'object'
+				? option
+				: {
+						label: option,
+						value: option,
+					}
+		);
+
+	if (type === 'date-range') {
+		return (
+			<div className="my-1">
+				<Form.DateRange
+					label={label}
+					onChange={(
+						value: string,
+						setValue: React.Dispatch<React.SetStateAction<string>>
+					) => {
+						setValue(value);
+
+						onChange({
+							target: {
+								name,
+								type: 'date-range',
+								value,
+							},
+						});
+					}}
+					value={currentValue[0]?.value || currentValue}
+				/>
+			</div>
+		);
+	}
+
+	if (['date', 'number', 'text', 'textarea'].includes(type)) {
+		return (
+			<Form.Input
+				disabled={isFieldDisabled()}
+				onChange={onChange}
+				onKeyDown={(event) => {
+					if (event.key === 'Enter' && type !== 'textarea') {
+						onApply();
+					}
+				}}
+				value={getFieldValue()}
+				{...(field as any)}
+			/>
+		);
+	}
+
+	if (type === 'select') {
+		return (
+			<Form.Select
+				disabled={disabled}
+				isLoading={isLoading}
+				label={label}
+				name={name}
+				onChange={onChange}
+				options={getOptions()}
+				value={currentValue[0]?.value || currentValue}
+			/>
+		);
+	}
+
+	if (type === 'checkbox') {
+		const onCheckboxChange = (event: any) => {
+			const labelValue = event.target.labels[0].innerText;
+			const inputValue = event.target.value;
+
+			const formValue: unknown[] = Array.isArray(form[name])
+				? [...form[name]]
+				: [];
+
+			const simplifiedFormValue = formValue.map((item: any) =>
+				typeof item === 'object' && item !== null ? item.value : item
+			);
+
+			const newEntry =
+				inputValue !== labelValue
+					? {label: labelValue, value: inputValue}
+					: inputValue;
+
+			const isSelected = simplifiedFormValue.includes(inputValue);
+
+			const newValue = isSelected
+				? formValue.filter((item: any) =>
+						typeof item === 'object'
+							? item.value !== inputValue
+							: item !== inputValue
+					)
+				: [...formValue, newEntry];
+
+			onChange({
+				target: {
+					name,
+					value: newValue,
+				},
+			});
+		};
+
+		return (
+			<div>
+				<label>{label}</label>
+
+				{getOptions().map((option, index) => {
+					const optionValue =
+						typeof option === 'string' ? option : option.value;
+
+					return (
+						<Form.Checkbox
+							checked={
+								Array.isArray(form[name]) &&
+								form[name].some((option: Options | string) =>
+									typeof option === 'string'
+										? option === optionValue
+										: option.value === optionValue
+								)
+							}
+							disabled={disabled}
+							key={index}
+							label={
+								typeof option === 'string'
+									? option
+									: option.label
+							}
+							name={name}
+							onChange={onCheckboxChange}
+							value={optionValue}
+						/>
+					);
+				})}
+			</div>
+		);
+	}
+
+	if (type === 'multiselect') {
+		return (
+			<div className="my-2">
+				<label>{label}</label>
+
+				<Form.MultiSelect
+					disabled={disabled}
+					isLoading={field.resource ? isLoading : false}
+					name={name}
+					onChange={onChange}
+					options={getOptions()}
+					value={currentValue}
+				/>
+			</div>
+		);
+	}
+
+	return null;
+};
+
+const Renderer: React.FC<RendererProps> = ({fields, ...otherProps}) => (
+	<div className="form-renderer">
+		{fields.map((field, index) => (
+			<div className="mb-4" key={index}>
+				<RenderField {...otherProps} field={field} />
+			</div>
+		))}
+	</div>
+);
+
+export default memo(Renderer);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Select.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/Select.tsx
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import classNames from 'classnames';
+import {InputHTMLAttributes} from 'react';
+
+import BaseWrapper from './BaseWrapper';
+
+type InputSelectProps = {
+	className?: string;
+	defaultOption?: boolean;
+	disabled?: boolean;
+	errors?: any;
+	forceSelectOption?: boolean;
+	id?: string;
+	isLoading?: boolean;
+	label?: string;
+	name: string;
+	options: {label: string; value: string | number}[];
+	register?: any;
+	registerOptions?: any;
+	required?: boolean;
+	type?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+const Select: React.FC<InputSelectProps> = ({
+	className,
+	disabled = false,
+	registerOptions,
+	defaultOption = true,
+	errors = {},
+	defaultValue,
+	label,
+	name,
+	register = () => {},
+	id = name,
+	isLoading,
+	options,
+	forceSelectOption = false,
+	required = false,
+	...otherProps
+}) => {
+	return (
+		<BaseWrapper
+			disabled={disabled}
+			error={errors[name]?.message}
+			label={label}
+			required={required}
+		>
+			<select
+				className={classNames('form-control rounded-xs', className)}
+				defaultValue={defaultValue}
+				disabled={disabled}
+				id={id}
+				name={name}
+				{...otherProps}
+				{...register(name, {required, ...registerOptions})}
+			>
+				{defaultOption && <option value=""></option>}
+
+				{isLoading ? (
+					<option value="">Loading...</option>
+				) : (
+					options?.map(({label, value}, index) => {
+						const valueOption =
+							name.includes('teamToComponents/name') ||
+							name.includes('componentToCaseResult/name')
+								? label
+								: value;
+
+						return (
+							<option
+								key={index}
+								label={label}
+								selected={
+									forceSelectOption
+										? value === defaultValue
+										: undefined
+								}
+								value={valueOption}
+							>
+								{label}
+							</option>
+						);
+					})
+				)}
+			</select>
+		</BaseWrapper>
+	);
+};
+
+export default Select;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Form/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayForm from '@clayui/form';
+
+import BaseWrapper from './BaseWrapper';
+import Checkbox from './Checkbox';
+import DateRange from './DateRange';
+import Input from './Input';
+import BaseWarning from './InputWarning';
+import MultiSelect from './MultiSelect';
+import Renderer from './Renderer';
+import Select from './Select';
+
+const Form = () => {};
+
+Form.BaseWarning = BaseWarning;
+Form.BaseWrapper = BaseWrapper;
+Form.Clay = ClayForm;
+Form.Checkbox = Checkbox;
+Form.DateRange = DateRange;
+Form.Divider = (props: React.HTMLAttributes<HTMLHRElement>) => (
+	<hr {...props} />
+);
+Form.Input = Input;
+Form.MultiSelect = MultiSelect;
+Form.Select = Select;
+Form.Renderer = Renderer;
+
+export default Form;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Header/Header.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Header/Header.tsx
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Text} from '@clayui/core';
+import {ReactNode} from 'react';
+
+type HeaderProps = {
+	description?: ReactNode | string;
+	icon?: ReactNode | string;
+	title?: ReactNode | string;
+};
+
+export function Header({description, icon, title}: HeaderProps) {
+	return (
+		<div className="d-flex flex-column mb-3">
+			<span>{icon}</span>
+			<Text size={9} weight="semi-bold">
+				{title}
+			</Text>
+
+			<span className="secondary-text">{description}</span>
+		</div>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Loading.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Loading.tsx
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {ComponentProps, ReactNode} from 'react';
+
+type LoadingProps = ComponentProps<typeof ClayLoadingIndicator>;
+
+type FullScreenProps = {
+	children: ReactNode;
+};
+
+const Loading: React.FC<LoadingProps> & {FullScreen: typeof FullScreen} = ({
+	displayType = 'primary',
+	shape = 'squares',
+	size = 'lg',
+	...props
+}) => (
+	<ClayLoadingIndicator
+		displayType={displayType}
+		shape={shape}
+		size={size}
+		{...props}
+	/>
+);
+
+const FullScreen: React.FC<FullScreenProps> = ({children}) => (
+	<div className="loading-overlay">
+		<div className="loading-container">
+			<div className="loading-text">
+				<Loading style={{marginBottom: '2rem'}} />
+				<span className="mt-3">{children}</span>
+			</div>
+		</div>
+	</div>
+);
+
+Loading.FullScreen = FullScreen;
+
+export default Loading;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Page.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Page.tsx
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ComponentProps, ReactElement, ReactNode} from 'react';
+
+import FetcherError from '../services/fetcher/FetcherError';
+import EmptyState from './EmptyState';
+import {Header} from './Header/Header';
+import Loading from './Loading';
+
+export type PageRendererProps = {
+	children: any;
+	className?: string;
+	error?: FetcherError;
+	isLoading?: boolean;
+};
+
+const PageRenderer: React.FC<PageRendererProps> = ({
+	children,
+	className,
+	error,
+	isLoading,
+}) => {
+	if (isLoading) {
+		return <Loading className="mt-3" />;
+	}
+
+	if (error) {
+		return (
+			<EmptyState
+				description={error?.info?.title}
+				title={error.message}
+				type="EMPTY_SEARCH"
+			/>
+		);
+	}
+
+	return className ? <div className={className}>{children}</div> : children;
+};
+
+type PageProps = {
+	children: any;
+	description?: string;
+	pageRendererProps?: Omit<ComponentProps<typeof PageRenderer>, 'children'>;
+	rightButton?: ReactNode;
+	title?: string;
+};
+
+const Page: React.FC<PageProps> = ({
+	children,
+	description,
+	pageRendererProps,
+	rightButton,
+	title,
+}) => (
+	<div className="w-100">
+		<div className="align-items-center d-flex justify-content-between">
+			{(description || title) && (
+				<Header description={description} title={title} />
+			)}
+			{rightButton}
+		</div>
+
+		{pageRendererProps ? (
+			<PageRenderer {...pageRendererProps}>
+				{children as ReactElement}
+			</PageRenderer>
+		) : (
+			children
+		)}
+	</div>
+);
+
+export {PageRenderer};
+
+export default Page;


### PR DESCRIPTION
Part of epic LPD-88257. Stacked on \`LPD-88257-services\`.

Adds the shared UI primitives: Page, Header, Loading, EmptyState, ButtonWithIcon, and the Form components (Input, Select, MultiSelect, Checkbox, DateRange, Renderer).