### PR TITLE
LPD-88257 Add Admin services, context, providers and hooks

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/context/OneContext.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/context/OneContext.tsx
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ReactNode, createContext, useContext} from 'react';
+import useSWR, {KeyedMutator} from 'swr';
+
+import {MarketplaceUserAccount} from '../entity/MarketplaceUserAccount';
+import {Liferay} from '../liferay/liferay';
+import HeadlessAdminUser from '../services/rest/HeadlessAdminUser';
+import {Properties} from '../utils/attributes';
+
+type Context = {
+	channel: Channel;
+	marketplaceUserAccount: MarketplaceUserAccount;
+	mutateMyUserAccount: KeyedMutator<UserAccount | undefined>;
+	myUserAccount: UserAccount;
+	properties: Properties;
+};
+
+type OneContextProviderProps = {
+	children: ReactNode;
+	properties: Properties;
+};
+
+const channel = {
+	channelId: Number(Liferay.CommerceContext?.commerceChannelId),
+	currencyCode: Liferay.CommerceContext?.currency?.currencyCode,
+	externalReferenceCode: 'MARKETPLACE',
+	id: Number(Liferay.CommerceContext?.commerceChannelId),
+} as Channel;
+
+const OneContext = createContext<Context>({} as Context);
+
+const OneContextProvider: React.FC<OneContextProviderProps> = ({
+	children,
+	properties,
+}) => {
+	const {data: myUserAccount, mutate} = useSWR(
+		Liferay.ThemeDisplay.isSignedIn() ? '/one/my-user-account' : null,
+		HeadlessAdminUser.getMyUserAccount
+	);
+
+	return (
+		<OneContext.Provider
+			value={
+				{
+					channel,
+					marketplaceUserAccount: new MarketplaceUserAccount(
+						myUserAccount as UserAccount
+					),
+					mutateMyUserAccount: mutate as KeyedMutator<UserAccount>,
+					myUserAccount,
+					properties,
+				} as Context
+			}
+		>
+			{children}
+		</OneContext.Provider>
+	);
+};
+
+const useOneContext = () => {
+	return useContext(OneContext);
+};
+
+export {OneContext, useOneContext};
+
+export default OneContextProvider;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/core/CreateFilters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/core/CreateFilters.ts
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {FilterVariables, RendererFields} from '../schema/filters';
+import SearchBuilder from './SearchBuilder';
+
+type Filter = {
+	[key: string]: string | number | string[] | number[];
+};
+
+type Value = string | number | boolean | null;
+
+export default class CreateFilters {
+	static createFilter({
+		appliedFilter,
+		defaultFilter,
+		filterSchema,
+	}: FilterVariables) {
+		const _filter = defaultFilter ? [defaultFilter] : [];
+
+		for (const key in appliedFilter) {
+			let searchCondition = '';
+			const rawValue = appliedFilter[key];
+
+			if (!rawValue) {
+				continue;
+			}
+
+			const schema = filterSchema.fields.find(
+				({name}) => key === name
+			) as RendererFields;
+
+			const normalizeValue = (val: any) =>
+				typeof val === 'object' && val !== null ? val.value : val;
+
+			let value: any;
+			if (Array.isArray(rawValue)) {
+				value = rawValue.map(normalizeValue);
+			}
+			else {
+				value = normalizeValue(rawValue);
+			}
+
+			const isFilterChanged =
+				typeof value === 'string' &&
+				(value.includes('false') || value.includes('No'));
+
+			const removeQuoteMark =
+				schema?.removeQuoteMark ||
+				schema?.type === 'number' ||
+				isFilterChanged;
+
+			const customOperator = schema?.operator;
+
+			if (customOperator && SearchBuilder[customOperator]) {
+				const [filterKey] = key.split('|');
+				const formattedKey = filterKey.replace('$', '');
+
+				if (
+					customOperator === 'lambda' ||
+					customOperator === 'lambdaContains'
+				) {
+					const builderFn =
+						customOperator === 'lambda'
+							? SearchBuilder.lambda
+							: SearchBuilder.lambdaContains;
+
+					searchCondition = Array.isArray(value)
+						? `(${value
+								.map((filter) => builderFn(filterKey, filter))
+								.join(' or ')})`
+						: builderFn(filterKey, value);
+				}
+				else {
+					const getOptionalSearchCondition = () => {
+						if (schema?.optionalOperator === 'ne') {
+							if (isFilterChanged) {
+								return `not (${SearchBuilder[
+									schema.optionalOperator
+								](formattedKey, null)})`;
+							}
+
+							if (
+								typeof value === 'string' &&
+								value.includes('true')
+							) {
+								return SearchBuilder[schema.optionalOperator](
+									formattedKey,
+									null
+								);
+							}
+						}
+
+						return SearchBuilder[customOperator](
+							formattedKey,
+							value
+						);
+					};
+
+					searchCondition = getOptionalSearchCondition();
+				}
+			}
+			else {
+				if (schema?.type === 'date-range' && Array.isArray(value)) {
+					const [start, end] = (value as string[])[0].split(' - ');
+
+					searchCondition = new SearchBuilder()
+						.gt(key, `${start}T00:00:00Z`)
+						.and()
+						.lt(key, `${end}T23:59:59Z`)
+						.build();
+				}
+				else {
+					if (Array.isArray(value)) {
+						searchCondition = SearchBuilder.in(key, value);
+					}
+					else {
+						searchCondition = SearchBuilder.eq(key, value);
+					}
+				}
+			}
+
+			_filter.push(
+				removeQuoteMark
+					? searchCondition.replaceAll(`'`, '')
+					: searchCondition
+			);
+		}
+
+		return _filter.join(' and ');
+	}
+
+	static formatValuesToString(values: Value[]) {
+		if (values) {
+			return values
+				.map((value) => `${value}`)
+				.join(',')
+				.trim();
+		}
+
+		return '';
+	}
+
+	static removeEmptyFilter(filter: Filter) {
+		const cleanedFilter: Filter = {};
+
+		for (const key in filter) {
+			const value = filter[key];
+
+			if (value === null) {
+				continue;
+			}
+
+			if (typeof value === 'string' && value.trim() === '') {
+				continue;
+			}
+
+			if (
+				Array.isArray(value) &&
+				value.some(
+					(item: any) =>
+						typeof item === 'object' && item?.value === ''
+				)
+			) {
+				continue;
+			}
+
+			cleanedFilter[key] = value;
+		}
+
+		return cleanedFilter;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceUserAccount.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceUserAccount.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AccountRoleType} from '../enums/Account';
+import {Liferay} from '../liferay/liferay';
+
+export class MarketplaceUserAccount {
+	constructor(protected userAccount: UserAccount) {}
+
+	get accountBriefs() {
+		return this.userAccount?.accountBriefs ?? [];
+	}
+
+	get accountName() {
+		return this.userAccount.name;
+	}
+
+	get accountType() {
+		return this.userAccount.type;
+	}
+
+	get isAdmin() {
+		return this.hasRegularRole(AccountRoleType.ADMINISTRATOR);
+	}
+
+	get isSolutionPublisher() {
+		return this.hasAccountRole(AccountRoleType.SOLUTION_PUBLISHER);
+	}
+
+	get isSSAAdmin() {
+		return this.hasAccountRole(AccountRoleType.SSA_ADMIN) || this.isAdmin;
+	}
+
+	get isSSAUser() {
+		return this.hasAccountRole(AccountRoleType.SSA_USER);
+	}
+
+	private hasAccountRole(roleName: AccountRoleType) {
+		return this.accountBriefs.some(
+			(accountBrief) =>
+				accountBrief.id ===
+					Liferay.CommerceContext.account?.accountId &&
+				accountBrief.roleBriefs.some(
+					(roleBrief) => roleBrief.name === roleName
+				)
+		);
+	}
+
+	private hasRegularRole(roleName: AccountRoleType) {
+		return this.userAccount?.roleBriefs.some(
+			(role) => role?.name === roleName
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useFetch.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useFetch.ts
@@ -1,0 +1,92 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+type APIParametersOptions = {
+	aggregationTerms?: string;
+	customParams?: {[key: string]: unknown};
+	fields?: string;
+	filter?: string;
+	nestedFields?: string;
+	nestedFieldsDepth?: number | string;
+	page?: number | string;
+	pageSize?: number | string;
+	sort?: string;
+};
+
+function getPageParameter(
+	parameters: APIParametersOptions = {},
+	baseURL?: string
+) {
+	const getBaseSearchParams = (resource?: string) => {
+		if (resource && resource.includes('?')) {
+			return resource.slice(resource.indexOf('?'));
+		}
+	};
+
+	const searchParams = new URLSearchParams(getBaseSearchParams(baseURL));
+
+	if (parameters.customParams) {
+		parameters = {
+			...parameters,
+			...parameters.customParams,
+		};
+
+		delete parameters.customParams;
+	}
+
+	for (const key in parameters) {
+		const value = (parameters as any)[key] as string | number | undefined;
+
+		if (value) {
+			searchParams.set(key, value.toString());
+		}
+	}
+
+	return searchParams.toString();
+}
+
+const getBaseURL = (url: string | null, options?: APIParametersOptions) => {
+	if (!url) {
+		return null;
+	}
+
+	const searchParams = getPageParameter(options, url);
+
+	let baseURL = url;
+
+	if (url.includes('?')) {
+		baseURL = url.slice(0, url.indexOf('?'));
+	}
+
+	if (searchParams.length) {
+		baseURL += `?${searchParams}`;
+	}
+
+	return baseURL;
+};
+
+export function useFetch<Data = any, Error = any>(
+	url: string | null,
+	fetchParameters?: Record<string, any>,
+	refreshInterval?: number
+) {
+	const {params} = fetchParameters ?? {};
+
+	const {data, error, isLoading, isValidating, mutate} = useSWR<Data, Error>(
+		getBaseURL(url, params),
+		{refreshInterval}
+	);
+
+	return {
+		data,
+		error,
+		isValidating,
+		loading: isLoading,
+		mutate,
+		revalidate: () => mutate((response) => response, {revalidate: true}),
+	};
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useListTypeDefinition.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useListTypeDefinition.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+import fetcher from '../services/fetcher';
+
+const useListTypeDefinition = (externalReferenceCode: string | null) => {
+	return useSWR(
+		externalReferenceCode
+			? `/list-type-definition/${externalReferenceCode}`
+			: null,
+		() =>
+			fetcher<ListTypeDefinition>(
+				`o/headless-admin-list-type/v1.0/list-type-definitions/by-external-reference-code/${externalReferenceCode}`
+			)
+	);
+};
+
+export default useListTypeDefinition;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useModalContext.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useModalContext.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Context} from '@clayui/modal';
+import {Size} from '@clayui/modal/lib/types';
+import {ReactElement, useContext} from 'react';
+
+export type ModalOptions = {
+	body: string | ReactElement;
+	center?: boolean;
+	footer?: (any | ReactElement)[];
+	header?: string | ReactElement;
+	size?: Size | 'md';
+	status?: 'danger' | 'info' | 'success' | 'warning';
+};
+
+const useModalContext = () => {
+	const [state, dispatch] = useContext(Context);
+
+	return {
+		onClose: state.onClose,
+		onOpenModal: ({center = true, ...payload}: ModalOptions) => {
+			dispatch({
+				payload: {
+					...payload,
+					center,
+					size: payload.size as Size,
+				},
+				type: 1,
+			});
+		},
+		state,
+	};
+};
+
+export default useModalContext;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useStorage.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useStorage.ts
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useCallback, useMemo, useState} from 'react';
+
+import MarketplaceStorage, {
+	CONSENT_TYPE,
+	STORAGE_KEYS,
+	StorageType,
+} from '../core/Storage';
+
+type UseStorage<T> = [T, (value: T) => void];
+
+const marketplaceStorage = MarketplaceStorage.getInstance();
+
+type UseStorageOptions<T> = {
+	consentType?: CONSENT_TYPE;
+	initialValue?: T;
+	storageType: StorageType;
+};
+
+const useStorage = <T = string>(
+	key: STORAGE_KEYS,
+	{consentType, initialValue, storageType}: UseStorageOptions<T> = {
+		storageType: 'persisted',
+	}
+): UseStorage<T> => {
+	const storage = useMemo(
+		() => marketplaceStorage.getStorage(storageType),
+		[storageType]
+	);
+
+	const [storedValue, setStoredValue] = useState(() => {
+		let storageValue;
+
+		try {
+			storageValue = storage.getItem(key, consentType);
+
+			return storageValue ? JSON.parse(storageValue) : initialValue;
+		}
+		catch (error) {
+			console.error(error);
+
+			return storageValue || initialValue;
+		}
+	});
+
+	const setStorageValue = useCallback(
+		(value: T) => {
+			try {
+				setStoredValue(value);
+
+				storage.setItem(key, JSON.stringify(value), consentType);
+			}
+			catch (error) {
+				console.error(error);
+			}
+		},
+		[key, consentType, storage]
+	);
+
+	return [storedValue, setStorageValue];
+};
+
+export default useStorage;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/main.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/main.tsx
@@ -4,12 +4,17 @@
  */
 
 import {ClayIconSpriteContext} from '@clayui/icon';
+import {ClayModalProvider} from '@clayui/modal';
 import React, {Suspense} from 'react';
 import {Root, createRoot} from 'react-dom/client';
+import {SWRConfig} from 'swr';
 
 import ErrorBoundary from './components/ErrorBoundary';
+import OneContextProvider from './context/OneContext';
 import {PropertiesProvider} from './context/PropertiesContext';
 import {getIconSpriteMap} from './liferay/constants';
+import SWRCacheProvider from './services/SWRCacheProvider';
+import fetcher from './services/fetcher';
 import {baseAttributes, getAttributes} from './utils/attributes';
 
 type RouterComponent = React.ComponentType;
@@ -31,14 +36,29 @@ class WebComponent extends HTMLElement {
 			return;
 		}
 
+		const properties = getAttributes(this);
+
 		this.root.render(
 			<ErrorBoundary>
 				<ClayIconSpriteContext.Provider value={getIconSpriteMap()}>
-					<PropertiesProvider value={getAttributes(this)}>
-						<Suspense fallback={null}>
-							<Router />
-						</Suspense>
-					</PropertiesProvider>
+					<SWRConfig
+						value={{
+							fetcher,
+							provider: SWRCacheProvider,
+							revalidateIfStale: true,
+							revalidateOnFocus: false,
+						}}
+					>
+						<PropertiesProvider value={properties}>
+							<OneContextProvider properties={properties}>
+								<ClayModalProvider>
+									<Suspense fallback={null}>
+										<Router />
+									</Suspense>
+								</ClayModalProvider>
+							</OneContextProvider>
+						</PropertiesProvider>
+					</SWRConfig>
 				</ClayIconSpriteContext.Provider>
 			</ErrorBoundary>
 		);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Params} from 'react-router-dom';
+
+import SearchBuilder, {Operators} from '../core/SearchBuilder';
+import i18n from '../i18n';
+
+type AutoCompleteProps = {
+	label?: string;
+	onSearch: (keyword: string) => any;
+	resource?: string | ((params: Readonly<Params<string>>) => string);
+	transformData?: (item: any) => any;
+};
+
+export type AppliedFilters = {
+	label: string;
+	value: string;
+};
+
+export type RenderedFieldOptions = string[] | AppliedFilters[];
+
+export type RendererFields = {
+	disabled?: boolean;
+	label: string;
+	name: string;
+	operator?: Operators;
+	optionalOperator?: Operators;
+	options?: RenderedFieldOptions;
+	placeholder?: string;
+	removeQuoteMark?: boolean;
+	requestOperator?: string;
+	type:
+		| 'autocomplete'
+		| 'checkbox'
+		| 'date'
+		| 'date-range'
+		| 'multiselect'
+		| 'number'
+		| 'select'
+		| 'text'
+		| 'textarea';
+} & Partial<AutoCompleteProps>;
+
+export type Filters = {
+	[key: string]: RendererFields[];
+};
+
+export type Filter = {
+	[key: string]: RendererFields;
+};
+
+export type FilterVariables = {
+	appliedFilter?: {
+		[key: string]: string | AppliedFilters;
+	};
+	defaultFilter?: string | SearchBuilder;
+	filterSchema: FilterSchema;
+};
+
+export type FilterSchema = {
+	fields: RendererFields[];
+	name?: string;
+	onApply?: (filterVariables: FilterVariables) => string;
+	placeholder?: string;
+};
+
+export type FilterSchemas = {
+	[key: string]: FilterSchema;
+};
+
+export const baseFilters: Filter = {
+	categories: {
+		label: i18n.translate('category'),
+		name: 'categoryNames',
+		operator: 'lambda',
+		type: 'select',
+	},
+	dateCreated: {
+		label: i18n.translate('date-created'),
+		name: 'createDate',
+		type: 'date-range',
+	},
+	status: {
+		label: i18n.translate('status'),
+		name: 'status',
+		type: 'select',
+	},
+	type: {
+		label: i18n.translate('type'),
+		name: 'type',
+		type: 'select',
+	},
+	version: {
+		label: i18n.translate('version'),
+		name: 'version',
+		type: 'select',
+	},
+};
+
+export function overrides(
+	object: RendererFields,
+	newObject: Partial<RendererFields>
+): RendererFields {
+	return {
+		...object,
+		...newObject,
+	};
+}
+
+export const filterSchema: FilterSchemas = {};
+
+export type FilterSchemaOption = keyof typeof filterSchema;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/SWRCacheProvider.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/SWRCacheProvider.ts
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const STORAGE_KEY = '@liferay-one/swr';
+
+/**
+ * @description When initializing, we restore the data from `STORAGE` into a map.
+ * Before unloading the app, we write back all the data into `STORAGE`.
+ * We still use the map for write & read for performance.
+ */
+
+const SWRCacheProvider = (): Map<any, any> => {
+	const cacheMap = new Map(
+		JSON.parse(sessionStorage.getItem(STORAGE_KEY) || '[]')
+	);
+
+	window.addEventListener('beforeunload', () => {
+		const appCache = JSON.stringify(Array.from(cacheMap.entries()));
+
+		sessionStorage.setItem(STORAGE_KEY, appCache);
+	});
+
+	return cacheMap;
+};
+
+export default SWRCacheProvider;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/fetcher/FetcherError.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/fetcher/FetcherError.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+class FetcherError extends Error {
+	public info: any;
+	public status?: number;
+
+	constructor(message: string) {
+		super(message);
+	}
+}
+
+export default FetcherError;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/fetcher/index.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/fetcher/index.ts
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Liferay} from '../../liferay/liferay';
+import FetcherError from './FetcherError';
+
+const liferayHost = window.location.origin;
+
+function changeResource(resource: RequestInfo) {
+	if (resource.toString().startsWith('http')) {
+		return resource;
+	}
+
+	return `${liferayHost}/${resource}`;
+}
+
+function getHeaders(options?: RequestInit): Record<string, string> {
+	const defaultHeaders = options?.headers;
+
+	const normalizedHeaders = defaultHeaders
+		? defaultHeaders instanceof Headers || Array.isArray(defaultHeaders)
+			? Object.fromEntries(defaultHeaders as any)
+			: (defaultHeaders as Record<string, string>)
+		: {};
+
+	const hasContentType = Object.keys(normalizedHeaders).some(
+		(name) => name.toLowerCase() === 'content-type'
+	);
+
+	const isFormData = options?.body instanceof FormData;
+
+	const headers: Record<string, string> = {
+		'x-csrf-token': Liferay.authToken,
+		...normalizedHeaders,
+	};
+
+	if (!hasContentType && !isFormData) {
+		headers['Content-Type'] = 'application/json';
+	}
+
+	return headers;
+}
+
+const fetcher = async <T = any>(
+	resource: RequestInfo,
+	options?: RequestInit
+): Promise<T> => {
+	const headers = getHeaders(options);
+
+	const response = await fetch(changeResource(resource), {
+		...options,
+		headers,
+	});
+
+	if (!response.ok) {
+		const error = new FetcherError(
+			'An error occurred while fetching the data.'
+		);
+
+		error.info = await response.json();
+		error.status = response.status;
+		throw error;
+	}
+
+	if (
+		options?.method === 'DELETE' ||
+		response.status === 204 ||
+		response.headers.get('Content-Length') === '0'
+	) {
+		return {} as T;
+	}
+
+	return response.json();
+};
+
+fetcher.delete = (resource: RequestInfo) =>
+	fetcher(resource, {
+		method: 'DELETE',
+	});
+
+fetcher.patch = <T = any>(
+	resource: RequestInfo,
+	data: unknown,
+	options?: RequestInit
+) =>
+	fetcher<T>(resource, {
+		...options,
+		body: JSON.stringify(data),
+		method: 'PATCH',
+	});
+
+fetcher.post = <T = any>(
+	resource: RequestInfo,
+	data?: unknown,
+	options?: RequestInit & {shouldStringify?: boolean}
+): Promise<T> => {
+	const shouldStringify = options?.shouldStringify ?? true;
+
+	let body: BodyInit | null = null;
+
+	if (data instanceof FormData) {
+		body = data;
+	}
+	else if (data !== null) {
+		body = shouldStringify ? JSON.stringify(data) : (data as BodyInit);
+	}
+
+	return fetcher<T>(resource, {
+		...options,
+		body,
+		method: 'POST',
+	});
+};
+
+fetcher.put = (resource: RequestInfo, data: unknown, options?: RequestInit) =>
+	fetcher(resource, {
+		...options,
+		body: JSON.stringify(data),
+		method: 'PUT',
+	});
+
+export default fetcher;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessAdminUser.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessAdminUser.ts
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+export default class HeadlessAdminUser {
+	static async deleteAccountUserAccountByEmailAddress(
+		accountExternalReferenceCode: string,
+		emailAddress: string
+	) {
+		return fetcher.delete(
+			`/o/headless-admin-user/v1.0/accounts/by-external-reference-code/${accountExternalReferenceCode}/user-accounts/by-email-address/${emailAddress}`
+		);
+	}
+
+	static async deleteRoleAccountUser(
+		accountId: number | string,
+		roleId: number,
+		userId: number
+	) {
+		return fetcher.delete(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}/account-roles/${roleId}/user-accounts/${userId}`
+		);
+	}
+
+	static async getAccount(accountId: string | number) {
+		return fetcher<Account>(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}`
+		);
+	}
+
+	static async getAccountByExternalReferenceCode(
+		externalReferenceCode: string
+	) {
+		return fetcher<Account>(
+			`/o/headless-admin-user/v1.0/accounts/by-external-reference-code/${externalReferenceCode}`
+		);
+	}
+
+	static async getAccountPostalAddresses(accountId: string | number) {
+		return fetcher<APIResponse<AccountPostalAddresses>>(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}/postal-addresses`
+		);
+	}
+
+	static async getAccountRoles(accountExternalReferenceCode: string) {
+		return fetcher<APIResponse<AccountRole>>(
+			`/o/headless-admin-user/v1.0/accounts/by-external-reference-code/${accountExternalReferenceCode}/account-roles`
+		);
+	}
+
+	static async getAccounts(searchParams = new URLSearchParams()) {
+		return fetcher<APIResponse<Account>>(
+			`/o/headless-admin-user/v1.0/accounts?${searchParams.toString()}`
+		);
+	}
+
+	static async getMyUserAccount() {
+		return fetcher<UserAccount>(
+			'/o/headless-admin-user/v1.0/my-user-account'
+		);
+	}
+
+	static async getRolesPage(searchParams = new URLSearchParams()) {
+		return fetcher<APIResponse<RoleBrief>>(
+			`/o/headless-admin-user/v1.0/roles?${searchParams}`
+		);
+	}
+
+	static async getUserAccountById(accountId: string | number) {
+		return fetcher<UserAccount>(
+			`/o/headless-admin-user/v1.0/user-accounts/${accountId}`
+		);
+	}
+
+	static async getUserEmailAddress(emailAddress: string) {
+		return fetcher<UserAccount>(
+			`/o/headless-admin-user/v1.0/user-accounts/by-email-address/${emailAddress}`
+		);
+	}
+
+	static async getUserAccounts() {
+		return fetcher(`/o/headless-admin-user/v1.0/user-accounts`);
+	}
+
+	static async getUserAccountsByAccountId(accountId: string | number) {
+		return fetcher(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}/user-accounts`
+		);
+	}
+
+	static async postAccountUserAccountByEmailAddress(
+		accountExternalReferenceCode: string,
+		emailAddress: string
+	) {
+		return fetcher.post<UserAccount>(
+			`/o/headless-admin-user/v1.0/accounts/by-external-reference-code/${accountExternalReferenceCode}/user-accounts/by-email-address/${emailAddress}`
+		);
+	}
+
+	static async postAddress(accountId: number, body: any) {
+		return fetcher.post(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}/postal-addresses`,
+			body
+		);
+	}
+
+	static async sendRoleAccountUser(
+		accountId: number | string,
+		roleId: number,
+		userId: number
+	) {
+		return fetcher.post(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}/account-roles/${roleId}/user-accounts/${userId}`
+		);
+	}
+
+	static async updateAccount(
+		accountId: number | string,
+		data: Partial<Account>
+	) {
+		return fetcher.patch(
+			`/o/headless-admin-user/v1.0/accounts/${accountId}`,
+			data
+		);
+	}
+
+	static async updateUserAccount(data: unknown, accountId: number) {
+		return fetcher.patch(
+			`/o/headless-admin-user/v1.0/user-accounts/${accountId}`,
+			data
+		);
+	}
+
+	static async updateUserImage(userId: number, formData: FormData) {
+		return fetcher.post(
+			`/o/headless-admin-user/v1.0/user-accounts/${userId}/image`,
+			formData,
+			{shouldStringify: false}
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceAdminCatalog.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceAdminCatalog.ts
@@ -1,0 +1,222 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+import GraphQL from './HeadlessGraphQL';
+
+export default class HeadlessCommerceAdminCatalog {
+	static async addOrUpdateProductImageByExternalReferenceCode(
+		externalReferenceCode: string,
+		body: unknown
+	) {
+		return fetcher.post(
+			`/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/${externalReferenceCode}/images`,
+			body
+		);
+	}
+
+	static async createProductOption(body: unknown[], productId: number) {
+		return fetcher.post<APIResponse<ProductOption>>(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/productOptions?nestedFields=productOptionValues`,
+			body
+		);
+	}
+
+	static async createProductOptionValue(body: unknown, optionId: number) {
+		return fetcher.post(
+			`/o/headless-commerce-admin-catalog/v1.0/productOptions/${optionId}/productOptionValues`,
+			body
+		);
+	}
+
+	static async createVirtualProduct({
+		catalogId,
+		categories,
+		description,
+		name,
+		productSpecifications,
+		productStatus,
+		workflowStatusInfo,
+	}: {
+		catalogId: number;
+		categories: Partial<Categories>[];
+		description: string;
+		name: string;
+		productSpecifications?: any;
+		productStatus?: number;
+		workflowStatusInfo?: number;
+	}) {
+		return fetcher.post(
+			`/o/headless-commerce-admin-catalog/v1.0/products?nestedFields=productVirtualSettings`,
+			{
+				active: true,
+				catalogId,
+				categories,
+				description: {en_US: description},
+				name: {en_US: name},
+				productConfiguration: {
+					allowBackOrder: true,
+					maxOrderQuantity: 99,
+				},
+				productSpecifications,
+				productStatus,
+				productType: 'virtual',
+				productVirtualSettings: {},
+				workflowStatusInfo,
+			}
+		);
+	}
+
+	static async createProductSKU(body: unknown, productId: string | number) {
+		return fetcher.post<SKU>(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/skus`,
+			body
+		);
+	}
+
+	static async deleteAttachmentByExternalReferenceCode(
+		externalReferenceCode: string
+	) {
+		return fetcher.delete(
+			`/o/headless-commerce-admin-catalog/v1.0/attachment/by-externalReferenceCode/${externalReferenceCode}`
+		);
+	}
+
+	static async updateProduct(productId: number, body: unknown) {
+		return fetcher.patch(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}`,
+			body
+		);
+	}
+
+	static async createProductSpecification(
+		productId: number | string,
+		productSpecification: ProductSpecification
+	) {
+		return fetcher.post(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/productSpecifications`,
+			productSpecification
+		);
+	}
+
+	static async deleteProduct(productId: string | number) {
+		return fetcher.delete(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}`
+		);
+	}
+
+	static async getCatalog(
+		catalogId: string | number,
+		searchParams = new URLSearchParams()
+	) {
+		return fetcher(
+			`/o/headless-commerce-admin-catalog/v1.0/catalog/${catalogId}?${searchParams.toString()}`
+		);
+	}
+
+	static async getCatalogs(searchParams = new URLSearchParams()) {
+		return fetcher<APIResponse<Catalog>>(
+			`/o/headless-commerce-admin-catalog/v1.0/catalogs?${searchParams.toString()}`
+		);
+	}
+
+	static async getOptions() {
+		return fetcher<APIResponse<CommerceOption>>(
+			'/o/headless-commerce-admin-catalog/v1.0/options'
+		);
+	}
+
+	static async getProduct(
+		productId: string | number,
+		searchParams = new URLSearchParams()
+	) {
+		return fetcher<Product>(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}?${searchParams.toString()}`
+		);
+	}
+
+	static async getProductByExternalReferenceCode(
+		externalReferenceCode: string,
+		searchParams = new URLSearchParams()
+	): Promise<Product> {
+		return fetcher(
+			`/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/${externalReferenceCode}?${searchParams.toString()}`
+		);
+	}
+
+	static async getProducts(searchParams = new URLSearchParams()) {
+		const response = await fetcher<APIResponse<Product>>(
+			`/o/headless-commerce-admin-catalog/v1.0/products?${searchParams.toString()}`
+		);
+
+		return response;
+	}
+
+	static async getProductsDashboardKPI(
+		filters: Record<string, string>,
+		options?: Record<string, any>
+	) {
+		return GraphQL.metrics<Product>(
+			{
+				group: 'headlessCommerceAdminCatalog_v1_0',
+				name: 'products',
+			},
+			filters,
+			options
+		);
+	}
+
+	static async getProductOptions(productId: number) {
+		return fetcher<APIResponse<ProductOption>>(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/productOptions?nestedFields=productOptionValues`
+		);
+	}
+
+	static async getProductSkus(productId: string | number) {
+		return fetcher<APIResponse<SKU>>(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/skus`
+		);
+	}
+
+	static async getProductSpecifications(productId: string | number) {
+		const response = await fetcher(
+			`/o/headless-commerce-admin-catalog/v1.0/products/${productId}/productSpecifications`
+		);
+
+		return (response?.items ?? []) as ProductSpecification[];
+	}
+
+	static async getSku(skuId: number, searchParams = new URLSearchParams()) {
+		return fetcher<SKU>(
+			`o/headless-commerce-admin-catalog/v1.0/skus/${skuId}?${searchParams}`
+		);
+	}
+
+	static async getSpecifications(searchParams = new URLSearchParams()) {
+		return fetcher<APIResponse>(
+			`/o/headless-commerce-admin-catalog/v1.0/specifications?${searchParams}`
+		);
+	}
+
+	static async updateProductByExternalReferenceCode(
+		externalReferenceCode: string,
+		body: unknown
+	) {
+		return fetcher.patch(
+			`/o/headless-commerce-admin-catalog/v1.0/products/by-externalReferenceCode/${externalReferenceCode}`,
+			body
+		);
+	}
+
+	static async updateProductSpecification(
+		id: number | string,
+		productSpecification: ProductSpecification
+	) {
+		return fetcher.patch(
+			`/o/headless-commerce-admin-catalog/v1.0/productSpecifications/${id}`,
+			productSpecification
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessGraphQL.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessGraphQL.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+type Metrics<T> = {[key: string]: APIResponse<T>};
+
+export default class GraphQL {
+	static async metrics<T>(
+		query: {
+			group: string;
+			name: string;
+			options?: Record<string, string>;
+		},
+		filters: Record<string, string>,
+		options?: Record<string, any>
+	) {
+		const queries = Object.entries(filters)
+			.map(([alias, filter]) => {
+				const option = options?.[alias];
+
+				const body = (option?.body || query.options?.body) ?? '';
+				const sort = (options?.sort || query?.options?.sort) ?? '';
+				const pageSize =
+					(option?.pageSize || query.options?.pageSize) ?? 1;
+
+				return `${alias}: ${query.name}(filter: "${filter}", pageSize: ${pageSize}, sort: "${sort}") {
+					totalCount
+
+					${body}
+			  	}
+			`;
+			})
+			.join('\n');
+
+		try {
+			const response = await fetcher.post<{
+				data: {
+					metrics: Metrics<T>;
+				};
+			}>(`/o/graphql`, {
+				query: `
+		  {
+			metrics: ${query.group} {
+			  ${queries}
+			}
+		  }
+		`,
+			});
+
+			return response;
+		}
+		catch {
+			const metrics: Metrics<T> = {};
+
+			for (const filterKey in filters) {
+				(metrics as any)[filterKey] = {
+					items: [],
+					totalCount: 0,
+				} as unknown as Metrics<T>;
+			}
+
+			return {
+				data: {
+					metrics,
+				},
+			};
+		}
+	}
+}


### PR DESCRIPTION
Part of epic LPD-88257 (Admin UI migration). Adds the foundation of the Admin shell: REST services, OneContext, providers, hooks, search/filters and the entity model.

Includes `src/services/{fetcher, SWRCacheProvider, rest/{HeadlessAdminUser, HeadlessCommerceAdminCatalog, HeadlessGraphQL}}`, `src/context/OneContext`, `src/entity/MarketplaceUserAccount`, `src/core/CreateFilters`, `src/schema/filters`, `src/hooks/{useFetch, useListTypeDefinition, useModalContext, useStorage}`. Wires the SWR/Modal/OneContext providers into `src/main.tsx`.