### PR TITLE
LPD-92498 Revert local environment to 2026.Q1.2 LTS hotfix 17

### DIFF
--- a/workspaces/liferay-one-workspace/gradle-local.properties
+++ b/workspaces/liferay-one-workspace/gradle-local.properties
@@ -1,2 +1,2 @@
-liferay.workspace.hotfix.url=https://releases-cdn.liferay.com/dxp/hotfix/2026.q2.1/liferay-dxp-2026.q2.1-hotfix-6.zip
-liferay.workspace.product=dxp-2026.q2.1
+liferay.workspace.hotfix.url=https://releases-cdn.liferay.com/dxp/hotfix/2026.q1.2-lts/liferay-dxp-2026.q1.2-lts-hotfix-17.zip
+liferay.workspace.product=dxp-2026.q1.2-lts


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92498

## What is being fixed

The liferay-one local environment was bumped to dxp-2026.q2.1 (hotfix 6)
by the original LPD-92498 work (PR #1102, now merged to master-temp).
That upgrade is being rolled back to the prior 2026.Q1.2 LTS release.

## How it is being fixed

Reverts gradle-local.properties in liferay-one-workspace from
dxp-2026.q2.1 / hotfix-6 back to dxp-2026.q1.2-lts / hotfix-17, the exact
inverse of the q2.1 bump.
