### PR TITLE
LPD-91704 Migrate Marketplace Apps page

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Apps/Apps.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Apps/Apps.tsx
@@ -3,10 +3,71 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useProperties} from '../../../context/PropertiesContext';
+import {useSearchParams} from 'react-router-dom';
+
+import Page from '../../../components/Page';
+import i18n from '../../../i18n';
+import InfoCard from '../MPSummary/components/InfoCard';
+import useAppsMetrics from './hooks/useAppsMetrics';
+import {percentage} from '../MPSummary/util';
+import AdministratorAppsListView from '../MPSummary/components/AdministratorAppsListView';
 
 export default function Apps() {
-	const {accountId} = useProperties();
+	const [searchParams] = useSearchParams();
 
-	return <div>{accountId}</div>;
+	const {
+		approved = 0,
+		approvedBeforeLastWeek = 0,
+		approvedLastWeek = 0,
+		inReview = 0,
+		inReviewBeforeLastWeek = 0,
+		inReviewLastWeek = 0,
+		products = 0,
+	} = useAppsMetrics('week');
+
+	return (
+		<>
+			<div
+				className="d-flex flex-wrap info-container"
+				style={{marginBottom: '1rem'}}
+			>
+				<InfoCard
+					className="mr-3"
+					growth={percentage(
+						products,
+						inReviewLastWeek - inReviewBeforeLastWeek
+					)}
+					growthContext={`+${inReviewLastWeek - inReviewBeforeLastWeek} this week`}
+					symbol="squares-clock"
+					title={i18n.translate('app-awaiting-review')}
+					value={inReview}
+				/>
+
+				<InfoCard
+					growth={percentage(
+						products,
+						approvedLastWeek - approvedBeforeLastWeek
+					)}
+					growthContext={`+${approvedLastWeek - approvedBeforeLastWeek} this week`}
+					symbol="squares"
+					title={i18n.translate('recently-published')}
+					value={approved}
+				/>
+			</div>
+
+			<Page
+				pageRendererProps={{className: 'border py-2 rounded-lg'}}
+				title={i18n.translate('apps')}
+			>
+				<AdministratorAppsListView
+					filter={searchParams.get('filter') as string}
+					isSortable
+					managementToolbarProps={{
+						searchVisible: true,
+						visible: true,
+					}}
+				/>
+			</Page>
+		</>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Apps/hooks/useAppsMetrics.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Apps/hooks/useAppsMetrics.ts
@@ -1,0 +1,113 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {addDays} from 'date-fns';
+import useSWR from 'swr';
+
+import SearchBuilder from '../../../../core/SearchBuilder';
+import {ProductWorkflowStatusCode} from '../../../../enums/Product';
+import HeadlessCommerceAdminCatalog from '../../../../services/rest/HeadlessCommerceAdminCatalog';
+
+type FilterType = 'month' | 'q1' | 'q2' | 'q3' | 'q4' | 'week';
+
+export const METRIC_PARAMETER = {
+	month: 30,
+	q1: 1,
+	q2: 2,
+	q3: 3,
+	q4: 4,
+	week: 7,
+};
+
+const approved = new SearchBuilder()
+	.in('statusCode', [ProductWorkflowStatusCode.APPROVED])
+	.build();
+
+const inReview = new SearchBuilder()
+	.in('statusCode', [
+		ProductWorkflowStatusCode.PENDING,
+		ProductWorkflowStatusCode.DRAFT,
+	])
+	.build();
+
+const currentTime = new Date();
+
+const useAppsMetricks = (param: FilterType = 'week') => {
+	const beforeLastPeriod = addDays(
+		currentTime,
+		-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER] * 2
+	);
+
+	const lastPeriod = addDays(
+		currentTime,
+		-METRIC_PARAMETER[param as keyof typeof METRIC_PARAMETER]
+	);
+
+	beforeLastPeriod.setHours(0, 0, 0);
+	lastPeriod.setHours(23, 59, 59);
+
+	const approvedBeforeLastWeek = new SearchBuilder()
+		.in('statusCode', [ProductWorkflowStatusCode.APPROVED])
+		.and()
+		.lt('createDate', lastPeriod.toISOString())
+		.and()
+		.gt('createDate', beforeLastPeriod.toISOString())
+		.build();
+
+	const approvedLastWeek = new SearchBuilder()
+		.in('statusCode', [ProductWorkflowStatusCode.APPROVED])
+		.and()
+		.gt('createDate', lastPeriod.toISOString())
+		.build();
+
+	const inReviewBeforeLastWeek = new SearchBuilder()
+		.in('statusCode', [
+			ProductWorkflowStatusCode.DRAFT,
+			ProductWorkflowStatusCode.PENDING,
+		])
+		.and()
+		.lt('createDate', lastPeriod.toISOString())
+		.and()
+		.gt('createDate', beforeLastPeriod.toISOString())
+		.build();
+
+	const inReviewLastWeek = new SearchBuilder()
+		.in('statusCode', [
+			ProductWorkflowStatusCode.DRAFT,
+			ProductWorkflowStatusCode.PENDING,
+		])
+		.and()
+		.gt('createDate', lastPeriod.toISOString())
+		.build();
+
+	const {data, ...swr} = useSWR('administrator/apps-kpis', () =>
+		HeadlessCommerceAdminCatalog.getProductsDashboardKPI({
+			approved,
+			approvedBeforeLastWeek,
+			approvedLastWeek,
+			inReview,
+			inReviewBeforeLastWeek,
+			inReviewLastWeek,
+			products: '',
+		}).then(({data: {metrics}}) => ({
+			approved: metrics?.approved?.totalCount || 0,
+			approvedBeforeLastWeek:
+				metrics?.approvedBeforeLastWeek?.totalCount || 0,
+			approvedLastWeek: metrics?.approvedLastWeek?.totalCount || 0,
+			inReview: metrics?.inReview?.totalCount || 0,
+			inReviewBeforeLastWeek:
+				metrics?.inReviewBeforeLastWeek?.totalCount || 0,
+			inReviewLastWeek: metrics?.inReviewLastWeek?.totalCount || 0,
+			products: metrics?.products?.totalCount || 0,
+		}))
+	);
+
+	return {
+		...swr,
+		...data,
+	};
+};
+
+export default useAppsMetricks;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -6,7 +6,11 @@
 import {Params} from 'react-router-dom';
 
 import SearchBuilder, {Operators} from '../core/SearchBuilder';
+import {MarketplaceCategory} from '../enums/Categories';
+import {ProductType, ProductWorkflowStatusCode} from '../enums/Product';
 import i18n from '../i18n';
+
+const LIFERAY_VERSION_PICKLIST = 'LIFERAY-VERSIONS';
 
 type AutoCompleteProps = {
 	label?: string;
@@ -108,6 +112,125 @@ export const overrides = (
 	...newObject,
 });
 
-export const filterSchema: FilterSchemas = {};
+export const filterSchema: FilterSchemas = {
+	administratorApps: {
+		fields: [
+			overrides(baseFilters.type, {
+				label: i18n.translate('app-type'),
+				name: 'specificationValues|appType',
+				operator: 'lambda',
+				options: [
+					{
+						label: i18n.translate('client-extension'),
+						value: ProductType.CLIENT_EXTENSION,
+					},
+					{
+						label: i18n.translate('cloud-app'),
+						value: ProductType.CLOUD,
+					},
+					{
+						label: i18n.translate('composite-app'),
+						value: ProductType.COMPOSITE_APP,
+					},
+					{
+						label: i18n.translate('dxp-app'),
+						value: ProductType.DXP,
+					},
+					{
+						label: i18n.translate('low-code-configuration'),
+						value: ProductType.LOW_CODE_CONFIGURATION,
+					},
+					{
+						label: i18n.translate('other'),
+						value: ProductType.OTHER,
+					},
+				],
+				type: 'checkbox',
+			}),
+			overrides(baseFilters.categories, {
+				options: [
+					{
+						label: i18n.translate('batch'),
+						value: `${MarketplaceCategory.BATCH}`,
+					},
+					{
+						label: i18n.translate('checkout'),
+						value: `${MarketplaceCategory.CHECKOUT}`,
+					},
+					{
+						label: i18n.translate('fragment'),
+						value: `${MarketplaceCategory.FRAGMENTS}`,
+					},
+					{
+						label: i18n.translate('object-action'),
+						value: `${MarketplaceCategory.OBJECT_ACTION}`,
+					},
+					{
+						label: i18n.translate('other'),
+						value: `${MarketplaceCategory.OTHER}`,
+					},
+					{
+						label: i18n.translate('payment-method'),
+						value: `${MarketplaceCategory.PAYMENT_METHODS}`,
+					},
+					{
+						label: i18n.translate('prompt'),
+						value: `${MarketplaceCategory.PROMPT}`,
+					},
+					{
+						label: i18n.translate('site-initializer'),
+						value: `${MarketplaceCategory.SITE_INITIALIZER}`,
+					},
+					{
+						label: i18n.translate('theme'),
+						value: `${MarketplaceCategory.THEME}`,
+					},
+					{
+						label: i18n.translate('workflow-action'),
+						value: `${MarketplaceCategory.WORKFLOW_ACTION}`,
+					},
+				],
+				type: 'select',
+			}),
+			baseFilters.dateCreated,
+			overrides(baseFilters.version, {
+				label: i18n.translate('liferay-version'),
+				name: 'specificationValues|liferayVersion',
+				operator: 'lambda',
+				resource: `o/headless-admin-list-type/v1.0/list-type-definitions/by-external-reference-code/${LIFERAY_VERSION_PICKLIST}`,
+				transformData: (item) =>
+					item.listTypeEntries.map((entry: any) => ({
+						label: entry.name,
+						value: entry.name,
+					})),
+				type: 'multiselect',
+			}),
+			overrides(baseFilters.dateCreated, {
+				label: i18n.translate('modified-date'),
+				name: 'modifiedDate',
+			}),
+			overrides(baseFilters.status, {
+				name: 'statusCode',
+				options: [
+					{
+						label: i18n.translate('approved'),
+						value: `${ProductWorkflowStatusCode.APPROVED}`,
+					},
+					{
+						label: i18n.translate('draft'),
+						value: `${ProductWorkflowStatusCode.DRAFT}`,
+					},
+					{
+						label: i18n.translate('pending'),
+						value: `${ProductWorkflowStatusCode.PENDING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'select',
+			}),
+		],
+		name: 'administratorApps',
+	},
+};
 
 export type FilterSchemaOption = keyof typeof filterSchema;


### PR DESCRIPTION
Migrates the Marketplace Apps page from the marketplace workspace. Stacked on \`LPD-91578\`.

Adds the Apps standalone page (2 InfoCards: awaiting review, recently published), the \`useAppsMetrics\` hook, and the \`administratorApps\` filter schema.