### PR TITLE
LPD-91578 Migrate Marketplace Summary from marketplace workspace

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/AdminLayout.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/AdminLayout.tsx
@@ -9,6 +9,8 @@ import AppLayout from '../../components/AppLayout';
 import {buildNavItems} from '../../utils/routes';
 import {adminRoutes} from './adminRoutes';
 
+import './admin.scss';
+
 export default function AdminLayout() {
 	const adminNav = useMemo(() => buildNavItems(adminRoutes), []);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/MPSummary.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/MPSummary.tsx
@@ -3,6 +3,158 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayIcon from '@clayui/icon';
+import {useMemo} from 'react';
+import {Link} from 'react-router-dom';
+
+import ErrorBoundary from '../../../components/ErrorBoundary';
+import Page from '../../../components/Page';
+import {useOneContext} from '../../../context/OneContext';
+import i18n from '../../../i18n';
+import {formatCurrency} from '../../../utils/currencies';
+import AdministratorAppsListView from './components/AdministratorAppsListView';
+import DonutKPIChart from './components/DonutKPIChart';
+import InfoCard from './components/InfoCard';
+import {AdministratorOrdersListView} from './components/AdministratorOrdersListView';
+import AdministratorMostPurchasedSection from './components/AdministratorMostPurchasedSection';
+import useAccountsMetrics from './hooks/useAccountsMetrics';
+import useKPI from './hooks/useKPI';
+import useOrderMetrics from './hooks/useOrderMetrics';
+
+import './mp_summary.scss';
+
 export default function MPSummary() {
-	return <div />;
+	const {data: {kpis = []} = {}} = useKPI();
+	const {data: accounts} = useAccountsMetrics('week');
+	const {data: orderMetrics} = useOrderMetrics('week');
+	const {marketplaceUserAccount} = useOneContext();
+
+	const infoCards = useMemo(
+		() => [
+			{
+				growth: accounts?.growth ?? 0,
+				growthContext: `+${accounts?.lastPeriod ?? 0} this week `,
+				symbol: 'users',
+				title: i18n.translate('accounts'),
+				value: accounts?.totalCount ?? 0,
+			},
+			{
+				symbol: 'dollar-symbol',
+				title: (
+					<span>
+						{i18n.translate('income')}{' '}
+						&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;
+					</span>
+				),
+				value: formatCurrency(orderMetrics?.totalAmount || 0),
+			},
+			{
+				growth: orderMetrics?.growth ?? 0,
+				growthContext: `+${orderMetrics?.lastPeriod ?? 0} this week `,
+				symbol: 'shopping-cart',
+				title: i18n.translate('orders'),
+				value: orderMetrics?.totalCount ?? 0,
+			},
+		],
+		[
+			accounts?.growth,
+			accounts?.lastPeriod,
+			accounts?.totalCount,
+			orderMetrics?.growth,
+			orderMetrics?.lastPeriod,
+			orderMetrics?.totalAmount,
+			orderMetrics?.totalCount,
+		]
+	);
+
+	return (
+		<Page
+			description={i18n.translate(
+				'a-sleek-and-intuitive-admin-dashboard-for-monitoring-key-metrics'
+			)}
+			title={i18n.translate('administrator-dashboard')}
+		>
+			<div className="d-flex flex-column">
+				<div className="d-flex flex-wrap mb-3" style={{gap: '20px'}}>
+					<ErrorBoundary>
+						{kpis.map((chart, index) => (
+							<DonutKPIChart {...chart} key={index} />
+						))}
+					</ErrorBoundary>
+				</div>
+
+				<div
+					className="d-flex flex-wrap info-container"
+					style={{marginBottom: '3.5rem'}}
+				>
+					{infoCards.map((infoCard, index) => (
+						<InfoCard {...infoCard} key={index} />
+					))}
+				</div>
+
+				<div style={{marginBottom: '3.5rem'}}>
+					<Page
+						pageRendererProps={{
+							className: 'border py-2 rounded-lg',
+						}}
+						rightButton={
+							marketplaceUserAccount?.isAdmin && (
+								<Link
+									className="font-weight-bold"
+									to="/admin/mp-orders"
+								>
+									{i18n.translate('view-all')}
+									<ClayIcon symbol="order-arrow-right" />
+								</Link>
+							)
+						}
+						title={i18n.translate('recent-orders')}
+					>
+						<AdministratorOrdersListView
+							listViewProps={{
+								id: 'summary-orders',
+								initialContext: {pageSize: 5},
+								paginationOptions: {displayType: false},
+							}}
+							managementToolbarProps={{
+								visible: false,
+							}}
+						/>
+					</Page>
+				</div>
+
+				<div style={{marginBottom: '3.5rem'}}>
+					<Page
+						pageRendererProps={{
+							className: 'border py-2 rounded-lg',
+						}}
+						rightButton={
+							<Link
+								className="font-weight-bold"
+								to="/admin/mp-apps"
+							>
+								{i18n.translate('view-all')}
+								<ClayIcon symbol="order-arrow-right" />
+							</Link>
+						}
+						title={i18n.translate('published-apps')}
+					>
+						<AdministratorAppsListView
+							isSortable
+							listViewProps={{
+								id: 'summary-apps',
+								initialContext: {pageSize: 5},
+								paginationOptions: {displayType: false},
+							}}
+							managementToolbarProps={{
+								visible: false,
+							}}
+						/>
+					</Page>
+				</div>
+
+				<AdministratorMostPurchasedSection />
+			</div>
+		</Page>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorAppsListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorAppsListView.tsx
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Label from '@clayui/label';
+import {ComponentProps} from 'react';
+
+import ListView, {ListViewProps} from '../../../../components/ListView';
+import {ManagementToolbarProps} from '../../../../components/ListView/components/ManagementToolbar';
+import {
+	ProductSpecificationKey,
+	ProductTypeLabels,
+	ProductWorkflowDisplayType,
+	ProductWorkflowStatusLabel,
+} from '../../../../enums/Product';
+import i18n from '../../../../i18n';
+import {formatDate} from '../../../../utils/date';
+
+type AdministratorAppsListViewProps = {
+	filter?: string;
+	isSortable?: boolean;
+	listViewProps?: Partial<ListViewProps<Product>>;
+	managementToolbarProps?: {
+		visible?: boolean;
+	} & Omit<
+		ManagementToolbarProps,
+		| 'actions'
+		| 'onSelectAllRows'
+		| 'rowSelectable'
+		| 'tableProps'
+		| 'totalItems'
+	>;
+};
+
+const AdministratorAppsListView: React.FC<AdministratorAppsListViewProps> = ({
+	isSortable = false,
+	listViewProps,
+	managementToolbarProps,
+}) => (
+	<ListView<Product>
+		id="administrator-apps"
+		managementToolbarProps={{
+			filterSchema: 'administratorApps',
+			...managementToolbarProps,
+		}}
+		resource={`/o/headless-commerce-admin-catalog/v1.0/products?${new URLSearchParams(
+			{
+				'nestedFields': 'catalog,productSpecifications',
+				'productSpecifications.pageSize': '-1',
+				'sort': 'createDate:desc',
+			}
+		)}`}
+		tableProps={{
+			actions: [
+				{
+					name: i18n.translate('view-details'),
+					onClick: (product: Product) => {
+						window.open(
+							`/group/guest/~/control_panel/manage?p_p_id=com_liferay_commerce_product_definitions_web_internal_portlet_CPDefinitionsPortlet&p_p_lifecycle=0&p_p_state=maximized&_com_liferay_commerce_product_definitions_web_internal_portlet_CPDefinitionsPortlet_mvcRenderCommandName=%2Fcp_definitions%2Fedit_cp_definition&_com_liferay_commerce_product_definitions_web_internal_portlet_CPDefinitionsPortlet_cpDefinitionId=${product.id}`,
+							'_blank'
+						);
+					},
+				},
+			],
+			columns: [
+				{
+					clickable: true,
+					id: 'name',
+					name: i18n.translate('name'),
+					render: (name, {thumbnail}) => (
+						<div>
+							<img
+								alt="App Image"
+								className="app-details-page-table-icon"
+								src={thumbnail}
+							/>
+
+							<span className="font-weight-semi-bold ml-2 text-nowrap">
+								{name?.en_US}
+							</span>
+						</div>
+					),
+					sortable: isSortable,
+				},
+				{
+					id: 'productSpecifications',
+					name: i18n.translate('app-type'),
+					render: (productSpecifications) => {
+						const productType = productSpecifications.find(
+							({specificationKey}) =>
+								specificationKey ===
+								ProductSpecificationKey.APP_TYPE
+						)?.value?.en_US;
+
+						const label =
+							ProductTypeLabels[
+								productType as keyof typeof ProductTypeLabels
+							];
+
+						return <div className="text-capitalize">{label}</div>;
+					},
+				},
+				{
+					id: 'catalog',
+					name: i18n.translate('publisher-name'),
+					render: (catalog) => catalog.name,
+				},
+				{
+					id: 'modifiedDate',
+					name: i18n.translate('last-update'),
+					render: (modifiedDate) => formatDate(modifiedDate),
+					sortable: isSortable,
+				},
+				{
+					id: 'createDate',
+					name: i18n.translate('published-at'),
+					render: (createDate) => formatDate(createDate),
+				},
+				{
+					id: 'workflowStatusInfo',
+					name: i18n.translate('status'),
+					render: (
+						workflowStatusInfo: Product['workflowStatusInfo']
+					) => (
+						<Label
+							displayType={
+								ProductWorkflowDisplayType[
+									workflowStatusInfo.code as keyof typeof ProductWorkflowDisplayType
+								] as ComponentProps<typeof Label>['displayType']
+							}
+						>
+							{
+								ProductWorkflowStatusLabel[
+									workflowStatusInfo.code as keyof typeof ProductWorkflowStatusLabel
+								]
+							}
+						</Label>
+					),
+				},
+			],
+			navigateTo: ({productId}) => `/admin/mp-apps/${productId}`,
+		}}
+		{...listViewProps}
+	/>
+);
+
+export default AdministratorAppsListView;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorMostPurchasedListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorMostPurchasedListView.tsx
@@ -1,0 +1,121 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useMemo, useState} from 'react';
+
+import EmptyState from '../../../../components/EmptyState';
+import Table, {
+	TableProps,
+} from '../../../../components/ListView/components/Table';
+import {Sort} from '../../../../components/ListView/hooks/ListViewContext';
+import {OrderTypes, orderTypeLabel} from '../../../../enums/Order';
+import i18n from '../../../../i18n';
+import {SortOption} from '../../../../utils/constants';
+
+export type PurchasedItem = {
+	orderTypeExternalReferenceCode: string;
+	productName: string;
+	purchaseCount: number;
+	thumbnail: string;
+};
+
+type AdministratorMostPurchasedListViewProps = {
+	items: PurchasedItem[];
+	showAppType?: boolean;
+};
+
+function getAppTypeLabel(erc: string) {
+	return orderTypeLabel[erc as OrderTypes] ?? erc;
+}
+
+const AdministratorMostPurchasedListView: React.FC<
+	AdministratorMostPurchasedListViewProps
+> = ({items, showAppType = false}) => {
+	const [sort, setSort] = useState<Sort>({
+		direction: SortOption.DESC,
+		key: 'purchaseCount',
+	});
+
+	const sortedItems = useMemo(() => {
+		const compare = (a: PurchasedItem, b: PurchasedItem) => {
+			if (sort.key === 'purchaseCount') {
+				return a.purchaseCount - b.purchaseCount;
+			}
+
+			if (sort.key === 'orderTypeExternalReferenceCode') {
+				return getAppTypeLabel(
+					a.orderTypeExternalReferenceCode
+				).localeCompare(
+					getAppTypeLabel(b.orderTypeExternalReferenceCode)
+				);
+			}
+
+			return a.productName.localeCompare(b.productName);
+		};
+
+		const sorted = [...items].sort(compare);
+
+		return sort.direction === SortOption.DESC ? sorted.reverse() : sorted;
+	}, [items, sort]);
+
+	const columns: TableProps<PurchasedItem>['columns'] = [
+		{
+			id: 'productName',
+			name: i18n.translate('name'),
+			render: (productName, {thumbnail}) => (
+				<div className="align-items-center d-flex">
+					<img
+						alt={productName}
+						className="app-details-page-table-icon"
+						src={thumbnail}
+					/>
+
+					<span
+						className="font-weight-semi-bold text-nowrap"
+						style={{marginLeft: '0.75rem'}}
+					>
+						{productName}
+					</span>
+				</div>
+			),
+			sortable: true,
+		},
+		...(showAppType
+			? ([
+					{
+						id: 'orderTypeExternalReferenceCode',
+						name: i18n.translate('app-type'),
+						render: (erc) => getAppTypeLabel(erc),
+						sortable: true,
+					},
+				] as TableProps<PurchasedItem>['columns'])
+			: []),
+		{
+			id: 'purchaseCount',
+			name: i18n.translate('number-of-purchases'),
+			sortable: true,
+		},
+	];
+
+	return (
+		<>
+			{!items.length && (
+				<EmptyState title={i18n.translate('no-results-found')} />
+			)}
+
+			{!!items.length && (
+				<Table<PurchasedItem>
+					columns={columns}
+					items={sortedItems}
+					mutate={() => Promise.resolve(undefined)}
+					onSort={(key, direction) => setSort({direction, key})}
+					sort={sort}
+				/>
+			)}
+		</>
+	);
+};
+
+export default AdministratorMostPurchasedListView;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorMostPurchasedSection.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorMostPurchasedSection.tsx
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React, {useEffect, useState} from 'react';
+
+import Loading from '../../../../components/Loading';
+import Page from '../../../../components/Page';
+import {
+	APP_ORDER_TYPES,
+	LIFERAY_PRODUCT_ORDER_TYPES,
+} from '../../../../enums/Order';
+import {useFetch} from '../../../../hooks/useFetch';
+import i18n from '../../../../i18n';
+import HeadlessCommerceAdminCatalog from '../../../../services/rest/HeadlessCommerceAdminCatalog';
+import {safeJSONParse} from '../../../../utils/util';
+import AdministratorMostPurchasedListView, {
+	PurchasedItem,
+} from './AdministratorMostPurchasedListView';
+
+type ProductsCountEntry = {
+	orderTypeExternalReferenceCode: string;
+	productId: number;
+	total: number;
+};
+
+type PurchasedReportValue = ProductsCountEntry[];
+
+type ReportsEntry = {
+	value?: string;
+};
+
+type SplitProducts = {
+	apps: PurchasedItem[];
+	liferayProducts: PurchasedItem[];
+};
+
+const REPORTS_ENDPOINT = 'o/c/reports';
+const REPORTS_FILTER = "externalReferenceCode eq 'PRODUCT-PURCHASES-COUNT'";
+const TOP_PRODUCTS_COUNT = 5;
+
+function getTopProducts(
+	productsPurchased: ProductsCountEntry[],
+	allowedTypes: readonly string[]
+): ProductsCountEntry[] {
+	return productsPurchased
+		.filter(({orderTypeExternalReferenceCode}) =>
+			allowedTypes.includes(orderTypeExternalReferenceCode)
+		)
+		.sort((a, b) => {
+			if (b.total !== a.total) {
+				return b.total - a.total;
+			}
+
+			return a.productId - b.productId;
+		})
+		.slice(0, TOP_PRODUCTS_COUNT);
+}
+
+async function withProductDetails(
+	entries: ProductsCountEntry[]
+): Promise<PurchasedItem[]> {
+	return Promise.all(
+		entries.map(
+			async ({orderTypeExternalReferenceCode, productId, total}) => {
+				let productName = '';
+				let thumbnail = '';
+
+				try {
+					const product =
+						await HeadlessCommerceAdminCatalog.getProduct(
+							productId
+						);
+
+					productName = product?.name?.en_US ?? '';
+					thumbnail = product?.thumbnail ?? '';
+				}
+				catch {}
+
+				return {
+					orderTypeExternalReferenceCode,
+					productName:
+						productName || i18n.translate('product-unavailable'),
+					purchaseCount: total,
+					thumbnail,
+				};
+			}
+		)
+	);
+}
+
+const AdministratorMostPurchasedSection: React.FC = () => {
+	const [products, setProducts] = useState<SplitProducts>({
+		apps: [],
+		liferayProducts: [],
+	});
+	const [loadingDetails, setLoadingDetails] = useState(false);
+
+	const {data: reportsData, loading} = useFetch<APIResponse<ReportsEntry>>(
+		`${REPORTS_ENDPOINT}?filter=${encodeURIComponent(REPORTS_FILTER)}`
+	);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		if (!reportsData?.items?.length) {
+			setProducts({apps: [], liferayProducts: []});
+
+			return;
+		}
+
+		const productsPurchased = safeJSONParse<PurchasedReportValue>(
+			reportsData.items[0]?.value || '',
+			[]
+		);
+
+		const topApps = getTopProducts(productsPurchased, APP_ORDER_TYPES);
+		const topLiferayProducts = getTopProducts(
+			productsPurchased,
+			LIFERAY_PRODUCT_ORDER_TYPES
+		);
+
+		if (!topApps.length && !topLiferayProducts.length) {
+			setProducts({apps: [], liferayProducts: []});
+
+			return;
+		}
+
+		setLoadingDetails(true);
+
+		Promise.all([
+			withProductDetails(topApps),
+			withProductDetails(topLiferayProducts),
+		])
+			.then(([apps, liferayProducts]) => {
+				if (!cancelled) {
+					setProducts({apps, liferayProducts});
+					setLoadingDetails(false);
+				}
+			})
+			.catch((error) => {
+				console.error(error);
+
+				if (!cancelled) {
+					setLoadingDetails(false);
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [reportsData]);
+
+	if (loading || loadingDetails) {
+		return <Loading />;
+	}
+
+	return (
+		<>
+			<div style={{marginBottom: '3.5rem', marginTop: '3.5rem'}}>
+				<Page
+					pageRendererProps={{
+						className: 'border py-2 rounded-lg',
+					}}
+					title={i18n.translate('most-purchased-apps')}
+				>
+					<AdministratorMostPurchasedListView
+						items={products.apps}
+						showAppType
+					/>
+				</Page>
+			</div>
+
+			<Page
+				pageRendererProps={{className: 'border py-2 rounded-lg'}}
+				title={i18n.translate('most-purchased-products')}
+			>
+				<AdministratorMostPurchasedListView
+					items={products.liferayProducts}
+				/>
+			</Page>
+		</>
+	);
+};
+
+export default AdministratorMostPurchasedSection;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorOrdersListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/AdministratorOrdersListView.tsx
@@ -1,0 +1,219 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Button from '@clayui/button';
+import Icon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import {Status} from '@clayui/modal/lib/types';
+import {ClayTooltipProvider} from '@clayui/tooltip';
+import {formatDistance} from 'date-fns';
+import {Fragment} from 'react';
+
+import ListView, {ListViewProps} from '../../../../components/ListView';
+import {ManagementToolbarProps} from '../../../../components/ListView/components/ManagementToolbar';
+import {
+	OrderCustomFields,
+	orderTypeLabel,
+	orderWorkflowDisplayType,
+	paymentWorkflowDisplayType,
+} from '../../../../enums/Order';
+import i18n from '../../../../i18n';
+import {FilterSchemaOption} from '../../../../schema/filters';
+import oneOAuth2 from '../../../../services/oauth/One';
+import {safeJSONParse} from '../../../../utils/util';
+
+type AdministratorOrdersListViewProps = {
+	isSortable?: boolean;
+	listViewProps?: Partial<ListViewProps<Order>>;
+	managementToolbarProps?: {
+		visible?: boolean;
+	} & Omit<
+		ManagementToolbarProps,
+		| 'actions'
+		| 'onSelectAllRows'
+		| 'rowSelectable'
+		| 'tableProps'
+		| 'totalItems'
+	>;
+};
+
+export function AdministratorOrdersListView({
+	isSortable = false,
+	listViewProps,
+	managementToolbarProps,
+}: AdministratorOrdersListViewProps) {
+	return (
+		<ListView<Order>
+			emptyStateProps={{title: i18n.translate('no-orders-yet')}}
+			id="administrator-orders"
+			managementToolbarProps={{
+				actionButton: (
+					filter: {
+						[key: string]: string;
+					},
+					filterSchema?: FilterSchemaOption
+				) => {
+					return (
+						<Button
+							className="align-items-center d-flex h-100 justify-content-center ml-3 mr-4"
+							displayType="unstyled"
+							onClick={() =>
+								oneOAuth2.downloadOrderReport(
+									filter,
+									filterSchema
+								)
+							}
+						>
+							<Icon className="mr-2" symbol="download" />
+							<b>{i18n.translate('export')}</b>
+						</Button>
+					);
+				},
+
+				filterSchema: 'administratorOrders',
+				...managementToolbarProps,
+			}}
+			resource={`/o/headless-commerce-admin-order/v1.0/orders?${new URLSearchParams(
+				{
+					nestedFields: 'account,orderItems',
+					sort: 'createDate:desc',
+				}
+			)}`}
+			tableProps={{
+				actions: [
+					{
+						name: i18n.translate('order-details'),
+						onClick: () => {},
+					},
+				],
+				columns: [
+					{
+						id: 'id',
+						name: i18n.translate('id'),
+						render: (id) => (
+							<span className="font-weight-bold">{id}</span>
+						),
+					},
+					{
+						id: 'orderItems',
+						name: i18n.translate('app-name'),
+						render: (orderItems) => (
+							<span className="text-wrap">
+								{orderItems[0]?.name?.en_US}
+							</span>
+						),
+					},
+					{
+						id: 'account',
+						name: i18n.translate('user-account'),
+						render: (account) => account.name,
+					},
+					{
+						id: 'orderTypeExternalReferenceCode',
+						name: i18n.translate('app-type'),
+						render: (orderTypeExternalReferenceCode) => (
+							<span>
+								{
+									orderTypeLabel[
+										orderTypeExternalReferenceCode as keyof typeof orderTypeLabel
+									]
+								}
+							</span>
+						),
+					},
+					{
+						id: 'totalFormatted',
+						name: i18n.translate('amount'),
+					},
+					{
+						id: 'orderStatusInfo',
+						name: i18n.translate('order-status'),
+						render: (orderStatusInfo) => (
+							<ClayLabel
+								className="text-nowrap"
+								displayType={
+									orderWorkflowDisplayType[
+										orderStatusInfo.code as keyof typeof orderWorkflowDisplayType
+									] as Status
+								}
+							>
+								{orderStatusInfo.label_i18n}
+							</ClayLabel>
+						),
+					},
+					{
+						id: 'paymentStatusInfo',
+						name: i18n.translate('payment-status'),
+						render: (paymentStatusInfo) => (
+							<ClayLabel
+								className="text-nowrap"
+								displayType={
+									paymentWorkflowDisplayType[
+										paymentStatusInfo?.code as keyof typeof paymentWorkflowDisplayType
+									] as Status
+								}
+							>
+								{paymentStatusInfo.label_i18n}
+							</ClayLabel>
+						),
+					},
+					{
+						id: 'customFields',
+						name: i18n.translate('customer-project'),
+						render: (customFields) => {
+							const projects = safeJSONParse(
+								customFields![
+									OrderCustomFields.KORONEIKI_PROJECT
+								],
+								[]
+							);
+
+							const Wrapper = projects.length
+								? ClayTooltipProvider
+								: Fragment;
+
+							return (
+								<Wrapper>
+									<div
+										data-tooltip-align="bottom"
+										title={projects
+											.map(
+												(
+													{name}: {name: string},
+													index: number
+												) =>
+													`${projects.length > 1 ? `(${index + 1})` : ''} ${name}`
+											)
+											.join('\n')}
+									>
+										{projects.length ? 'Yes' : 'No'}
+									</div>
+								</Wrapper>
+							);
+						},
+					},
+					{
+						id: 'createDate',
+						name: i18n.translate('created-at'),
+						render: (createDate) => (
+							<span
+								className="ml-2 text-capitalize text-nowrap"
+								title={createDate}
+							>
+								{formatDistance(
+									new Date(createDate ?? ''),
+									Date.now(),
+									{addSuffix: true}
+								)}
+							</span>
+						),
+						sortable: isSortable,
+					},
+				],
+			}}
+			{...listViewProps}
+		/>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/DonutKPIChart.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/DonutKPIChart.tsx
@@ -1,0 +1,201 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Button from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import Label from '@clayui/label';
+import React from 'react';
+import {Cell, Pie, PieChart, ResponsiveContainer} from 'recharts';
+
+import i18n from '../../../../i18n';
+import {percentage as getPercentage} from '../util';
+
+import './donut_kpi_chart.scss';
+
+type DonutKPIChartProps = {
+	annualTargetCurrent: number;
+	annualTargetTotal: number | string;
+	colors: string[];
+	externalPage?: boolean;
+	lastYearCount?: number;
+	lastYearLabel?: string;
+	monthlyIncreasePct?: number;
+	monthlyIncreaseValue?: number;
+	monthlyIncreaseValueIsGrowing?: number;
+	onClick?: null | (() => void);
+	title: string;
+};
+
+const DonutKPIChart: React.FC<DonutKPIChartProps> = ({
+	annualTargetCurrent,
+	annualTargetTotal,
+	colors,
+	externalPage,
+	lastYearCount,
+	lastYearLabel,
+	monthlyIncreasePct = 0,
+	monthlyIncreaseValue = 0,
+	monthlyIncreaseValueIsGrowing = false,
+	onClick,
+	title,
+}) => {
+	const percentage = getPercentage(
+		Number(annualTargetTotal),
+		annualTargetCurrent
+	);
+
+	const data = [
+		{name: 'filed', value: Math.min(percentage, 100)},
+		{name: 'remainder', value: Math.max(0, 100 - percentage)},
+	];
+
+	return (
+		<div className="border d-inline-flex flex-column justify-content-between marketplace-donut-chart p-4">
+			<div className="align-items-start d-flex flex-row justify-content-between">
+				<span
+					className="font-weight-bold text-wrap"
+					style={{marginRight: '0.75rem'}}
+				>
+					{title}
+				</span>
+
+				{onClick && (
+					<span className="align-items-center d-flex justify-content-center">
+						<Button
+							className="align-items-center d-flex details-button rounded-lg text-nowrap"
+							displayType="secondary"
+							onClick={onClick}
+							size="sm"
+						>
+							{i18n.translate('view-details')}{' '}
+							{externalPage && (
+								<ClayIcon
+									className="ml-1 mt-0"
+									style={{fontSize: 8}}
+									symbol="shortcut"
+								/>
+							)}
+						</Button>
+					</span>
+				)}
+			</div>
+
+			<div
+				className="align-items-center d-flex flex-row justify-content-between"
+				style={{marginTop: '0.75rem'}}
+			>
+				<div className="donut-chart-container">
+					<ResponsiveContainer>
+						<PieChart tabIndex={-1}>
+							<Pie
+								cornerRadius={0}
+								data={data}
+								dataKey="value"
+								endAngle={-270}
+								innerRadius={40}
+								outerRadius={80}
+								paddingAngle={0}
+								startAngle={90}
+							>
+								{data.map((_: any, index: number) => (
+									<Cell fill={colors[index]} key={index}>
+										{index}
+									</Cell>
+								))}
+							</Pie>
+
+							<text
+								className="marketplace-donut-chart-center-legend"
+								dominantBaseline="middle"
+								textAnchor="middle"
+								x="52%"
+								y="52%"
+							>
+								<tspan
+									fontSize={percentage >= 100 ? '40' : '44'}
+								>
+									{percentage}
+								</tspan>
+								<tspan fontSize="14">%</tspan>
+							</text>
+						</PieChart>
+					</ResponsiveContainer>
+				</div>
+
+				<div className="chart-legend d-flex flex-column">
+					<div
+						className="d-flex flex-column"
+						style={{marginBottom: '0.75rem'}}
+					>
+						<span className="font-weight-bold text-small">
+							{i18n.translate('annual-target')}
+						</span>
+
+						<div className="align-items-center d-flex flex-row">
+							<div className="align-items-center d-flex font-weight-bold justify-content-center text-title">
+								<span className="chart-legend-data mr-1">
+									{annualTargetCurrent || 0}
+								</span>
+								/
+								<span className="mx-1">
+									{annualTargetTotal || 0}
+								</span>
+							</div>
+							<span className="text-small">
+								{i18n.translate('of-target')}
+							</span>
+						</div>
+
+						{lastYearCount !== undefined && (
+							<span className="text-muted text-small">
+								{lastYearLabel
+									? `${lastYearLabel}: ${lastYearCount} / ${annualTargetTotal || 0}`
+									: `Last year: ${lastYearCount} / ${annualTargetTotal || 0}`}
+							</span>
+						)}
+					</div>
+
+					{!!monthlyIncreaseValue && (
+						<div className="d-flex flex-column">
+							<span className="font-weight-bold text-small">
+								{i18n.translate('monthly-increase')}
+							</span>
+
+							<div className="align-items-center d-flex flex-row">
+								<div
+									className="font-weight-bold text-title"
+									style={{marginRight: '0.75rem'}}
+								>
+									{`${monthlyIncreaseValueIsGrowing ? '+' : '-'}${monthlyIncreaseValue}`}
+								</div>
+
+								<Label
+									displayType={
+										monthlyIncreaseValueIsGrowing
+											? 'success'
+											: 'danger'
+									}
+								>
+									<span className="d-flex lign-items-center">
+										<ClayIcon
+											symbol={
+												monthlyIncreaseValueIsGrowing
+													? 'order-arrow-up'
+													: 'order-arrow-donw'
+											}
+										/>
+										<span className="ml-1">{`${monthlyIncreasePct} % `}</span>
+									</span>
+								</Label>
+							</div>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default DonutKPIChart;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/InfoCard.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/InfoCard.tsx
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import {ReactElement} from 'react';
+
+type InfoCardProps = {
+	className?: string;
+	growth?: number;
+	growthContext?: string;
+	limited?: boolean;
+	symbol: string;
+	title: string | ReactElement;
+	value?: string | number;
+};
+
+const InfoCard: React.FC<InfoCardProps> = ({
+	className,
+	growth = 0,
+	growthContext,
+	limited = false,
+	symbol,
+	title,
+	value,
+}) => (
+	<div
+		className={classNames(
+			'border d-flex flex-column info-card justify-content-between p-3',
+			{
+				limited,
+			},
+			className
+		)}
+	>
+		<div className="align-content-center d-flex justify-content-between mb-2">
+			<span className="d-flex flex-column">
+				<span className="font-weight-lighter mb-2 mr-2 text-black-50">
+					{title}
+				</span>
+
+				<span className="font-weight-bold h2">{value}</span>
+			</span>
+
+			<span className="d-flex flex-column justify-content-center">
+				<ClayIcon
+					className="text-primary"
+					fontSize={32}
+					symbol={symbol}
+				/>
+			</span>
+		</div>
+
+		{growthContext && (
+			<div className="font-weight-bold text-black-50">
+				<span
+					className={classNames('mr-2', {
+						'text-danger': growth < 0,
+						'text-success': growth > 0,
+					})}
+				>
+					<ClayIcon
+						className="mr-21"
+						symbol={
+							growth > 0 ? 'order-arrow-up' : 'order-arrow-down'
+						}
+					/>
+					{!isFinite(growth) ? 0 : growth}%
+				</span>
+
+				<span>{growthContext}</span>
+			</div>
+		)}
+	</div>
+);
+
+export default InfoCard;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/ProjectsUsingMarketplace.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/ProjectsUsingMarketplace.tsx
@@ -1,0 +1,99 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Label from '@clayui/label';
+
+import {orderTypeLabel} from '../../../../enums/Order';
+
+type ProjectOrder = {
+	creatorEmailAddress: string;
+	id: number;
+	orderTypeExternalReferenceCode: string;
+	projects: {
+		key: string;
+		name: string;
+	}[];
+};
+
+type ProjectsUsingMarketplaceModalBodyProps = {
+	projectsUsingMarkeplaceApps: [
+		string,
+		{
+			accountName: string;
+			orders: ProjectOrder[];
+		},
+	][];
+};
+
+type ProjectUsingMarketplaceProps = {
+	index: number;
+	order: ProjectOrder;
+};
+
+function ProjectUsingMarketplace({index, order}: ProjectUsingMarketplaceProps) {
+	const exactMatch =
+		order.projects.length === 1 ||
+		order.orderTypeExternalReferenceCode.startsWith('KOR-');
+
+	return (
+		<details className="border-0 list-group-item py-1" key={index}>
+			<summary>
+				<span>
+					<Label displayType={exactMatch ? 'success' : 'warning'}>
+						{exactMatch ? 'Exact Match' : 'Multiple projects'}
+					</Label>{' '}
+					Order #{order.id}
+				</span>{' '}
+				–{' '}
+				<span className="text-muted">
+					{
+						orderTypeLabel[
+							order.orderTypeExternalReferenceCode as keyof typeof orderTypeLabel
+						]
+					}
+				</span>
+			</summary>
+
+			<p>Created by: {order.creatorEmailAddress}</p>
+
+			{!exactMatch && (
+				<p>
+					Projects:{' '}
+					{order.projects.map((customerProject, index) => (
+						<Label key={index}>{customerProject.name}</Label>
+					))}
+				</p>
+			)}
+		</details>
+	);
+}
+
+export default function ProjectsUsingMarketplaceModalBody({
+	projectsUsingMarkeplaceApps,
+}: ProjectsUsingMarketplaceModalBodyProps) {
+	return (
+		<ul className="list-group list-group-flush">
+			{projectsUsingMarkeplaceApps.map(([key, project], index) => (
+				<li className="list-group-item" key={index}>
+					<div className="mb-1">
+						<strong className="mr-1 text-dark">
+							[{index + 1}] {key}
+						</strong>
+
+						<span className="text-dark">{project.accountName}</span>
+					</div>
+
+					{project.orders?.map((order, index) => (
+						<ProjectUsingMarketplace
+							index={index}
+							key={index}
+							order={order}
+						/>
+					))}
+				</li>
+			))}
+		</ul>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/donut_kpi_chart.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/components/donut_kpi_chart.scss
@@ -1,0 +1,29 @@
+.marketplace-donut-chart {
+	border-radius: 8px;
+	height: 290px;
+	width: 346px;
+
+	&-center-legend {
+		font-size: 34px;
+		font-weight: 700;
+	}
+
+	.chart-legend {
+		&-data {
+			font-size: 26px;
+		}
+	}
+
+	.details-button {
+		font-size: 11px;
+	}
+
+	.donut-chart-container {
+		height: 165px;
+		width: 165px;
+	}
+}
+
+.recharts-pie * {
+	outline: none !important;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useAccountsMetrics.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useAccountsMetrics.ts
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {addDays} from 'date-fns';
+import useSWR from 'swr';
+
+import SearchBuilder from '../../../../core/SearchBuilder';
+import HeadlessAdminUser from '../../../../services/rest/HeadlessAdminUser';
+
+type UseOrderMetricsProps = 'month' | 'q1' | 'q2' | 'q3' | 'q4' | 'week';
+
+export const METRIC_PARAMETER = {
+	month: 30,
+	q1: 1,
+	q2: 2,
+	q3: 3,
+	q4: 4,
+	week: 7,
+};
+
+const useAccountsMetrics = (param: UseOrderMetricsProps) => {
+	const getAccountsMetrics = async () => {
+		const currentTime = new Date();
+
+		const beforeLastPeriod = addDays(
+			currentTime,
+			-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER] * 2
+		);
+
+		const lastPeriod = addDays(
+			currentTime,
+			-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER]
+		);
+
+		beforeLastPeriod.setHours(0, 0, 0);
+		lastPeriod.setHours(23, 59, 59);
+
+		const requestsParams = [
+			new URLSearchParams({
+				fields: 'id',
+				pageSize: '1',
+			}),
+			new URLSearchParams({
+				fields: 'id',
+				filter: SearchBuilder.gt(
+					'dateCreated',
+					lastPeriod.toISOString()
+				),
+				pageSize: '1',
+			}),
+			new URLSearchParams({
+				fields: 'id',
+				filter: new SearchBuilder()
+					.lt('dateCreated', lastPeriod.toISOString())
+					.and()
+					.gt('dateCreated', beforeLastPeriod.toISOString())
+					.build(),
+				pageSize: '1',
+			}),
+		];
+
+		const response = await Promise.all(
+			requestsParams.map((searchParam) =>
+				HeadlessAdminUser.getAccounts(searchParam)
+			)
+		);
+
+		const newAccounts = response[1].totalCount - response[2].totalCount;
+
+		return {
+			beforeLastPeriod: response[2].totalCount,
+			growth: Number(
+				((newAccounts / response[1].totalCount) * 100).toFixed(2)
+			),
+			lastPeriod: response[1].totalCount,
+			param,
+			totalCount: response[0].totalCount,
+		};
+	};
+
+	return useSWR('metrics/accounts', getAccountsMetrics);
+};
+
+export default useAccountsMetrics;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useKPI.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useKPI.tsx
@@ -1,0 +1,380 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ComponentProps} from 'react';
+import {useNavigate} from 'react-router-dom';
+import useSWR from 'swr';
+
+import {useOneContext} from '../../../../context/OneContext';
+import SearchBuilder from '../../../../core/SearchBuilder';
+import {AccountType} from '../../../../enums/Account';
+import {ProductType, ProductWorkflowStatusCode} from '../../../../enums/Product';
+import useListTypeDefinition from '../../../../hooks/useListTypeDefinition';
+import useModalContext from '../../../../hooks/useModalContext';
+import HeadlessCommerceAdminCatalog from '../../../../services/rest/HeadlessCommerceAdminCatalog';
+import GraphQL from '../../../../services/rest/HeadlessGraphQL';
+import {safeJSONParse} from '../../../../utils/util';
+import ProjectsUsingMarketplaceModalBody from '../components/ProjectsUsingMarketplace';
+
+const currentYear = new Date().getFullYear();
+const lastYear = currentYear - 1;
+const lastYearISO = new Date(currentYear, 0, 1, 0, 0, 0).toISOString();
+
+const baseSearchBuilder = new SearchBuilder()
+	.in('statusCode', [ProductWorkflowStatusCode.APPROVED])
+	.and();
+
+const lastYearBaseSearchBuilder = new SearchBuilder()
+	.lt('createDate', lastYearISO)
+	.and()
+	.in('statusCode', [ProductWorkflowStatusCode.APPROVED])
+	.and();
+
+const buildQReleaseFilter = (base: SearchBuilder) =>
+	base
+		.clone()
+		.group('OPEN')
+		.lambdaContains('specificationValues', '2026 Q')
+		.or()
+		.lambdaContains('specificationValues', '2025 Q')
+		.or()
+		.lambdaContains('specificationValues', '2024 Q')
+		.or()
+		.lambdaContains('specificationValues', '2023 Q')
+		.group('CLOSE')
+		.and()
+		.not()
+		.lambda('specificationValues', ProductType.LOW_CODE_CONFIGURATION)
+		.build();
+
+const appsAndConnectorSupportingQReleaseFilter =
+	buildQReleaseFilter(baseSearchBuilder);
+
+const lastYearAppsAndConnectorSupportingQReleaseFilter = buildQReleaseFilter(
+	lastYearBaseSearchBuilder
+);
+
+const lowCodeConfigurationsPublishedFilter = baseSearchBuilder
+	.clone()
+	.lambda('specificationValues', ProductType.LOW_CODE_CONFIGURATION)
+	.build();
+
+const lastYearLowCodeConfigurationsPublishedFilter = lastYearBaseSearchBuilder
+	.clone()
+	.lambda('specificationValues', ProductType.LOW_CODE_CONFIGURATION)
+	.build();
+
+const technologyPartnershipIntegrationFilter = new SearchBuilder()
+	.lambda('specificationValues', AccountType.TECHNOLOGY_PARTNER)
+	.build();
+
+const lastYearTechnologyPartnershipIntegrationFilter = new SearchBuilder()
+	.lt('createDate', lastYearISO)
+	.and()
+	.lambda('specificationValues', AccountType.TECHNOLOGY_PARTNER)
+	.build();
+
+const getAnnualTargetValues = (kpiTarget: string, value: number) => {
+	if (kpiTarget.includes('/')) {
+		const [current, total] = kpiTarget.split('/');
+
+		return {
+			annualTargetCurrent: Number(current),
+			annualTargetTotal: Number(total),
+		};
+	}
+
+	return {
+		annualTargetCurrent: Number(value),
+		annualTargetTotal: Number(kpiTarget),
+	};
+};
+
+const queries = [
+	HeadlessCommerceAdminCatalog.getProductsDashboardKPI(
+		{
+			appsAndConnectorSupportingQRelease:
+				appsAndConnectorSupportingQReleaseFilter,
+			lastYearAppsAndConnectorSupportingQRelease:
+				lastYearAppsAndConnectorSupportingQReleaseFilter,
+			lastYearLowCodeConfigurationsPublished:
+				lastYearLowCodeConfigurationsPublishedFilter,
+			lastYearPartnershipIntegration:
+				lastYearTechnologyPartnershipIntegrationFilter,
+			lowCodeConfigurationsPublished:
+				lowCodeConfigurationsPublishedFilter,
+			partnershipIntegration: technologyPartnershipIntegrationFilter,
+		},
+		{
+			appsAndConnectorSupportingQRelease: {
+				body: ` items { catalogExternalReferenceCode, id, name, thumbnail } `,
+				pageSize: -1,
+			},
+			lastYearAppsAndConnectorSupportingQRelease: {
+				body: ` items { catalogExternalReferenceCode, id } `,
+				pageSize: -1,
+			},
+		}
+	),
+	HeadlessCommerceAdminCatalog.getCatalogs(
+		new URLSearchParams({
+			fields: 'externalReferenceCode,name',
+			pageSize: '-1',
+		})
+	),
+	GraphQL.metrics<{
+		externalReferenceCode: string;
+		name: string;
+		value: string;
+	}>(
+		{
+			group: 'c',
+			name: 'reports',
+			options: {
+				body: `items { externalReferenceCode, name, value }`,
+				pageSize: '-1',
+				sort: 'dateCreated:desc',
+			},
+		},
+		{
+			koroneikiProjects: SearchBuilder.contains(
+				'externalReferenceCode',
+				'KORONEIKI-PROJECT-'
+			),
+		}
+	),
+] as const;
+
+const useKPI = () => {
+	const {data: liferayVersionsPicklist} =
+		useListTypeDefinition('LIFERAY-VERSIONS');
+
+	const modal = useModalContext();
+	const navigate = useNavigate();
+
+	const liferayQuarterlyVersionEntries =
+		liferayVersionsPicklist?.listTypeEntries.filter((entry) =>
+			entry.externalReferenceCode.includes('Q')
+		);
+
+	const liferayQuarterlyVersionsAndConnectors = JSON.stringify({
+		'specificationValues|liferayVersion':
+			liferayQuarterlyVersionEntries?.map((entry) => entry.name),
+	});
+
+	const {
+		properties: {
+			kpi: anualTargetKPIs,
+			lastYearProjectsUsingMarketplaceAppsCount,
+		},
+	} = useOneContext();
+
+	const {
+		kpiConnectorQuartelyRelease,
+		kpiLowCodePublishedApps,
+		kpiPartnershipIntegration,
+		kpiProjectUsingMarketplaceApps,
+		kpiQuartelyReleaseApps,
+	} = anualTargetKPIs;
+
+	return useSWR('metrics/kpi', async () => {
+		const [
+			{
+				data: {
+					metrics: {
+						appsAndConnectorSupportingQRelease,
+						lastYearAppsAndConnectorSupportingQRelease,
+						lastYearLowCodeConfigurationsPublished,
+						lastYearPartnershipIntegration,
+						lowCodeConfigurationsPublished,
+						partnershipIntegration,
+					},
+				},
+			},
+			catalogsResponse,
+			projectsKPI,
+		] = await Promise.all(queries);
+
+		const lastYearSupportingQuartelyReleaseCount = new Set(
+			(lastYearAppsAndConnectorSupportingQRelease.items ?? []).map(
+				(product) => product.catalogExternalReferenceCode
+			)
+		).size;
+
+		const lastYearLabel = `${lastYear}`;
+
+		const koroneikiReports =
+			projectsKPI?.data?.metrics?.koroneikiProjects?.items ?? [];
+
+		const projectsByKorKey: Record<
+			string,
+			{accountName: string; orders: unknown[]}
+		> = {};
+
+		for (const report of koroneikiReports) {
+			const match = report.externalReferenceCode?.match(
+				/^KORONEIKI-PROJECT-(.+)$/
+			);
+
+			if (!match) {
+				continue;
+			}
+
+			const korKey = match[1];
+
+			projectsByKorKey[korKey] = safeJSONParse<{
+				accountName: string;
+				orders: unknown[];
+			}>(report.value, {accountName: '', orders: []});
+		}
+
+		const projectsUsingMarkeplaceApps = Object.entries(projectsByKorKey);
+
+		const catalogs = Object.groupBy(
+			appsAndConnectorSupportingQRelease.items.map((product) => ({
+				...product,
+				catalogName:
+					catalogsResponse.items.find(
+						(catalog) =>
+							catalog.externalReferenceCode ===
+							product.catalogExternalReferenceCode
+					)?.name ?? product.externalReferenceCode,
+			})),
+			({catalogName}) => catalogName
+		);
+
+		const supportingQuartelyRelease = {
+			...appsAndConnectorSupportingQRelease,
+			totalCount: Object.keys(catalogs).length,
+		};
+
+		return {
+			kpis: [
+				{
+					...getAnnualTargetValues(
+						kpiProjectUsingMarketplaceApps,
+						projectsUsingMarkeplaceApps.length
+					),
+					colors: ['#9CE269', '#D4F3BE'],
+					lastYearCount: lastYearProjectsUsingMarketplaceAppsCount
+						? Number(lastYearProjectsUsingMarketplaceAppsCount)
+						: undefined,
+					lastYearLabel,
+					onClick: projectsUsingMarkeplaceApps.length
+						? () =>
+								modal.onOpenModal({
+									body: (
+										<ProjectsUsingMarketplaceModalBody
+											projectsUsingMarkeplaceApps={
+												projectsUsingMarkeplaceApps as ComponentProps<
+													typeof ProjectsUsingMarketplaceModalBody
+												>['projectsUsingMarkeplaceApps']
+											}
+										/>
+									),
+									header: 'New Projects Using Marketplace Apps',
+									size: 'lg',
+								})
+						: null,
+					title: 'New Projects Using Marketplace Apps',
+				},
+				{
+					onClick: () =>
+						navigate(
+							`/admin/publishers?filter={"customFields/AccountType":["${AccountType.TECHNOLOGY_PARTNER}"]}&filterSchema=administratorPublishers`
+						),
+					...getAnnualTargetValues(
+						kpiPartnershipIntegration,
+						partnershipIntegration.totalCount
+					),
+					colors: ['#FFB46E', '#FFE9D4'],
+					externalPage: true,
+					lastYearCount: lastYearPartnershipIntegration.totalCount,
+					lastYearLabel,
+					title: 'Technology Partnership With Integrations',
+				},
+				{
+					onClick: () =>
+						modal.onOpenModal({
+							body: (
+								<ol>
+									{Object.entries(catalogs).map(
+										([catalog, products = []], index) => (
+											<li key={index}>
+												<span className="font-weight-bold">
+													{catalog}
+												</span>
+
+												<ol>
+													{products.map(
+														(
+															{name},
+															productIndex
+														) => (
+															<li
+																key={
+																	productIndex
+																}
+															>
+																{name.en_US}
+															</li>
+														)
+													)}
+												</ol>
+											</li>
+										)
+									)}
+								</ol>
+							),
+							header: `Publisher With Apps Supporting Quarterly Release (${supportingQuartelyRelease.totalCount})`,
+						}),
+					...getAnnualTargetValues(
+						kpiQuartelyReleaseApps,
+						supportingQuartelyRelease.totalCount
+					),
+					colors: ['#4B9BFF', '#B1D4FF'],
+					lastYearCount: lastYearSupportingQuartelyReleaseCount,
+					lastYearLabel,
+					title: 'Publisher With Apps Supporting Quarterly Release',
+				},
+				{
+					...getAnnualTargetValues(
+						kpiConnectorQuartelyRelease,
+						appsAndConnectorSupportingQRelease.totalCount
+					),
+					colors: ['#FF73C3', '#FFE1F0'],
+					externalPage: true,
+					lastYearCount:
+						lastYearAppsAndConnectorSupportingQRelease.totalCount,
+					lastYearLabel,
+					onClick: () =>
+						navigate(
+							`/admin/mp-apps?filter=${liferayQuarterlyVersionsAndConnectors}&filterSchema=administratorApps`
+						),
+					title: 'Apps & Connectors Supporting Quarterly Release',
+				},
+				{
+					...getAnnualTargetValues(
+						kpiLowCodePublishedApps,
+						lowCodeConfigurationsPublished.totalCount
+					),
+					colors: ['#FFD76E', '#FFF3D4'],
+					externalPage: true,
+					lastYearCount:
+						lastYearLowCodeConfigurationsPublished.totalCount,
+					lastYearLabel,
+					onClick: () =>
+						navigate(
+							`/admin/mp-apps?filter={"specificationValues|appType":"${ProductType.LOW_CODE_CONFIGURATION}"}&filterSchema=administratorApps`
+						),
+					title: 'Low Code Configurations Published',
+				},
+			],
+			projectsKPI,
+		};
+	});
+};
+
+export default useKPI;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useOrderMetrics.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/hooks/useOrderMetrics.ts
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {addDays} from 'date-fns';
+import useSWR from 'swr';
+
+import SearchBuilder from '../../../../core/SearchBuilder';
+import {OrderWorkflowStatusCode} from '../../../../enums/Order';
+import GraphQL from '../../../../services/rest/HeadlessGraphQL';
+import {getLastDayOfMonth} from '../../../../utils/date';
+
+export const METRIC_PARAMETER = {
+	month: 30,
+	q1: 1,
+	q2: 2,
+	q3: 3,
+	q4: 4,
+	week: 7,
+};
+
+type FilterType = 'month' | 'q1' | 'q2' | 'q3' | 'q4' | 'week';
+
+const currentTime = new Date();
+
+const useOrderMetrics = (param: FilterType) => {
+	return useSWR('metrics/order', async () => {
+		const beforeLastPeriod = addDays(
+			currentTime,
+			-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER] * 2
+		);
+
+		const lastPeriod = addDays(
+			currentTime,
+			-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER]
+		);
+
+		beforeLastPeriod.setHours(0, 0, 0);
+		lastPeriod.setHours(23, 59, 59);
+
+		const [
+			{
+				orders,
+				ordersCreateBetweenLastPeriod,
+				ordersCreatedLastPeriod,
+				...metrics
+			},
+			ordersWithTotalAmount,
+		] = await Promise.all([
+			GraphQL.metrics(
+				{
+					group: 'headlessCommerceAdminOrder_v1_0',
+					name: 'orders',
+				},
+				{
+					orders: '',
+					ordersCreateBetweenLastPeriod: new SearchBuilder()
+						.lt('createDate', lastPeriod.toISOString())
+						.and()
+						.gt('createDate', beforeLastPeriod.toISOString())
+						.build(),
+					ordersCreatedLastPeriod: SearchBuilder.gt(
+						'createDate',
+						lastPeriod.toISOString()
+					),
+					ordersThisMonth: new SearchBuilder()
+						.gt(
+							'createDate',
+							new Date(
+								currentTime.getFullYear(),
+								currentTime.getMonth(),
+								1,
+								0,
+								0,
+								0
+							).toISOString()
+						)
+						.and()
+						.lt(
+							'createDate',
+							new Date(
+								currentTime.getFullYear(),
+								currentTime.getMonth(),
+								getLastDayOfMonth(
+									currentTime.getMonth(),
+									currentTime.getFullYear()
+								),
+								23,
+								59,
+								59
+							).toISOString()
+						)
+						.build(),
+					ordersThisYear: SearchBuilder.gt(
+						'createDate',
+						new Date(
+							currentTime.getFullYear(),
+							0,
+							1,
+							0,
+							0,
+							0
+						).toISOString()
+					),
+				}
+			).then(({data: {metrics}}) => ({
+				orders: metrics.orders.totalCount,
+				ordersCreateBetweenLastPeriod:
+					metrics.ordersCreateBetweenLastPeriod.totalCount,
+				ordersCreatedLastPeriod:
+					metrics.ordersCreatedLastPeriod.totalCount,
+				ordersThisMonth: metrics.ordersThisMonth.totalCount,
+				ordersThisYear: metrics.ordersThisYear.totalCount,
+			})),
+			GraphQL.metrics(
+				{
+					group: 'headlessCommerceAdminOrder_v1_0',
+					name: 'orders',
+					options: {
+						body: `items {totalAmount}`,
+						pageSize: '-1',
+					},
+				},
+				{
+					totalAmount: new SearchBuilder()
+						.gt('totalAmount', 0)
+						.and()
+						.lambda(
+							'orderStatus',
+							OrderWorkflowStatusCode.COMPLETED,
+							{
+								unquote: true,
+							}
+						)
+						.build(),
+				}
+			),
+		]);
+
+		const newOrders =
+			ordersCreatedLastPeriod - ordersCreateBetweenLastPeriod;
+
+		let growth = Number(
+			((newOrders / ordersCreatedLastPeriod) * 100).toFixed(2)
+		);
+
+		if (Number.isNaN(growth)) {
+			growth = 0;
+		}
+
+		return {
+			beforeLastPeriod: ordersCreateBetweenLastPeriod,
+			growth,
+			lastPeriod: ordersCreatedLastPeriod,
+			totalAmount: (
+				ordersWithTotalAmount.data.metrics.totalAmount.items as Order[]
+			).reduce(
+				(previousItem, currentItem) =>
+					previousItem + (currentItem.totalAmount ?? 0),
+				0
+			),
+			totalCount: orders,
+			...metrics,
+		};
+	});
+};
+
+export default useOrderMetrics;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/mp_summary.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/mp_summary.scss
@@ -1,0 +1,55 @@
+.info-container {
+	box-sizing: border-box;
+	gap: 16px;
+
+	.info-card {
+		border-radius: 10px;
+		flex: 1 0 0;
+		max-width: none;
+		transition: all ease-in-out 0.3s;
+
+		&.limited {
+			flex: 1 0 auto;
+			max-width: 274px;
+		}
+	}
+}
+
+.metrics {
+	&-container {
+		box-sizing: border-box;
+		gap: 16px;
+	}
+
+	&-card {
+		background: #fbfcfe;
+		border: 2px solid #eef3fd;
+		border-radius: 10px;
+		flex: 1 1 auto;
+		transition: all ease-in-out 0.3s;
+
+		&:hover {
+			background: #f0f5ff;
+			border: 2px solid #80acff;
+		}
+
+		&:last-child {
+			min-width: 474px;
+		}
+	}
+}
+
+.trial {
+	&-card {
+		background: #fbfcfe;
+		border: 2px solid #eef3fd;
+		border-radius: 10px;
+		flex: 1 1 auto;
+		transition: all ease-in-out 0.3s;
+
+		&:hover {
+			background: #f0f5ff;
+			border: 2px solid #80acff;
+		}
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/util.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPSummary/util.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const percentage = (total: number, partial: number): number => {
+	if (!total) {
+		return 0;
+	}
+
+	return Math.round((partial / total) * 100);
+};
+
+export {percentage};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/admin.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/admin.scss
@@ -1,0 +1,14 @@
+.app-details-page-table-icon {
+	border-radius: 4px;
+	max-height: 36px;
+	object-fit: contain;
+	width: 36px;
+}
+
+.tr-table {
+	td,
+	th {
+		padding-bottom: 0.5rem;
+		padding-top: 0.5rem;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/OAuth2Client.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/OAuth2Client.ts
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {IOAuth2ClientAgentApplication, Liferay} from '../../liferay/liferay';
+import FetcherError from '../fetcher/FetcherError';
+
+type Options<T> = RequestInit & {
+
+	/**
+	 * @description by design the OAuth2Client automatically
+	 * responds with the response.json()
+	 * when this happen we must set this property to true
+	 */
+	earlyReturn?: boolean;
+
+	parseResponse?: (response: Response) => T;
+};
+
+class OAuth2Client {
+	public oAuth2Client: IOAuth2ClientAgentApplication;
+
+	constructor(
+		protected agentName: string,
+		protected basePath: string
+	) {
+		this.oAuth2Client =
+			Liferay.OAuth2Client?.FromUserAgentApplication(agentName);
+	}
+
+	private async parseError(response: Response | Error) {
+		if (response instanceof Response && !response.ok) {
+			const error = new FetcherError(
+				'An error occurred while fetching the data.'
+			);
+
+			if (response.headers.get('Content-Length') !== '0') {
+				error.info = await response.json();
+			}
+
+			error.status = response.status;
+
+			throw error;
+		}
+
+		return response;
+	}
+
+	private fetcher = async <T = any>(
+		resource: RequestInfo,
+		options?: Options<T>
+	): Promise<T> => {
+		const response = (await this.oAuth2Client
+			.fetch(`${this.basePath + resource}`, options)
+			.catch(this.parseError.bind(this))) as Response;
+
+		if (options?.earlyReturn || !(response instanceof Response)) {
+			return response as T;
+		}
+
+		if (!response.ok) {
+			throw this.parseError(response);
+		}
+
+		if (
+			options?.method === 'DELETE' ||
+			response.status === 204 ||
+			response.headers.get('Content-Length') === '0'
+		) {
+			return {} as T;
+		}
+
+		if (options?.parseResponse) {
+			return options.parseResponse(response);
+		}
+
+		return response.json();
+	};
+
+	protected async delete(resource: RequestInfo) {
+		await this.fetcher(resource, {method: 'DELETE'});
+	}
+
+	protected get<T>(resource: RequestInfo, options?: Options<T>): Promise<T> {
+		return this.fetcher(resource, options);
+	}
+
+	protected patch<T>(
+		resource: RequestInfo,
+		data?: unknown,
+		options?: Options<T>
+	) {
+		return this.fetcher(resource, {
+			...options,
+			body: JSON.stringify(data),
+			method: 'patch',
+		});
+	}
+
+	protected put<T>(
+		resource: RequestInfo,
+		data?: unknown,
+		options?: Options<T>
+	) {
+		return this.fetcher(resource, {
+			...options,
+			body: JSON.stringify(data),
+			method: 'put',
+		});
+	}
+
+	protected post<T>(
+		resource: RequestInfo,
+		data?: FormData | unknown,
+		options?: Options<T>
+	) {
+		return this.fetcher(resource, {
+			...options,
+			body: data instanceof FormData ? data : JSON.stringify(data),
+			method: 'POST',
+		});
+	}
+}
+
+export class OneSpringBootOAuth2 extends OAuth2Client {
+	constructor(resource: string) {
+		super('liferay-one-etc-spring-boot-oaua', resource);
+	}
+}
+
+export default OAuth2Client;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/One.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/One.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import CreateFilters from '../../core/CreateFilters';
+import {
+	FilterSchemaOption,
+	filterSchema as filterSchemas,
+} from '../../schema/filters';
+import {downloadFile} from '../../utils/file';
+import {OneSpringBootOAuth2} from './OAuth2Client';
+
+class OneOAuth2 extends OneSpringBootOAuth2 {
+	async downloadOrderReport(
+		filter: {
+			[key: string]: string;
+		},
+		filterSchema?: FilterSchemaOption
+	) {
+		const searchBuilder = CreateFilters.createFilter({
+			appliedFilter: filter,
+			filterSchema: (filterSchemas as any)[filterSchema ?? ''],
+		});
+
+		const response = await this.get<Response>(
+			`/orders/export?filters=${searchBuilder}`,
+			{earlyReturn: true}
+		);
+
+		await downloadFile('orders.csv', response);
+	}
+}
+
+const oneOAuth2 = new OneOAuth2('');
+
+export default oneOAuth2;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/types.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/types.ts
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export type ConsoleProjectsUsage = {
+	userEmail: string;
+	userProjects: ConsoleUserProject[];
+};
+
+export type ConsoleUserProject = {
+	environments: {isExtensionEnvironment: boolean; projectId: string}[];
+	rootProjectId: string;
+	rootProjectPlanUsage: {
+		cpu: ConsoleCPU;
+		instance: ConsoleCPU;
+		memory: ConsoleCPU;
+	};
+};
+
+type ConsoleCPU = {
+	free: number;
+	limit: number;
+	used: number;
+};
+
+export type LicenseKey = {
+	active: boolean;
+	complimentary: boolean;
+	createDate: string;
+	description: string;
+	expirationDate: string;
+	hostName: string;
+	id: number;
+	ipAddresses: string;
+	key: string;
+	keyType: string;
+	licenseType: string;
+	macAddresses: string;
+	modifiedDate: string;
+	modifiedUserName: string;
+	modifiedUserUuid: string;
+	orderId: string;
+	owner: string;
+	productId: string;
+	productName: string;
+	productVersion: string;
+	startDate: string;
+	userName: string;
+	userUuid: string;
+};
+
+export type LicenseTypePayload = {
+	licenseEntry: {
+		description: string;
+		hostName: string | undefined;
+		ipAddresses: string | undefined;
+		macAddresses: string | undefined;
+		orderId: string;
+		productId?: string;
+		productPurchaseKey: string;
+		productVersion: string;
+	};
+	skuId: number;
+	type: string;
+};
+
+export type SubscriptionsType = {
+	endDate?: string;
+	name: string;
+	perpetual: boolean;
+	productPurchasedKey: string;
+	productVersion: string;
+	provisionedCount: number;
+	purchasedCount: number;
+	startDate: string;
+};
+
+export type Product = {
+	dateCreated: string;
+	dateModified: string;
+	externalLinks: ExternalLink[];
+	key: string;
+	name: string;
+	properties: Properties;
+};
+
+export type ProductPurchase = {
+	accountKey: string;
+	dateCreated: string;
+	endDate: string;
+	externalLinks: any[];
+	key: string;
+	originalEndDate: string;
+	perpetual: boolean;
+	product: Product;
+	productConsumptions: any;
+	productKey: string;
+	properties: Properties2;
+	quantity: number;
+	startDate: string;
+	status: string;
+	statusAsString: string;
+};
+
+export type ExternalLink = {
+	dateCreated: string;
+	domain: string;
+	entityId: string;
+	entityName: string;
+	key: string;
+	url: string;
+};
+
+export type Properties = {
+	'display-group-name': string;
+	'display-name': string;
+	'type': string;
+};
+
+export type Properties2 = {
+	licenses: string;
+	sizing: string;
+	version: string;
+};
+
+export type Entitlement = {
+	entitlementDefinitionKey: string;
+	name: string;
+};
+
+export type PostalAddress = {
+	addressCountry: string;
+	addressLocality: string;
+	addressRegion: string;
+	addressType: string;
+	id: number;
+	mailing: boolean;
+	postalCode: string;
+	primary: boolean;
+	streetAddressLine1: string;
+	streetAddressLine2: string;
+	streetAddressLine3: string;
+};
+
+export type AccountProperties = {
+	allowComplimentary: string;
+	allowPermanentLicenses: string;
+	allowSelfProvisioning: string;
+};


### PR DESCRIPTION
Migrates the Marketplace Summary page from the marketplace workspace. Stacked on \`LPD-88257-listview\`.

Includes the 5 KPI donut charts, 3 InfoCards (Accounts/Income/Orders), Recent Orders and Published Apps embedded tables, and the Most Purchased sections.

Note: the two shared list-views (\`AdministratorOrdersListView\`, \`AdministratorAppsListView\`) live under \`MPSummary/components/\` because the Summary embeds both. The standalone Orders/Apps pages (later PRs) import from here.