### PR TITLE
LPD-91692 Migrate Marketplace Orders page frontend

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Orders/Orders.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Orders/Orders.tsx
@@ -3,10 +3,74 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useProperties} from '../../../context/PropertiesContext';
+import {useMemo} from 'react';
+
+import Page from '../../../components/Page';
+import i18n from '../../../i18n';
+import {AdministratorOrdersListView} from '../MPSummary/components/AdministratorOrdersListView';
+import InfoCard from '../MPSummary/components/InfoCard';
+import useOrderMetrics from '../MPSummary/hooks/useOrderMetrics';
 
 export default function Orders() {
-	const {accountId} = useProperties();
+	const {data: metrics} = useOrderMetrics('week');
 
-	return <div>{accountId}</div>;
+	const infoCards = useMemo(
+		() => [
+			{
+				growth: metrics?.growth ?? 0,
+				growthContext: `+${metrics?.lastPeriod ?? 0} this week `,
+				title: 'Total Orders',
+				value: metrics?.totalCount,
+			},
+			{
+				title: 'Monthly Orders',
+				value: metrics?.ordersThisMonth,
+			},
+			{
+				title: 'Current Year Orders',
+				value: metrics?.ordersThisYear,
+			},
+		],
+		[
+			metrics?.growth,
+			metrics?.lastPeriod,
+			metrics?.ordersThisMonth,
+			metrics?.ordersThisYear,
+			metrics?.totalCount,
+		]
+	);
+
+	return (
+		<>
+			<div className="d-flex flex-column">
+				<div
+					className="d-flex flex-wrap info-container"
+					style={{marginBottom: '1rem'}}
+				>
+					{infoCards.map((infoCard, index) => (
+						<InfoCard
+							{...infoCard}
+							key={index}
+							symbol="shopping-cart"
+							title={infoCard.title}
+							value={infoCard.value}
+						/>
+					))}
+				</div>
+			</div>
+
+			<Page
+				pageRendererProps={{className: 'border py-2'}}
+				title={i18n.translate('marketplace-orders')}
+			>
+				<AdministratorOrdersListView
+					isSortable
+					managementToolbarProps={{
+						searchVisible: true,
+						visible: true,
+					}}
+				/>
+			</Page>
+		</>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -7,6 +7,7 @@ import {Params} from 'react-router-dom';
 
 import SearchBuilder, {Operators} from '../core/SearchBuilder';
 import {MarketplaceCategory} from '../enums/Categories';
+import {OrderWorkflowStatusCode} from '../enums/Order';
 import {ProductType, ProductWorkflowStatusCode} from '../enums/Product';
 import i18n from '../i18n';
 
@@ -232,6 +233,64 @@ export const filterSchema: FilterSchemas = {
 			}),
 		],
 		name: 'administratorApps',
+	},
+	administratorOrders: {
+		fields: [
+			overrides(baseFilters.type, {
+				label: i18n.translate('app-type'),
+				name: 'orderTypeExternalReferenceCode',
+				resource:
+					'o/headless-commerce-admin-order/v1.0/order-types?pageSize=-1&sort=name:asc',
+				transformData: ({items = []}) =>
+					items.map(
+						({
+							externalReferenceCode,
+							name,
+						}: {
+							externalReferenceCode: string;
+							name: {[locale: string]: string};
+						}) => ({
+							label: name?.en_US ?? externalReferenceCode,
+							value: externalReferenceCode,
+						})
+					),
+				type: 'checkbox',
+			}),
+			overrides(baseFilters.status, {
+				label: i18n.translate('order-status'),
+				name: 'orderStatus',
+				options: [
+					{
+						label: i18n.translate('canceled'),
+						value: `${OrderWorkflowStatusCode.CANCELLED}`,
+					},
+					{
+						label: i18n.translate('completed'),
+						value: `${OrderWorkflowStatusCode.COMPLETED}`,
+					},
+					{
+						label: i18n.translate('in-progress'),
+						value: `${OrderWorkflowStatusCode.IN_PROGRESS}`,
+					},
+					{
+						label: i18n.translate('on-hold'),
+						value: `${OrderWorkflowStatusCode.ON_HOLD}`,
+					},
+					{
+						label: i18n.translate('pending'),
+						value: `${OrderWorkflowStatusCode.PENDING}`,
+					},
+					{
+						label: i18n.translate('processing'),
+						value: `${OrderWorkflowStatusCode.PROCESSING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'multiselect',
+			}),
+			baseFilters.dateCreated,
+		],
+		name: 'administratorOrders',
 	},
 	administratorSolutions: {
 		fields: [


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91692

## What is being fixed

The Admin dashboard's Orders page in liferay-one-custom-element is still a placeholder; the Marketplace Orders view from liferay-marketplace-workspace has not been ported to the new workspace.

## How it is being fixed

Ports the Marketplace Orders page from the marketplace workspace into liferay-one as a near-verbatim lift-and-shift. Replaces the Orders.tsx placeholder with the real page (order metrics InfoCard + AdministratorOrdersListView reused from the already-migrated Summary infrastructure) and registers the administratorOrders filter schema (app type, order status, date created). No backend or shared-infrastructure changes are introduced — it reuses the ListView, services, and Summary components already merged.

## Why are there no tests?

Mechanical lift-and-shift migration of the Marketplace admin UI into liferay-one. The original marketplace screens ship no automated coverage, and this ports the existing page verbatim without altering behavior; verification is manual against the running dashboard.

**pr-check: PASS** — tested on `987f1e08da5af863122652a048332de2abcf46ef`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "987f1e08da5af863122652a048332de2abcf46ef"} -->
