### PR TITLE
LPD-91717 Migrate Marketplace Publishers page

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Publishers/Publishers.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Publishers/Publishers.tsx
@@ -3,10 +3,99 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useProperties} from '../../../context/PropertiesContext';
+import Label from '@clayui/label';
+
+import ListView from '../../../components/ListView';
+import Page from '../../../components/Page';
+import SearchBuilder from '../../../core/SearchBuilder';
+import i18n from '../../../i18n';
+import {formatDate} from '../../../utils/date';
 
 export default function Publishers() {
-	const {accountId} = useProperties();
+	return (
+		<Page
+			pageRendererProps={{className: 'border py-2 rounded-lg'}}
+			title={i18n.translate('publishers')}
+		>
+			<ListView<Account>
+				defaultFilters={{
+					filter: `${SearchBuilder.eq('type', 'supplier')}`,
+				}}
+				id="administrator-publishers"
+				managementToolbarProps={{
+					filterSchema: 'administratorPublishers',
+					searchVisible: true,
+					visible: true,
+				}}
+				resource={`/o/headless-admin-user/v1.0/accounts?${new URLSearchParams({sort: 'dateCreated:desc'})}`}
+				tableProps={{
+					columns: [
+						{
+							id: 'name',
+							name: 'Name',
+							render: (name, {logoURL}) => (
+								<div>
+									<img
+										className="mr-2 rounded"
+										draggable={false}
+										height={42}
+										src={logoURL}
+										width={42}
+									/>
+									<span className="font-weight-bold">
+										{name}
+									</span>
+								</div>
+							),
+							sortable: true,
+						},
+						{
+							id: 'id',
+							name: 'ID',
+						},
+						{
+							id: 'externalReferenceCode',
+							name: 'External Reference Code',
+						},
+						{
+							id: 'customFields',
+							name: 'Type',
+							render: (customFields) => {
+								const type = customFields?.find(
+									({name}) => name === 'AccountType'
+								);
 
-	return <div>{accountId}</div>;
+								return (
+									type?.customValue.data ||
+									'Marketplace Publisher'
+								);
+							},
+							sortable: true,
+						},
+						{
+							id: 'dateCreated',
+							name: 'Created at',
+							render: (createDate) => formatDate(createDate),
+							sortable: true,
+						},
+						{
+							id: 'status',
+							name: 'Status',
+							render: (status) => {
+								return (
+									<Label
+										displayType={
+											status === 0 ? 'success' : 'warning'
+										}
+									>
+										{status === 0 ? 'Approved' : 'Pending'}
+									</Label>
+								);
+							},
+						},
+					],
+				}}
+			/>
+		</Page>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -6,6 +6,7 @@
 import {Params} from 'react-router-dom';
 
 import SearchBuilder, {Operators} from '../core/SearchBuilder';
+import {AccountType} from '../enums/Account';
 import {MarketplaceCategory} from '../enums/Categories';
 import {OrderWorkflowStatusCode} from '../enums/Order';
 import {ProductType, ProductWorkflowStatusCode} from '../enums/Product';
@@ -291,6 +292,24 @@ export const filterSchema: FilterSchemas = {
 			baseFilters.dateCreated,
 		],
 		name: 'administratorOrders',
+	},
+	administratorPublishers: {
+		fields: [
+			overrides(baseFilters.type, {
+				label: i18n.translate('account-type'),
+				name: 'customFields/AccountType',
+				options: [
+					AccountType.MARKETPLACE_DEVELOPER,
+					AccountType.STRATEGIC_PARTNER,
+					AccountType.TECHNOLOGY_PARTNER,
+				],
+				type: 'multiselect',
+			}),
+			overrides(baseFilters.dateCreated, {
+				name: 'dateCreated',
+			}),
+		],
+		name: 'administratorPublishers',
 	},
 	administratorSolutions: {
 		fields: [


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91717

## What is being fixed

The Admin dashboard's Publishers page in liferay-one-custom-element is still a placeholder; the Marketplace Publishers view has not been ported into the new workspace.

## How it is being fixed

Ports the Marketplace Publishers page from the marketplace workspace into liferay-one as a near-verbatim lift-and-shift. Replaces the Publishers.tsx placeholder with the real page and registers the administratorPublishers filter schema (account type, date created), reusing the shared ListView and services already merged. No backend or shared-infrastructure changes.

## Why are there no tests?

Mechanical lift-and-shift migration of the Marketplace admin UI into liferay-one. The original marketplace screens ship no automated coverage; this ports the existing page verbatim without altering behavior, and verification is manual.

**pr-check: PASS** — tested on `55b41f7e8f2e422f7b67e96bb9d449ba54882d21`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "55b41f7e8f2e422f7b67e96bb9d449ba54882d21"} -->
