### PR TITLE
LPD-93295 Add Admin ListView with management toolbar and filters

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/ListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/ListView.tsx
@@ -1,0 +1,348 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayPaginationBarWithBasicItems} from '@clayui/pagination-bar';
+import React, {
+	ComponentProps,
+	ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+} from 'react';
+import {useSearchParams} from 'react-router-dom';
+import {KeyedMutator} from 'swr';
+
+import CreateFilters from '../../core/CreateFilters';
+import {useFetch} from '../../hooks/useFetch';
+import i18n from '../../i18n';
+import {
+	FilterSchema as FilterSchemaType,
+	RendererFields,
+	filterSchema as filterSchemas,
+} from '../../schema/filters';
+import {PAGINATION, SortDirection} from '../../utils/constants';
+import {safeJSONParse} from '../../utils/util';
+import EmptyState from '../EmptyState';
+import Loading from '../Loading';
+import ManagementToolbar, {
+	ManagementToolbarProps,
+} from './components/ManagementToolbar';
+import Table, {TableProps} from './components/Table';
+import ListViewContextProvider, {
+	AppActions,
+	InitialState as ListViewContextState,
+	ListViewContext,
+	ListViewContextProviderProps,
+	ListViewTypes,
+	Sort,
+} from './hooks/ListViewContext';
+import useUpdateUrlParams from './hooks/useUpdateUrlParams';
+
+type ChildrenOptions = {
+	dispatch: React.Dispatch<AppActions>;
+	listViewContext: ListViewContextState;
+	mutate: KeyedMutator<APIResponse<any>>;
+};
+
+export type ListViewProps<T extends Record<string, any>> = {
+	children?: (
+		response: APIResponse<T>,
+		options: ChildrenOptions
+	) => ReactNode;
+
+	defaultFilters?: {filter: string};
+
+	emptyStateProps?: ComponentProps<typeof EmptyState>;
+
+	/**
+	 * The key of SWR Cache for the list view.
+	 * It must be provided to avoid cache collisions.
+	 *
+	 * @default 'listView:{id}?page={page}&pageSize={pageSize}'
+	 */
+	id: string;
+
+	initialContext?: ListViewContextProviderProps;
+
+	managementToolbarProps?: {
+		visible?: boolean;
+	} & Omit<
+		ManagementToolbarProps,
+		| 'actions'
+		| 'onSelectAllRows'
+		| 'rowSelectable'
+		| 'tableProps'
+		| 'totalItems'
+	>;
+
+	/**
+	 * The options for the pagination.
+	 *
+	 * @default {displayType: true}
+	 */
+	paginationOptions?: {
+		displayType: boolean;
+	};
+
+	refreshInterval?: number;
+
+	resource: string;
+
+	tableProps: Omit<
+		TableProps<T>,
+		'items' | 'mutate' | 'onSelectAllRows' | 'onSort'
+	>;
+
+	/**
+	 * A function to transform the data before rendering.
+	 * It can be used to format or filter the data.
+	 *
+	 * @default undefined
+	 */
+	transformData?: (response: APIResponse<T>) => APIResponse<T>;
+};
+
+function getMatchedOption(rawValue: string, field?: RendererFields) {
+	const matchedOption = field?.options?.find((opt) => {
+		if (typeof opt === 'object') {
+			return opt.value === rawValue;
+		}
+	});
+
+	return typeof matchedOption === 'object'
+		? matchedOption
+		: {label: rawValue, value: rawValue};
+}
+
+const ListView = <T extends Record<string, any>>({
+	children,
+	defaultFilters,
+	emptyStateProps,
+	managementToolbarProps: {
+		visible: managementToolbarVisible = false,
+		...managementToolbarProps
+	} = {},
+	paginationOptions = {displayType: true},
+	refreshInterval,
+	resource,
+	tableProps,
+	transformData = (item) => item,
+}: ListViewProps<T>) => {
+	const [listViewContext, dispatch] = useContext(ListViewContext);
+
+	const updateUrlParams = useUpdateUrlParams();
+	const [searchParams] = useSearchParams();
+
+	const {filters, keywords, sort} = listViewContext;
+
+	const filterSchema = (filterSchemas as any)[
+		managementToolbarProps?.filterSchema ?? ''
+	] as FilterSchemaType;
+
+	const encodedFilter = searchParams.get('filter');
+
+	const setFilters = useCallback(() => {
+		const parsedFilter = safeJSONParse(encodedFilter, {});
+
+		if (!Object.keys(parsedFilter).length) {
+			return;
+		}
+
+		const fields = filterSchema?.fields ?? ([] as RendererFields[]);
+
+		const normalizedFilter = Object.fromEntries(
+			Object.entries(parsedFilter).map(([key, value]) => {
+				const fieldSchema = fields.find((field) => field.name === key);
+				const rawValues = Array.isArray(value)
+					? value
+					: [String(value)];
+
+				return [
+					key,
+					rawValues.map((value) =>
+						getMatchedOption(value, fieldSchema)
+					),
+				];
+			})
+		);
+
+		dispatch({
+			payload: {
+				filters: {
+					entries: Object.entries(normalizedFilter).map(
+						([key, selectedOptions]) => ({
+							label:
+								fields.find(({name}) => name === key)?.label ??
+								key,
+							name: key,
+							value: selectedOptions
+								.map((opt) => opt.label)
+								.join(', '),
+						})
+					),
+					filter: normalizedFilter,
+				},
+			},
+			type: ListViewTypes.SET_FILTERS,
+		});
+	}, [dispatch, encodedFilter, filterSchema?.fields]);
+
+	useEffect(() => setFilters(), [encodedFilter, setFilters]);
+
+	const currentPage = searchParams.get('page');
+	const currentPageSize = searchParams.get('pageSize');
+
+	const filterVariables = useMemo(
+		() => ({
+			appliedFilter: filters.filter,
+			defaultFilter: defaultFilters?.filter,
+			filterSchema,
+		}),
+		[filters, defaultFilters?.filter, filterSchema]
+	);
+
+	const filter = useMemo(() => {
+		const baseFilter = CreateFilters.createFilter(filterVariables) || '';
+
+		return {filter: baseFilter};
+	}, [filterVariables]);
+
+	const buildSort = (sort: Sort) =>
+		sort.key ? `${sort.key}:${sort.direction.toLowerCase()}` : '';
+
+	const onSort = useCallback(
+		(key: string, direction: SortDirection) => {
+			dispatch({
+				payload: {direction, key},
+				type: ListViewTypes.SET_SORT,
+			});
+		},
+		[dispatch]
+	);
+
+	const getURLSearchParams = useCallback(
+		() => ({
+			...filter,
+			page: currentPage ? Number(currentPage) : listViewContext.page,
+			pageSize: currentPageSize
+				? Number(currentPageSize)
+				: listViewContext.pageSize,
+			search: keywords,
+			sort: buildSort(sort),
+		}),
+		[
+			currentPage,
+			currentPageSize,
+			filter,
+			listViewContext.page,
+			listViewContext.pageSize,
+			keywords,
+			sort,
+		]
+	);
+
+	const {
+		data: response,
+		error,
+		isValidating,
+		loading,
+		mutate,
+	} = useFetch(
+		resource,
+		{
+			params: getURLSearchParams(),
+		},
+		refreshInterval
+	);
+
+	const {
+		items = [],
+		page = 1,
+		pageSize,
+		totalCount = 0,
+	} = transformData(response || {items: []});
+
+	if (loading || (isValidating && searchParams.get('filter'))) {
+		return <Loading />;
+	}
+
+	const Pagination = (
+		<ClayPaginationBarWithBasicItems
+			activeDelta={pageSize}
+			activePage={page}
+			deltas={listViewContext.paginationDeltaOptions.map((label) => ({
+				label,
+			}))}
+			ellipsisBuffer={PAGINATION.ellipsisBuffer}
+			labels={{
+				paginationResults: i18n.translate('showing-x-to-x-of-x'),
+				perPageItems: i18n.translate('x-items'),
+				selectPerPageItems: i18n.translate('x-items'),
+			}}
+			onDeltaChange={(delta) => {
+				updateUrlParams({pageSize: delta});
+
+				dispatch({payload: delta, type: ListViewTypes.SET_PAGE_SIZE});
+			}}
+			onPageChange={(page) => {
+				updateUrlParams({page});
+
+				dispatch({payload: page, type: ListViewTypes.SET_PAGE});
+			}}
+			totalItems={totalCount}
+		/>
+	);
+
+	return (
+		<>
+			{managementToolbarVisible && (
+				<ManagementToolbar
+					{...managementToolbarProps}
+					totalItems={totalCount}
+				/>
+			)}
+
+			{!items.length && (
+				<>
+					<EmptyState
+						description={error?.message}
+						type={error ? 'EMPTY_SEARCH' : 'EMPTY_STATE'}
+						{...emptyStateProps}
+					/>
+				</>
+			)}
+			{!!items.length && (
+				<>
+					<Table
+						{...tableProps}
+						items={items}
+						mutate={mutate}
+						onSort={onSort}
+						sort={sort}
+					/>
+
+					{paginationOptions.displayType && Pagination}
+				</>
+			)}
+			{children &&
+				children(response!, {
+					dispatch,
+					listViewContext,
+					mutate,
+				})}
+		</>
+	);
+};
+const ListViewWithContext = <T extends Record<string, any>>({
+	initialContext,
+	...otherProps
+}: ListViewProps<T>): React.ReactElement => (
+	<ListViewContextProvider {...initialContext} id={otherProps.id}>
+		<ListView {...otherProps} />
+	</ListViewContextProvider>
+);
+
+export default ListViewWithContext;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbar.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbar.tsx
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayManagementToolbar from '@clayui/management-toolbar';
+import {ReactElement, useContext} from 'react';
+
+import {
+	FilterSchemaOption,
+	filterSchema as filterSchemas,
+} from '../../../schema/filters';
+import {ListViewContext} from '../hooks/ListViewContext';
+import ManagementToolbarFilter from './ManagementToolbarFilters/ManagementToolbarFilters';
+import ManagementToolbarResultsBar from './ManagementToolbarResultsBar/ManagementToolbarResultsBar';
+import ManagementToolbarSearch from './ManagementToolbarSearch';
+
+export type ManagementToolbarProps = {
+	actionButton?: (
+		filter: {
+			[key: string]: string;
+		},
+		filterSchema?: FilterSchemaOption
+	) => ReactElement;
+
+	filterSchema?: FilterSchemaOption;
+	searchVisible?: boolean;
+	totalItems: number;
+};
+
+const ManagementToolbar: React.FC<ManagementToolbarProps> = ({
+	actionButton,
+	filterSchema,
+	searchVisible = false,
+	totalItems,
+}) => {
+	const [{filters}] = useContext(ListViewContext);
+
+	return (
+		<>
+			<ClayManagementToolbar>
+				<div className="d-flex justify-content-between w-100">
+					{filterSchema && (
+						<ManagementToolbarFilter
+							filterSchema={
+								(filterSchemas as any)[filterSchema ?? '']
+							}
+						/>
+					)}
+
+					{!!searchVisible && (
+						<div className="d-flex w-100">
+							<ManagementToolbarSearch />
+							{actionButton &&
+								actionButton(filters.filter, filterSchema)}
+						</div>
+					)}
+				</div>
+
+				{!!filters.entries?.filter(({value}) => value).length && (
+					<ManagementToolbarResultsBar totalItems={totalItems} />
+				)}
+			</ClayManagementToolbar>
+		</>
+	);
+};
+
+export default ManagementToolbar;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarFilters/ManagementToolbarFilters.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarFilters/ManagementToolbarFilters.scss
@@ -1,0 +1,13 @@
+.management-toolbar-dropdown {
+	padding: 0 10px 10px;
+	width: 400px;
+
+	&-body {
+		width: 100%;
+	}
+}
+
+.management-toolbar-filter-button {
+	height: 40px;
+	max-height: 40px;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarFilters/ManagementToolbarFilters.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarFilters/ManagementToolbarFilters.tsx
@@ -1,0 +1,328 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayDropDown, {Align} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import {
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import {useLocation, useNavigate, useParams} from 'react-router-dom';
+import useSWR from 'swr';
+
+import CreateFilters from '../../../../core/CreateFilters';
+import i18n from '../../../../i18n';
+import {FilterSchema, RendererFields} from '../../../../schema/filters';
+import fetcher from '../../../../services/fetcher';
+import {safeJSONParse} from '../../../../utils/util';
+import Form from '../../../Form/index';
+import {ListViewContext, ListViewTypes} from '../../hooks/ListViewContext';
+import useUpdateUrlParams from '../../hooks/useUpdateUrlParams';
+
+import './ManagementToolbarFilters.scss';
+
+type ManagementToolbarFilterProps = {
+	filterSchema?: FilterSchema;
+};
+
+export type Option = {label: string; value: string};
+
+type FilterBodyProps = {
+	filterSchema: FilterSchema | undefined;
+	setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const FilterBody: React.FC<FilterBodyProps> = ({
+	filterSchema,
+	setIsVisible,
+}) => {
+	const [listViewContext, dispatch] = useContext(ListViewContext);
+	const location = useLocation();
+	const navigate = useNavigate();
+	const params = useParams();
+	const updateUrlParams = useUpdateUrlParams();
+
+	const fields = useMemo(
+		() => filterSchema?.fields as RendererFields[],
+		[filterSchema?.fields]
+	);
+
+	const initialFilters = useMemo(() => {
+		const initialValues: {[key: string]: string} = {};
+
+		for (const field of fields) {
+			initialValues[field.name] = '';
+		}
+
+		return initialValues;
+	}, [fields]);
+
+	const [form, setForm] = useState(() => ({
+		...initialFilters,
+		...listViewContext.filters.filter,
+	}));
+
+	const clearButtonDisabled = Object.values(form).every(
+		(value) => !value || !value.length
+	);
+
+	const onClear = () => setForm(initialFilters);
+
+	const onChange = (event: any) => {
+		const {
+			target: {name, options, type},
+		} = event;
+
+		let {value} = event.target;
+
+		if (type === 'date-range') {
+			value = [
+				{
+					label: value,
+					value,
+				},
+			];
+		}
+		else if (type === 'select-one') {
+			value = [
+				{
+					label: options.item(options.selectedIndex).label,
+					value: Number(value) || value,
+				},
+			];
+		}
+
+		if (Array.isArray(value)) {
+			if (!value[0]) {
+				value = '';
+			}
+			else if (typeof value[0] === 'object') {
+				value = !value[0].label ? '' : value;
+			}
+		}
+
+		setForm({
+			...form,
+			[name]: value,
+		});
+	};
+
+	const handleRemoveItemFromFilter = useCallback(() => {
+		const searchParams = new URLSearchParams(location.search);
+		searchParams.delete('filter');
+		searchParams.delete('filterSchema');
+
+		return navigate({
+			search: `?${searchParams.toString()}`,
+		});
+	}, [location.search, navigate]);
+
+	const paramsMemoized = useMemo(() => {
+		return JSON.stringify({...params});
+	}, [params]);
+
+	const fieldsMemoized = useMemo(() => filterSchema?.fields, [filterSchema]);
+
+	const {data: fieldOptions = {}, isLoading} = useSWR(
+		filterSchema?.fields?.length ? `/filter-${filterSchema?.name}` : null,
+		async () => {
+			const parameters = safeJSONParse(paramsMemoized, {});
+
+			const fieldsWithResource = fieldsMemoized?.filter(
+				({resource}) => resource
+			);
+
+			const _fieldOptions: any = {};
+
+			if (fieldsWithResource) {
+				await Promise.all(
+					fieldsWithResource.map((field) =>
+						fetcher(
+							(typeof field.resource === 'function'
+								? field.resource(parameters)
+								: field.resource) as string
+						)
+					)
+				).then((results) =>
+					results.forEach((result, index) => {
+						const field = fieldsWithResource[index];
+
+						if (field.transformData) {
+							const parsedValue = field.transformData(result);
+
+							_fieldOptions[field.name] = parsedValue;
+						}
+					})
+				);
+			}
+
+			return _fieldOptions;
+		}
+	);
+
+	const onApply = useCallback(() => {
+		const filterCleaned = CreateFilters.removeEmptyFilter(form);
+
+		const entries = Object.keys(filterCleaned).map((key) => ({
+			label: fields?.find(({name}) => name === key)?.label,
+			name: key,
+			value: filterCleaned[key],
+		}));
+
+		const filters = Object.keys(filterCleaned).map((key) => ({
+			name: key,
+			value: Array.isArray(filterCleaned[key])
+				? (filterCleaned as any)[key].map((options: Option) =>
+						options?.value
+							? options?.value
+							: options?.label || options
+					)
+				: filterCleaned[key],
+		}));
+
+		const formattedFilter = filters.reduce(
+			(previousValue, currentValue) => {
+				return {
+					...previousValue,
+					[currentValue.name]: currentValue.value,
+				};
+			},
+			{}
+		);
+
+		if (filterSchema) {
+			updateUrlParams({
+				filter: JSON.stringify(formattedFilter),
+				filterSchema: filterSchema?.name as string,
+				page: '1',
+			});
+		}
+
+		if (!Object.keys(formattedFilter).length) {
+			handleRemoveItemFromFilter();
+		}
+
+		dispatch({
+			payload: {filters: {entries, filter: filterCleaned}},
+			type: ListViewTypes.SET_FILTERS,
+		});
+
+		setIsVisible(false);
+	}, [
+		dispatch,
+		fields,
+		filterSchema,
+		form,
+		handleRemoveItemFromFilter,
+		setIsVisible,
+		updateUrlParams,
+	]);
+
+	useEffect(() => {
+		const searchParams = new URLSearchParams(location.search);
+
+		if (!searchParams.get('filter')) {
+			setForm(initialFilters);
+		}
+	}, [initialFilters, location.search]);
+
+	return (
+		<div className="align-content-between d-flex flex-column">
+			<ClayDropDown.Section>
+				<div className="management-toolbar-body">
+					<div className="dropdown-filter-content" tabIndex={1}>
+						<Form.Renderer
+							fieldOptions={fieldOptions}
+							fields={fields}
+							filterSchema={filterSchema?.name as string}
+							form={form}
+							isLoading={isLoading}
+							onApply={onApply}
+							onChange={onChange}
+						/>
+					</div>
+				</div>
+			</ClayDropDown.Section>
+
+			<ClayDropDown.Section className="d-flex dropdown-footer justify-content-center">
+				<ClayButton className="mt-2" onClick={onApply}>
+					{i18n.translate('apply')}
+				</ClayButton>
+
+				<ClayButton
+					className="ml-3 mt-2"
+					disabled={clearButtonDisabled}
+					displayType="secondary"
+					onClick={onClear}
+				>
+					{i18n.translate('clear')}
+				</ClayButton>
+			</ClayDropDown.Section>
+		</div>
+	);
+};
+
+const ManagementToolbarFilter: React.FC<ManagementToolbarFilterProps> = ({
+	filterSchema,
+}) => {
+	const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+	const [isVisible, setIsVisible] = useState(false);
+
+	const hasOneFilter = filterSchema?.fields?.length === 1;
+
+	const handleExpand = (
+		event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+	) => {
+		buttonRef.current = event.target as HTMLButtonElement;
+
+		setIsVisible((isVisible) => !isVisible);
+	};
+
+	return (
+		<>
+			<div className="align-items-center d-flex justify-content-between">
+				<ClayButton
+					className="align-items-center btn-secondary d-flex justify-content-between management-toolbar-filter-button ml-3 mr-2 px-2"
+					displayType="unstyled"
+					onClick={handleExpand}
+				>
+					<ClayIcon className="mr-2" symbol="filter" />
+					{i18n.translate('filter')}
+				</ClayButton>
+			</div>
+
+			{isVisible && (
+				<ClayDropDown.Menu
+					active={isVisible}
+					alignElementRef={buttonRef}
+					alignmentPosition={Align.BottomLeft}
+					className={classNames('management-toolbar-dropdown', {
+						'dropdown-management-toolbar-small': hasOneFilter,
+					})}
+					closeOnClickOutside
+					onActiveChange={() =>
+						setIsVisible((isVisible) => !isVisible)
+					}
+				>
+					<div className="management-toolbar-dropdown-body">
+						<FilterBody
+							filterSchema={filterSchema}
+							setIsVisible={setIsVisible}
+						/>
+					</div>
+				</ClayDropDown.Menu>
+			)}
+		</>
+	);
+};
+
+export default ManagementToolbarFilter;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarResultsBar/ManagementToolbarResultsBar.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarResultsBar/ManagementToolbarResultsBar.scss
@@ -1,0 +1,5 @@
+.toolbar-results-container {
+	.subnav-tbar-primary {
+		background-color: white !important;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarResultsBar/ManagementToolbarResultsBar.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarResultsBar/ManagementToolbarResultsBar.tsx
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLabel from '@clayui/label';
+import {ClayResultsBar} from '@clayui/management-toolbar';
+import {useContext, useEffect} from 'react';
+import {useLocation, useNavigate} from 'react-router-dom';
+
+import i18n from '../../../../i18n';
+import {ListViewContext, ListViewTypes} from '../../hooks/ListViewContext';
+
+import './ManagementToolbarResultsBar.scss';
+
+type ManagementToolbarResultsBarProps = {
+	totalItems: number;
+};
+
+const ManagementToolbarResultsBar: React.FC<
+	ManagementToolbarResultsBarProps
+> = ({totalItems}) => {
+	const location = useLocation();
+	const navigate = useNavigate();
+	const searchParams = new URLSearchParams(location.search);
+
+	const filter = searchParams.get('filter');
+
+	const [{filters}, dispatch] = useContext(ListViewContext);
+
+	const handleRemoveItemFromFilter = (itemToRemove: string) => {
+		if (!filter) {
+			return;
+		}
+
+		const filterJSON = JSON.parse(decodeURIComponent(filter));
+
+		delete filterJSON[itemToRemove];
+
+		if (Object.keys(filterJSON).length) {
+			searchParams.set('filter', JSON.stringify(filterJSON));
+		}
+		else {
+			searchParams.delete('filter');
+			searchParams.delete('filterSchema');
+			searchParams.delete('page');
+		}
+
+		navigate({
+			search: `?${searchParams.toString()}`,
+		});
+	};
+
+	const onRemoveFilter = (filterName: string) => {
+		dispatch({payload: filterName, type: ListViewTypes.SET_REMOVE_FILTER});
+
+		handleRemoveItemFromFilter(filterName);
+	};
+
+	useEffect(() => {
+		if (!filter) {
+			filters.entries
+				.filter(({value}) => value)
+				.forEach((entry) =>
+					dispatch({
+						payload: entry.name,
+						type: ListViewTypes.SET_REMOVE_FILTER,
+					})
+				);
+		}
+	}, [dispatch, filter, filters.entries]);
+
+	return (
+		<div className="border-bottom border-top d-block toolbar-results-container w-100">
+			<ClayResultsBar>
+				<ClayResultsBar.Item>
+					<span className="component-text text-truncate-inline">
+						<span className="text-truncate">
+							{i18n.sub('x-results-for', [totalItems.toString()])}
+						</span>
+					</span>
+				</ClayResultsBar.Item>
+
+				{filters.entries
+					.filter(({value}) => value)
+					.map((entry, index) => (
+						<ClayResultsBar.Item
+							expand={index === filters.entries.length - 1}
+							key={index}
+						>
+							<ClayLabel
+								className="component-label result-filter tbar-label"
+								displayType="unstyled"
+							>
+								<span className="d-flex flex-row">
+									<b>{entry.label}</b>
+
+									{`: ${
+										Array.isArray(entry.value)
+											? entry.value
+													.map((entryValue) =>
+														String(
+															typeof entryValue ===
+																'object'
+																? entryValue?.label
+																: entryValue
+														)
+													)
+													.sort((entryA, entryB) =>
+														entryA.localeCompare(
+															entryB
+														)
+													)
+													.join(', ')
+											: entry.value
+									}`}
+
+									<ClayIcon
+										className="cursor-pointer ml-2"
+										onClick={() =>
+											onRemoveFilter(entry.name)
+										}
+										symbol="times"
+									/>
+								</span>
+							</ClayLabel>
+						</ClayResultsBar.Item>
+					))}
+			</ClayResultsBar>
+		</div>
+	);
+};
+
+export default ManagementToolbarResultsBar;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarSearch.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/ManagementToolbarSearch.tsx
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import ClayManagementToolbar from '@clayui/management-toolbar';
+import {useCallback, useContext, useEffect, useRef, useState} from 'react';
+
+import ButtonWithIcon from '../../../components/ButtonWithIcon';
+import i18n from '../../../i18n';
+import {ListViewContext, ListViewTypes} from '../hooks/ListViewContext';
+
+const ManagementToolbarSearch = () => {
+	const [{keywords}, dispatch] = useContext(ListViewContext);
+	const [search, setSearch] = useState(keywords || '');
+
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		const timeout = setTimeout(() => {
+			inputRef?.current?.focus();
+		}, 100);
+
+		return () => clearTimeout(timeout);
+	}, [inputRef]);
+
+	const onApply = useCallback(() => {
+		dispatch({
+			payload: search,
+			type: ListViewTypes.SET_SEARCH,
+		});
+	}, [dispatch, search]);
+
+	const onClear = useCallback(() => {
+		dispatch({
+			payload: '',
+			type: ListViewTypes.SET_SEARCH,
+		});
+	}, [dispatch]);
+
+	return (
+		<div className="w-100">
+			<ClayManagementToolbar.Search
+				onSubmit={(event: React.FormEvent<HTMLFormElement>) => {
+					event.preventDefault();
+					onApply();
+				}}
+			>
+				<ClayInput.Group>
+					<ClayInput.GroupItem>
+						<ClayInput
+							aria-label="Search"
+							className="bg-white form-control input-group-inset input-group-inset-after"
+							onChange={({target: {value}}) => setSearch(value)}
+							placeholder={i18n.translate('search')}
+							ref={inputRef}
+							type="text"
+							value={search}
+						/>
+						<ClayInput.GroupInsetItem
+							after
+							className="bg-white"
+							tag="span"
+						>
+							<ButtonWithIcon
+								aria-label="Search"
+								displayType="unstyled"
+								onClick={onApply}
+								symbol="search"
+							/>
+							{keywords && (
+								<ButtonWithIcon
+									aria-label="Search"
+									displayType="unstyled"
+									onClick={onClear}
+									symbol="times"
+								/>
+							)}
+						</ClayInput.GroupInsetItem>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+			</ClayManagementToolbar.Search>
+		</div>
+	);
+};
+
+export default ManagementToolbarSearch;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/Table.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/components/Table.tsx
@@ -1,0 +1,271 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayDropDown, {Align} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import ClayTable from '@clayui/table';
+import classNames from 'classnames';
+import React, {useState} from 'react';
+import {Link} from 'react-router-dom';
+import {KeyedMutator} from 'swr';
+
+import ButtonWithIcon from '../../../components/ButtonWithIcon';
+import {Action, SortDirection, SortOption} from '../../../utils/constants';
+import {Sort} from '../hooks/ListViewContext';
+
+export type Column<
+	T extends Record<string, any>,
+	K extends keyof T = keyof T,
+> = {
+	clickable?: boolean;
+	id: K;
+	name: string;
+	render?: (
+		itemValue: T[K],
+		item: T,
+		mutate: KeyedMutator<APIResponse<T>>
+	) => String | React.ReactNode;
+	selectable?: boolean;
+	size?: 'sm' | 'md' | 'lg' | 'xl' | 'none';
+	sortable?: boolean;
+	truncate?: boolean;
+	width?: '50' | '75' | '100' | '200' | '250' | '300' | '350' | '400';
+};
+
+export type TableProps<T extends Record<string, any> = any> = {
+	actions?: Action[];
+	bodyVerticalAlignment?: 'bottom' | 'middle' | 'top';
+	columns: {
+		[K in keyof T]: Column<T, K>;
+	}[keyof T][];
+	highlight?: (item: T) => boolean;
+	items: T[];
+	mutate: KeyedMutator<APIResponse<T>>;
+	navigateTo?: (item: T) => string;
+	onClickRow?: (item: T) => void;
+	onSelectRow?: (row: T) => void;
+	onSort: (columnTable: string, direction: SortDirection) => void;
+	responsive?: boolean;
+	rowWrap?: boolean;
+	sort?: Sort;
+};
+
+const Table = <T extends Record<string, any>>({
+	actions,
+	bodyVerticalAlignment = 'middle',
+	columns,
+	highlight,
+	items,
+	mutate,
+	navigateTo,
+	onClickRow,
+	onSort,
+	responsive,
+	rowWrap = false,
+	sort,
+}: TableProps<T>) => {
+	const [sorted, setSorted] = useState<SortDirection>(SortOption.DESC);
+
+	const changeSort = (key: string) => {
+		onSort(key, sorted);
+
+		setSorted(sorted === SortOption.ASC ? SortOption.DESC : SortOption.ASC);
+	};
+
+	const getSortSymbol = (key: string) => {
+		if (!sort) {
+			return '';
+		}
+
+		if (sort.key === key) {
+			return sort.direction === SortOption.ASC
+				? 'caret-top-l'
+				: 'caret-bottom-l';
+		}
+
+		return 'caret-double-l';
+	};
+
+	let _columns = columns;
+
+	if (actions) {
+		_columns = [
+			...columns,
+			{
+				id: '_actions_',
+				name: '',
+				render: (_, item) => (
+					<ClayDropDown
+						alignmentPosition={Align.BottomCenter}
+						className="d-flex justify-content-end"
+						closeOnClick
+						items={actions.map((action) => ({
+							...action,
+							disabled:
+								typeof action.disabled === 'boolean'
+									? action.disabled
+									: action?.disabled?.(item),
+							hidden:
+								typeof action.hidden === 'boolean'
+									? action.hidden
+									: action?.hidden?.(item),
+							onClick: () => {
+								if (action.onClick) {
+									return action?.onClick(item, mutate);
+								}
+							},
+						}))}
+						trigger={
+							<ButtonWithIcon
+								aria-label="actions"
+								className="btn-monospaced"
+								displayType="unstyled"
+								onClick={(event) => event.stopPropagation()}
+								symbol="ellipsis-v"
+							/>
+						}
+					>
+						{(item, index) => (
+							<ClayDropDown.Item
+								disabled={item.disabled}
+								hidden={!!item.hidden}
+								onClick={() => item.onClick()}
+								{...{['keyValue']: index}}
+							>
+								{item.icon && (
+									<ClayIcon
+										className="mr-2"
+										symbol={item.icon}
+									/>
+								)}
+
+								{typeof item.name === 'string'
+									? item.name
+									: item.name(item)}
+							</ClayDropDown.Item>
+						)}
+					</ClayDropDown>
+				),
+			},
+		];
+	}
+
+	return (
+		<ClayTable
+			borderless
+			className="tr-table"
+			hover
+			responsive={responsive}
+			striped={false}
+			tableVerticalAlignment={bodyVerticalAlignment}
+		>
+			<ClayTable.Head>
+				<ClayTable.Row>
+					{_columns.map((column, index) => (
+						<ClayTable.Cell headingTitle key={index}>
+							<span className="d-flex justify-content-between">
+								<span
+									className={classNames({
+										'cursor-pointer': column.sortable,
+									})}
+									onClick={() => {
+										if (column.sortable) {
+											changeSort(column.id.toString());
+										}
+									}}
+								>
+									{column.name}
+								</span>
+
+								{column.sortable && (
+									<ClayIcon
+										className="cursor-pointer mr-auto mt-1"
+										onClick={() =>
+											changeSort(column.id.toString())
+										}
+										symbol={getSortSymbol(
+											column.id.toString()
+										)}
+									/>
+								)}
+							</span>
+						</ClayTable.Cell>
+					))}
+				</ClayTable.Row>
+			</ClayTable.Head>
+
+			<ClayTable.Body>
+				{items.map((item, rowIndex) => (
+					<ClayTable.Row
+						className={classNames('tr-table__row', {
+							'text-nowrap': !rowWrap,
+							'text-wrap': rowWrap,
+							'tr-table__row--highligth':
+								highlight && highlight(item),
+						})}
+						key={rowIndex}
+					>
+						{_columns.map((column, columnIndex) => {
+							const Wrapper: React.ElementType =
+								column.selectable ||
+								(column.clickable && navigateTo)
+									? Link
+									: 'div';
+
+							const itemValue = item[column.id];
+
+							return (
+								<ClayTable.Cell
+									className={classNames('text-dark', {
+										'cursor-pointer': column.clickable,
+										[`table-cell-minw-${column.width}`]:
+											column.width,
+										'table-cell-expand':
+											column.size === 'sm',
+										'table-cell-expand-small':
+											column.size === 'xl',
+										'table-cell-expand-smaller':
+											column.size === 'lg',
+										'table-cell-expand-smallest':
+											column.size === 'md',
+									})}
+									expanded={column.truncate}
+									key={columnIndex}
+									onClick={() => {
+										if (onClickRow) {
+											onClickRow(item);
+										}
+									}}
+									truncate={column.truncate}
+								>
+									<Wrapper
+										className="text-dark"
+										{...(Wrapper === Link
+											? {
+													to: navigateTo?.(
+														item
+													)?.toString() as string,
+												}
+											: {})}
+									>
+										{column.render
+											? column.render(
+													itemValue,
+													item,
+													mutate
+												)
+											: itemValue}
+									</Wrapper>
+								</ClayTable.Cell>
+							);
+						})}
+					</ClayTable.Row>
+				))}
+			</ClayTable.Body>
+		</ClayTable>
+	);
+};
+
+export default Table;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/hooks/ListViewContext.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/hooks/ListViewContext.tsx
@@ -1,0 +1,260 @@
+/* eslint-disable no-case-declarations */
+
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ReactNode, createContext, useReducer} from 'react';
+
+import MarketplaceStorage, {
+	CONSENT_TYPE,
+	STORAGE_KEYS,
+} from '../../../core/Storage';
+import useStorage from '../../../hooks/useStorage';
+import {
+	PAGINATION_DELTA,
+	SortDirection,
+	SortOption,
+} from '../../../utils/constants';
+
+const marketplaceStorage =
+	MarketplaceStorage.getInstance().getStorage('persisted');
+
+export type Entry = {
+	label: string;
+	name: string;
+	value: string;
+};
+
+export type Sort = {
+	direction: SortDirection;
+	key: string;
+};
+
+type ListViewFilter = {
+	entries: Entry[];
+	filter: {
+		[key: string]: string;
+	};
+};
+
+type ListViewColumns = {
+	[key: string]: boolean;
+};
+
+export type InitialState = {
+	checkAll: boolean;
+	columns: ListViewColumns;
+	columnsFixed: string[];
+	filters: ListViewFilter;
+	id: string;
+	keywords: string;
+	page: number;
+	pageSize: number;
+	paginationDeltaOptions: number[];
+	selectedRows: number[];
+	sort: Sort;
+};
+
+const initialState: InitialState = {
+	checkAll: false,
+	columns: {},
+	columnsFixed: [],
+	filters: {
+		entries: [],
+		filter: {},
+	},
+	id: '',
+	keywords: '',
+	page: 1,
+	pageSize: PAGINATION_DELTA[0],
+	paginationDeltaOptions: PAGINATION_DELTA,
+	selectedRows: [],
+	sort: {direction: SortOption.ASC, key: ''},
+};
+
+export enum ListViewTypes {
+	SET_APPLY_FILTERS = 'SET_APPLY_FILTERS',
+	SET_CHECKED_ALL_ROWS = 'SET_CHECKED_ALL_ROWS',
+	SET_CHECKED_ROW = 'SET_CHECKED_ROW',
+	SET_CLEAR = 'SET_CLEAR',
+	SET_COLUMNS = 'SET_COLUMNS',
+	SET_FILTERS = 'SET_FILTERS',
+	SET_PAGE = 'SET_PAGE',
+	SET_PAGE_SIZE = 'SET_PAGE_SIZE',
+	SET_REMOVE_FILTER = 'SET_REMOVE_FILTER',
+	SET_SEARCH = 'SET_SEARCH',
+	SET_SORT = 'SET_SORT',
+}
+
+type ListViewPayload = {
+	[ListViewTypes.SET_APPLY_FILTERS]: boolean;
+	[ListViewTypes.SET_CHECKED_ALL_ROWS]: boolean;
+	[ListViewTypes.SET_CHECKED_ROW]: number | number[];
+	[ListViewTypes.SET_CLEAR]: null;
+	[ListViewTypes.SET_COLUMNS]: {columns: any};
+	[ListViewTypes.SET_FILTERS]: {filters?: any; pin?: any};
+	[ListViewTypes.SET_PAGE]: number;
+	[ListViewTypes.SET_PAGE_SIZE]: number;
+	[ListViewTypes.SET_REMOVE_FILTER]: string;
+	[ListViewTypes.SET_SEARCH]: string;
+	[ListViewTypes.SET_SORT]: Sort;
+};
+
+export type AppActions =
+	ActionMap<ListViewPayload>[keyof ActionMap<ListViewPayload>];
+
+export const ListViewContext = createContext<
+	[InitialState, (_param: AppActions) => void]
+>([initialState, () => null]);
+
+const reducer = (state: InitialState, action: AppActions) => {
+	switch (action.type) {
+		case ListViewTypes.SET_APPLY_FILTERS:
+			return {
+				...state,
+				appliedFilter: action.payload,
+			};
+
+		case ListViewTypes.SET_CHECKED_ROW:
+			const rowIds = action.payload;
+
+			let selectedRows = [...state.selectedRows];
+
+			if (Array.isArray(rowIds)) {
+				selectedRows = state.checkAll ? [] : rowIds;
+
+				state.checkAll = !state.checkAll;
+			}
+			else {
+				const rowAlreadyInserted = state.selectedRows.includes(
+					rowIds as number
+				);
+
+				rowAlreadyInserted
+					? (selectedRows = selectedRows.filter(
+							(row) => row !== rowIds
+						))
+					: (selectedRows = [...selectedRows, rowIds as number]);
+			}
+
+			return {
+				...state,
+				selectedRows,
+			};
+
+		case ListViewTypes.SET_CHECKED_ALL_ROWS:
+			return {
+				...state,
+				checkAll: action.payload,
+			};
+
+		case ListViewTypes.SET_CLEAR:
+			return {
+				...state,
+				filters: initialState.filters,
+				keywords: '',
+			};
+
+		case ListViewTypes.SET_COLUMNS:
+			const columns = action.payload.columns;
+			const storageColumnsName =
+				STORAGE_KEYS.LIST_VIEW_COLUMNS + state.id;
+
+			marketplaceStorage.setItem(
+				storageColumnsName,
+				JSON.stringify(columns),
+				CONSENT_TYPE.NECESSARY
+			);
+
+			return {
+				...state,
+				columns,
+			};
+
+		case ListViewTypes.SET_PAGE:
+			return {
+				...state,
+				page: action.payload,
+			};
+
+		case ListViewTypes.SET_PAGE_SIZE:
+			return {
+				...state,
+				page: 1,
+				pageSize: action.payload,
+			};
+
+		case ListViewTypes.SET_REMOVE_FILTER: {
+			const filterKey = action.payload;
+			const updatedFilters = {...state.filters};
+
+			delete updatedFilters.filter[filterKey];
+
+			const filterEntries = updatedFilters.entries.filter(
+				({name}) => name !== filterKey
+			);
+
+			const filters = {
+				entries: filterEntries,
+				filter: updatedFilters.filter,
+			};
+
+			return {
+				...state,
+				filters,
+			};
+		}
+
+		case ListViewTypes.SET_SEARCH:
+			return {
+				...state,
+				keywords: action.payload,
+				page: 1,
+			};
+
+		case ListViewTypes.SET_SORT:
+			return {
+				...state,
+				sort: action.payload,
+			};
+
+		case ListViewTypes.SET_FILTERS: {
+			return {
+				...state,
+				filters: action.payload.filters || state.filters,
+				page: 1,
+			};
+		}
+
+		default:
+			return state;
+	}
+};
+
+export type ListViewContextProviderProps = Partial<InitialState>;
+
+const ListViewContextProvider: React.FC<
+	ListViewContextProviderProps & {children: ReactNode; id: string}
+> = ({children, id, ...initialStateProps}) => {
+	const [columnsStorage] = useStorage<ListViewColumns>(
+		(STORAGE_KEYS.LIST_VIEW_COLUMNS + id) as STORAGE_KEYS,
+		{consentType: CONSENT_TYPE.NECESSARY, storageType: 'persisted'}
+	);
+
+	const [state, dispatch] = useReducer(reducer, {
+		...initialState,
+		...initialStateProps,
+		...(columnsStorage && {columns: columnsStorage}),
+		id,
+	});
+
+	return (
+		<ListViewContext.Provider value={[state, dispatch]}>
+			{children}
+		</ListViewContext.Provider>
+	);
+};
+
+export default ListViewContextProvider;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/hooks/useUpdateUrlParams.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/hooks/useUpdateUrlParams.ts
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useMemo} from 'react';
+import {useSearchParams} from 'react-router-dom';
+
+type Params = {
+	[key: string]: string | number | boolean;
+};
+
+const useUpdateUrlParams = () => {
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const page = searchParams.get('page');
+	const pageSize = searchParams.get('pageSize');
+
+	const serializedFilter = useMemo(() => {
+		return JSON.parse(searchParams.get('filter') as string) || '';
+	}, [searchParams]);
+
+	const filterSchemaKey = searchParams.get('filterSchema');
+
+	const updateParams = (param: Params) => {
+		setSearchParams(
+			new URLSearchParams({
+				...(serializedFilter && {
+					filter: JSON.stringify(serializedFilter),
+					filterSchema: filterSchemaKey,
+				}),
+				...(page && {page}),
+				...(pageSize && {page: 1, pageSize}),
+				...param,
+			})
+		);
+	};
+
+	return updateParams;
+};
+
+export default useUpdateUrlParams;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ListView/index.tsx
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ListView, {ListViewProps} from './ListView';
+
+export type {ListViewProps};
+
+export default ListView;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93295

## What is being fixed

The Liferay One admin dashboard pages need a shared, data-driven ListView
to render server-paginated tables with search, column filters, sorting,
and a results bar. This is the last foundation piece (F5) of the Admin UI;
without it the migrated Orders, Apps, Solutions, and Publishers pages have
no table infrastructure to build on.

## How it is being fixed

The ListView subtree is ported from the marketplace workspace: the ListView
container (data fetching through useFetch with URL-parameter-driven
pagination and sort), the management toolbar split into search, filters, and
results-bar components, the Table renderer, and the supporting
ListViewContext and useUpdateUrlParams hook. It consumes the services,
schema, and utilities already landed in the earlier foundation tasks. The
only deviation from the source is merging a duplicate import from
schema/filters to satisfy the source formatter.

## Why are there no tests?

This is a verbatim migration of frontend infrastructure from the marketplace
workspace, which carries no unit-test coverage, and the liferay-one custom
element has no JavaScript test harness configured. Verification is the
workspace Gradle build plus manual rendering of the admin pages that consume
the ListView.

---

**pr-check: PASS** — tested on `5c807d8fd552267e41e2fef4b9e140a546e9b258`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "5c807d8fd552267e41e2fef4b9e140a546e9b258"} -->
