### PR TITLE
LPD-91516 Add Trials New Trial and View Details modals

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/autocomplete": "^3.159.0",
 		"@clayui/button": "^3.159.0",
 		"@clayui/core": "^3.159.0",
 		"@clayui/date-picker": "^3.159.0",
@@ -11,6 +12,7 @@
 		"@clayui/loading-indicator": "^3.159.0",
 		"@clayui/management-toolbar": "^3.159.0",
 		"@clayui/modal": "^3.159.0",
+		"@clayui/multi-select": "^3.159.0",
 		"@clayui/pagination-bar": "^3.159.0",
 		"@clayui/table": "^3.159.0",
 		"@clayui/tooltip": "^3.159.0",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Select/Select.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Select/Select.scss
@@ -1,0 +1,15 @@
+.custom-select.disabled {
+	background-color: #f7f7f8 !important;
+	color: #282934;
+	opacity: 0.7;
+}
+
+.selection {
+	&-first-option {
+		color: #c9c9cf !important;
+	}
+}
+
+.select-empty-value {
+	color: #6b6c7e;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/Trials.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/Trials.tsx
@@ -23,7 +23,7 @@ const getAvailabilityResourceLabel = (availability: Availability) => {
 };
 
 export default function Trials() {
-	const {availability, isLoading, orderTableData, totalCount} =
+	const {availability, isLoading, mutate, orderTableData, totalCount} =
 		useTrialMetrics('week');
 
 	return (
@@ -124,7 +124,10 @@ export default function Trials() {
 				</div>
 
 				<div className="border d-flex flex-column justify-content-center p-6 rounded-lg">
-					<TrialTable items={orderTableData?.items || []} />
+					<TrialTable
+						items={orderTableData?.items || []}
+						revalidate={mutate}
+					/>
 				</div>
 			</div>
 		</Page>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
@@ -1,0 +1,239 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Autocomplete from '@clayui/autocomplete';
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
+import ClayMultiSelect from '@clayui/multi-select';
+import classNames from 'classnames';
+import {useState} from 'react';
+import {useForm} from 'react-hook-form';
+
+import BaseWrapper from '../../../../components/Input/base/BaseWrapper';
+import Select from '../../../../components/Select/Select';
+import {useOneContext} from '../../../../context/OneContext';
+import {OrderCustomFields} from '../../../../enums/Order';
+import useDebounce from '../../../../hooks/useDebounce';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import zodSchema, {z, zodResolver} from '../../../../schema/zod';
+import {getProductType} from '../../../../utils/productUtils';
+import ProductPurchaseSolutionTrial from '../../../ProductPurchase/services/ProductPurchasePreBuiltTrial';
+import {useTrialProducts} from './useTrialProducts';
+
+type NewTrialModalProps = {
+	onClose: () => void;
+	revalidate: () => void;
+};
+
+type MultiSelectValue = {
+	key: string;
+	label: string;
+	value: string;
+};
+
+const defaultEmailAddress = Liferay.ThemeDisplay.getUserEmailAddress();
+
+const NewTrialModal: React.FC<NewTrialModalProps> = ({onClose, revalidate}) => {
+	const {channel, myUserAccount} = useOneContext();
+
+	const {formState, handleSubmit, register, setValue, trigger, watch} =
+		useForm({
+			defaultValues: {
+				_refInviteEmailAddresses: [
+					{
+						key: defaultEmailAddress,
+						label: defaultEmailAddress,
+						value: defaultEmailAddress,
+					},
+				],
+				accountId: String(myUserAccount.accountBriefs[0].id),
+				consoleInviteEmailAddresses: [defaultEmailAddress],
+				product: undefined,
+				sendNotificationEmail: false,
+			},
+			mode: 'all',
+			reValidateMode: 'onChange',
+			resolver: zodResolver(zodSchema.trialForm),
+		});
+
+	const {isValid} = formState;
+
+	const _refInviteEmailAddresses = watch('_refInviteEmailAddresses');
+	const {accountBriefs = []} = myUserAccount;
+
+	const [search, setSearch] = useState('');
+	const [emailAddressText, setEmailAddressText] = useState('');
+	const debouncedSearch = useDebounce(search, 1500);
+
+	const {data: apps, isValidating} = useTrialProducts(
+		channel.id,
+		debouncedSearch
+	);
+
+	const onSubmit = async (form: z.infer<typeof zodSchema.trialForm>) => {
+		const product = form.product as DeliveryProduct;
+
+		const {isDXP} = getProductType(product);
+
+		if (isDXP) {
+			return Liferay.Util.openToast({
+				message: 'Not possible to create Trial for DXP Apps',
+				type: 'danger',
+			});
+		}
+
+		const account = accountBriefs.find(
+			({id}) => id === Number(form.accountId)
+		) as unknown as Account;
+
+		const productPurchase = new ProductPurchaseSolutionTrial(
+			account,
+			product
+		);
+
+		try {
+			await productPurchase.createOrder({
+				customFields: {
+					[OrderCustomFields.TRIAL_SETTINGS]: JSON.stringify({
+						consoleInviteEmailAddresses:
+							form.consoleInviteEmailAddresses,
+						sendNotificationEmail: form.sendNotificationEmail,
+					}),
+				},
+			} as Cart);
+
+			await revalidate();
+
+			setTimeout(() => revalidate(), 5000);
+
+			Liferay.Util.openToast({
+				message: 'Trial created successfully',
+				type: 'success',
+			});
+
+			onClose();
+		}
+		catch (error) {
+			console.error(error);
+
+			Liferay.Util.openToast({
+				message: i18n.translate('an-unexpected-error-occurred'),
+				type: 'danger',
+			});
+		}
+	};
+
+	return (
+		<div className="pb-8">
+			<BaseWrapper boldLabel label="Cloud App" required>
+				<Autocomplete
+					filterKey="productName"
+					items={apps?.items || []}
+					loadingState={isValidating ? 1 : 4}
+					messages={{
+						loading: 'Loading...',
+						notFound: 'No results found',
+					}}
+					onChange={setSearch}
+					placeholder="Search for the app name"
+					value={search}
+				>
+					{(product) => (
+						<Autocomplete.Item
+							{...({} as any)}
+							disabled
+							key={product.productId}
+							onClick={() => {
+								setValue('product', product as any);
+
+								trigger();
+							}}
+						>
+							{product.name}
+						</Autocomplete.Item>
+					)}
+				</Autocomplete>
+			</BaseWrapper>
+
+			<Select
+				{...register('accountId')}
+				boldLabel
+				defaultOptionLabel={i18n.translate('account-selection')}
+				helpText="Account where this Order will be registered."
+				label={i18n.translate('account-selection')}
+				options={accountBriefs
+					.sort((accountA, accountB) =>
+						accountA.name.localeCompare(accountB.name)
+					)
+					.map((account) => ({
+						key: account.id.toString(),
+						name: account.name,
+					}))}
+				required
+			/>
+
+			<ClayInput.Group
+				className={classNames('my-4', {
+					'has-error':
+						formState.errors.consoleInviteEmailAddresses?.length,
+				})}
+			>
+				<div className="d-flex flex-column">
+					<label htmlFor="allowed-email-domains">
+						Invite Members
+					</label>
+
+					<small>
+						Everyone with an email address at these list will be
+						invited to the Cloud Environment.
+					</small>
+				</div>
+
+				<ClayInput.Group>
+					<ClayInput.GroupItem prepend>
+						<ClayMultiSelect
+							items={_refInviteEmailAddresses}
+							onChange={setEmailAddressText}
+							onItemsChange={(values: MultiSelectValue[]) => {
+								setValue(
+									'_refInviteEmailAddresses',
+									values as any
+								);
+
+								setValue(
+									'consoleInviteEmailAddresses',
+									values.map(({value}) => value) as any
+								);
+							}}
+							value={emailAddressText}
+						/>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+
+				<ClayForm.FeedbackItem>
+					{formState.errors.consoleInviteEmailAddresses?.[0]?.message}
+				</ClayForm.FeedbackItem>
+			</ClayInput.Group>
+
+			<ClayToggle
+				label="Send Notification Email"
+				onToggle={(value) => setValue('sendNotificationEmail', value)}
+				toggled={watch('sendNotificationEmail')}
+			/>
+
+			<div className="d-flex justify-content-end">
+				<ClayButton
+					disabled={!isValid}
+					onClick={handleSubmit(onSubmit)}
+				>
+					Create Trial
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default NewTrialModal;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/TrialDetailsModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/TrialDetailsModal.tsx
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLabel from '@clayui/label';
+import {Status} from '@clayui/modal/lib/types';
+import {formatDistance} from 'date-fns';
+import {z} from 'zod';
+
+import QATable from '../../../../components/QATable';
+import {OrderCustomFields} from '../../../../enums/Order';
+import i18n from '../../../../i18n';
+import zodSchema from '../../../../schema/zod';
+import {safeJSONParse} from '../../../../utils/util';
+
+type TrialDetailsProps = {
+	order: Order;
+};
+
+export const ORDER_STATUS_LABEL = {
+	completed: 'success',
+	pending: 'info',
+	processing: 'secondary',
+};
+
+const getDateOrDefault = (customField: string) =>
+	customField
+		? formatDistance(new Date(customField), Date.now(), {addSuffix: true})
+		: 'N/A';
+
+type TrialFormSchema = z.infer<typeof zodSchema.trialForm>;
+
+const TrialDetails: React.FC<TrialDetailsProps> = ({order}) => {
+	const customFields = order?.customFields || {};
+
+	const trialSettings = safeJSONParse<
+		Pick<
+			TrialFormSchema,
+			'consoleInviteEmailAddresses' | 'sendNotificationEmail'
+		>
+	>(customFields[OrderCustomFields.TRIAL_SETTINGS], {
+		consoleInviteEmailAddresses: [],
+		sendNotificationEmail: true,
+	});
+
+	const trialError = customFields[OrderCustomFields.TRIAL_ERROR];
+
+	return (
+		<QATable
+			items={[
+				{
+					title: i18n.translate('order-id'),
+					value: order?.id,
+				},
+				{
+					title: i18n.translate('app-name'),
+					value: order?.orderItems?.[0].name?.en_US,
+				},
+				{
+					title: i18n.translate('trial-url'),
+					value:
+						customFields[OrderCustomFields.TRIAL_VIRTUAL_HOST] ||
+						'N/A',
+				},
+				{
+					title: i18n.translate('trial-status'),
+					value: (
+						<ClayLabel
+							className="text-nowrap"
+							displayType={
+								ORDER_STATUS_LABEL[
+									order.orderStatusInfo
+										?.label as keyof typeof ORDER_STATUS_LABEL
+								] as Status
+							}
+						>
+							{order.orderStatusInfo?.label_i18n}
+						</ClayLabel>
+					),
+				},
+				{
+					title: i18n.translate('created-at'),
+					value: getDateOrDefault(order?.createDate as string),
+				},
+				{
+					title: i18n.translate('start-date'),
+					value: getDateOrDefault(
+						customFields[OrderCustomFields.TRIAL_START_DATE]
+					),
+				},
+				{
+					title: i18n.translate('trial-end-date'),
+					value: getDateOrDefault(
+						customFields[OrderCustomFields.TRIAL_END_DATE]
+					),
+				},
+				{
+					title: 'Console Invited Email Addresses',
+					value: trialSettings.consoleInviteEmailAddresses?.join(
+						', \n'
+					),
+				},
+				{
+					title: 'Send Notification Email',
+					value: i18n.translate(
+						trialSettings.sendNotificationEmail ? 'yes' : 'no'
+					),
+				},
+				{
+					title: 'Error',
+					value: (
+						<span
+							className="cursor-pointer text-secondary"
+							onClick={() =>
+								alert(
+									JSON.stringify(
+										safeJSONParse(trialError, {}),
+										null,
+										2
+									)
+								)
+							}
+						>
+							{i18n.translate('details')}
+						</span>
+					),
+					visible: !!trialError,
+				},
+			]}
+		/>
+	);
+};
+
+export default TrialDetails;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/TrialTable.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/TrialTable.tsx
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
+import DropDown from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import {Status} from '@clayui/modal/lib/types';
 import {formatDistance} from 'date-fns';
@@ -11,138 +14,272 @@ import {DashboardPage} from '../../../../components/DashBoardPage/DashboardPage'
 import {DashboardEmptyTable} from '../../../../components/DashboardTable/DashboardEmptyTable';
 import Loading from '../../../../components/Loading';
 import Table from '../../../../components/Table/Table';
-import {OrderWorkflowStatusCode} from '../../../../enums/Order';
+import {
+	OrderCustomFields,
+	OrderWorkflowStatusCode,
+} from '../../../../enums/Order';
+import {useConfirmationModal} from '../../../../hooks/useConfirmationModal';
+import useModalContext from '../../../../hooks/useModalContext';
 import i18n from '../../../../i18n';
-
-const ORDER_STATUS_LABEL = {
-	Approved: 'success',
-	Completed: 'success',
-	Open: 'secondary',
-	Pending: 'warning',
-};
+import trialOAuth2 from '../../../../services/oauth/Trial';
+import HeadlessCommerceAdminOrder from '../../../../services/rest/HeadlessCommerceAdminOrder';
+import NewTrialModal from './NewTrialModal';
+import TrialDetailsModal, {ORDER_STATUS_LABEL} from './TrialDetailsModal';
 
 type TrialTableProps = {
 	items: Order[];
+	revalidate: () => void;
 };
 
-const TrialTable: React.FC<TrialTableProps> = ({items}) => (
-	<DashboardPage
-		messages={{description: '', title: i18n.translate('trials')}}
-	>
-		{items.length ? (
-			<Table
-				className="mt-3"
-				columns={[
-					{
-						key: 'id',
-						render: (id) => (
-							<span className="font-weight-bold">{id}</span>
-						),
-						title: i18n.translate('id'),
-					},
-					{
-						key: 'orderItems',
-						render: (orderItems) => orderItems[0]?.name.en_US,
-						title: i18n.translate('product'),
-					},
-					{
-						key: 'account',
-						render: (account) => account?.name,
-						title: i18n.translate('user-account'),
-					},
-					{
-						key: 'orderStatusInfo',
-						render: (orderStatusInfo) => (
-							<div className="align-items-center d-flex">
-								<ClayLabel
-									className="text-nowrap"
-									displayType={
-										ORDER_STATUS_LABEL[
-											orderStatusInfo?.label as keyof typeof ORDER_STATUS_LABEL
-										] as Status
+type DropDownItems = {
+	id: number;
+	name: string;
+	onClick: (item?: Order) => void;
+};
+
+const safeRunner = async (promise: any) => {
+	try {
+		await promise;
+	}
+	catch {}
+};
+
+const TrialTable: React.FC<TrialTableProps> = ({items, revalidate}) => {
+	const modalContext = useModalContext();
+	const confirmationModal = useConfirmationModal();
+
+	const onDeleteTrial = async (order: Order) => {
+		await safeRunner(HeadlessCommerceAdminOrder.deleteOrder(order.id));
+		await safeRunner(trialOAuth2.deleteTrial(order.id));
+
+		await revalidate();
+	};
+
+	const onClickDetails = (order: Order) => {
+		modalContext.onOpenModal({
+			body: <TrialDetailsModal order={order} />,
+			center: true,
+			footer: [
+				null,
+				null,
+				<ClayButton
+					aria-label="close"
+					displayType="secondary"
+					key={0}
+					onClick={modalContext.onClose}
+					size="sm"
+				>
+					{i18n.translate('close')}
+				</ClayButton>,
+			],
+			header: i18n.translate('trial-details'),
+			size: 'md',
+		});
+	};
+
+	const itemsDropdown = [
+		{
+			name: i18n.translate('view-details'),
+			onClick: onClickDetails,
+		},
+		{
+			name: i18n.translate('go-to-trial'),
+			onClick: (order: Order) =>
+				window.open(
+					`https://${
+						order?.customFields?.[
+							OrderCustomFields.TRIAL_VIRTUAL_HOST
+						]
+					}`
+				),
+		},
+		{
+			name: i18n.translate('delete'),
+			onClick: (order: Order) => {
+				confirmationModal.openModal({
+					body: (
+						<p>
+							{i18n.sub(
+								'x-will-be-deleted-and-this-action-cant-be-undone-are-you-sure-you-want-to-delete-it',
+								`Order ${order.id}`
+							)}
+						</p>
+					),
+					header: i18n.translate('confirm-deletion'),
+					onConfirm: () => onDeleteTrial(order),
+				});
+			},
+		},
+	];
+
+	return (
+		<DashboardPage
+			buttonMessage={i18n.translate('new-trial')}
+			messages={{description: '', title: i18n.translate('trials')}}
+			onButtonClick={() =>
+				modalContext.onOpenModal({
+					body: (
+						<NewTrialModal
+							onClose={modalContext.onClose}
+							revalidate={revalidate}
+						/>
+					),
+					header: i18n.translate('new-trial'),
+				})
+			}
+		>
+			{items.length ? (
+				<Table
+					className="mt-3"
+					columns={[
+						{
+							key: 'id',
+							render: (id) => (
+								<span className="font-weight-bold">{id}</span>
+							),
+							title: i18n.translate('id'),
+						},
+						{
+							key: 'orderItems',
+							render: (orderItems) => orderItems[0]?.name.en_US,
+							title: i18n.translate('product'),
+						},
+						{
+							key: 'account',
+							render: (account) => account?.name,
+							title: i18n.translate('user-account'),
+						},
+						{
+							key: 'orderStatusInfo',
+							render: (orderStatusInfo) => (
+								<div className="align-items-center d-flex">
+									<ClayLabel
+										className="text-nowrap"
+										displayType={
+											ORDER_STATUS_LABEL[
+												orderStatusInfo?.label as keyof typeof ORDER_STATUS_LABEL
+											] as Status
+										}
+									>
+										{orderStatusInfo?.label_i18n}
+									</ClayLabel>
+
+									{[
+										OrderWorkflowStatusCode.ON_HOLD,
+										OrderWorkflowStatusCode.PROCESSING,
+									].includes(orderStatusInfo.code) && (
+										<Loading
+											displayType="primary"
+											shape="circle"
+											size="sm"
+										/>
+									)}
+								</div>
+							),
+							title: i18n.translate('trial-status'),
+						},
+						{
+							key: 'createDate',
+							render: (createDate) => (
+								<span className="ml-2 text-capitalize text-nowrap">
+									{createDate &&
+										formatDistance(
+											new Date(createDate),
+											Date.now(),
+											{addSuffix: true}
+										)}
+								</span>
+							),
+							title: i18n.translate('created-at'),
+						},
+						{
+							key: 'customFields',
+							render: (customFields) => (
+								<span className="ml-2 text-capitalize text-nowrap">
+									{customFields['trial-start-date'] &&
+										formatDistance(
+											new Date(
+												customFields['trial-start-date']
+											),
+											Date.now(),
+											{addSuffix: true}
+										)}
+								</span>
+							),
+							title: i18n.translate('start-date'),
+						},
+						{
+							key: 'customFields',
+							render: (customFields) => (
+								<span className="ml-2 text-capitalize text-nowrap">
+									{customFields['trial-end-date'] &&
+										formatDistance(
+											new Date(
+												customFields['trial-end-date']
+											),
+											Date.now(),
+											{addSuffix: true}
+										)}
+								</span>
+							),
+							title: i18n.translate('expiration-date'),
+						},
+						{
+							align: 'right',
+							key: 'accountId',
+							render: (_, order) => (
+								<DropDown
+									closeOnClick
+									filterKey="name"
+									trigger={
+										<ClayButton
+											aria-label="Action Dropdown"
+											displayType="unstyled"
+										>
+											<ClayIcon symbol="ellipsis-v" />
+										</ClayButton>
 									}
 								>
-									{orderStatusInfo?.label_i18n}
-								</ClayLabel>
+									<DropDown.ItemList items={itemsDropdown}>
+										{(dropDownItem: unknown) => {
+											const item =
+												dropDownItem as DropDownItems;
 
-								{[
-									OrderWorkflowStatusCode.ON_HOLD,
-									OrderWorkflowStatusCode.PROCESSING,
-								].includes(orderStatusInfo.code) && (
-									<Loading
-										displayType="primary"
-										shape="circle"
-										size="sm"
-									/>
-								)}
-							</div>
-						),
-						title: i18n.translate('trial-status'),
-					},
-					{
-						key: 'createDate',
-						render: (createDate) => (
-							<span className="ml-2 text-capitalize text-nowrap">
-								{createDate &&
-									formatDistance(
-										new Date(createDate),
-										Date.now(),
-										{addSuffix: true}
-									)}
-							</span>
-						),
-						title: i18n.translate('created-at'),
-					},
-					{
-						key: 'customFields',
-						render: (customFields) => (
-							<span className="ml-2 text-capitalize text-nowrap">
-								{customFields['trial-start-date'] &&
-									formatDistance(
-										new Date(
-											customFields['trial-start-date']
-										),
-										Date.now(),
-										{addSuffix: true}
-									)}
-							</span>
-						),
-						title: i18n.translate('start-date'),
-					},
-					{
-						key: 'customFields',
-						render: (customFields) => (
-							<span className="ml-2 text-capitalize text-nowrap">
-								{customFields['trial-end-date'] &&
-									formatDistance(
-										new Date(
-											customFields['trial-end-date']
-										),
-										Date.now(),
-										{addSuffix: true}
-									)}
-							</span>
-						),
-						title: i18n.translate('expiration-date'),
-					},
-				]}
-				rows={items}
-			/>
-		) : (
-			<div className="mt-3">
-				<DashboardEmptyTable
-					description1={i18n.translate(
-						'purchase-and-install-new-apps-and-they-will-show-up-here'
-					)}
-					description2={i18n.translate(
-						'click-on-browse-catalog-to-start'
-					)}
-					icon="grid"
-					title={i18n.translate('no-orders-yet')}
+											return (
+												<DropDown.Item
+													key={item.name}
+													onClick={() =>
+														item.onClick(order)
+													}
+												>
+													{item?.name}
+												</DropDown.Item>
+											);
+										}}
+									</DropDown.ItemList>
+								</DropDown>
+							),
+							title: '',
+						},
+					]}
+					rows={items}
 				/>
-			</div>
-		)}
-	</DashboardPage>
-);
+			) : (
+				<div className="mt-3">
+					<DashboardEmptyTable
+						description1={i18n.translate(
+							'purchase-and-install-new-apps-and-they-will-show-up-here'
+						)}
+						description2={i18n.translate(
+							'click-on-browse-catalog-to-start'
+						)}
+						icon="grid"
+						title={i18n.translate('no-orders-yet')}
+					/>
+				</div>
+			)}
+		</DashboardPage>
+	);
+};
 
 export default TrialTable;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/useTrialProducts.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/useTrialProducts.ts
@@ -1,0 +1,24 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+import SearchBuilder from '../../../../core/SearchBuilder';
+import HeadlessCommerceDeliveryCatalog from '../../../../services/rest/HeadlessCommerceDeliveryCatalog';
+
+export function useTrialProducts(channelId: number, name: string) {
+	return useSWR(`administrator-dashboard/trial/products/${name}`, () =>
+		HeadlessCommerceDeliveryCatalog.getProductsByChannelId(
+			channelId,
+			new URLSearchParams({
+				'accountId': '-1',
+				'filter': SearchBuilder.contains('name', name),
+				'nestedFields': 'productSpecifications,skus',
+				'pageSize': '10',
+				'skus.accountId': '-1',
+			})
+		)
+	);
+}

--- a/workspaces/liferay-one-workspace/yarn.lock
+++ b/workspaces/liferay-one-workspace/yarn.lock
@@ -329,6 +329,20 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
+"@clayui/autocomplete@^3.159.0", "@clayui/autocomplete@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/autocomplete/-/autocomplete-3.164.0.tgz#7d7b293bf3244a499118016c0aaa50fa3caaae11"
+  integrity sha512-AB1TYHYjAa7D/kmWIOmLx7Upnf4jhpnl3Q406keaiF0fUS2N/UP4et3+Q1VHVGrYq8H71/PkWUCXR+PXy89xFA==
+  dependencies:
+    "@clayui/core" "^3.164.0"
+    "@clayui/data-provider" "^3.164.0"
+    "@clayui/drop-down" "^3.164.0"
+    "@clayui/form" "^3.164.0"
+    "@clayui/loading-indicator" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    classnames "2.3.1"
+    fuzzy "^0.1.3"
+
 "@clayui/button@^3.159.0", "@clayui/button@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/button/-/button-3.163.0.tgz#4d73e8b8cfd5e2ee22d107b47caf52983b70f5ce"
@@ -336,6 +350,16 @@
   dependencies:
     "@clayui/icon" "^3.163.0"
     "@clayui/loading-indicator" "^3.163.0"
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/button@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/button/-/button-3.164.0.tgz#5e284d8cf6fbdc1578a19e82a8d86245743e80dd"
+  integrity sha512-c/aKdYsLHSKE6Wtd6/41n+ePZDb/kreveYevCgwXra6PlGtpOPOgY3JBY/5xHxHaWjJ3cZRB3GmTg1ums2E6Fg==
+  dependencies:
+    "@clayui/icon" "^3.164.0"
+    "@clayui/loading-indicator" "^3.164.0"
     classnames "2.3.1"
     warning "^4.0.3"
 
@@ -366,6 +390,33 @@
     react-transition-group "^4.4.1"
     warning "^4.0.3"
 
+"@clayui/core@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/core/-/core-3.164.0.tgz#8e44ccf96de009288a5e367b7bc7f117874d88d4"
+  integrity sha512-s6gmbHjn6/5/BVRMZXy8coEUO+PHOerRFNPefDGq157IlviIAjN0PhesI3j/jvupLVPdsiCrZKLZvWjOy3G4uA==
+  dependencies:
+    "@clayui/button" "^3.164.0"
+    "@clayui/data-provider" "^3.164.0"
+    "@clayui/form" "^3.164.0"
+    "@clayui/icon" "^3.164.0"
+    "@clayui/label" "^3.164.0"
+    "@clayui/layout" "^3.164.0"
+    "@clayui/link" "^3.164.0"
+    "@clayui/loading-indicator" "^3.164.0"
+    "@clayui/modal" "^3.164.0"
+    "@clayui/provider" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    "@clayui/table" "^3.164.0"
+    "@clayui/tooltip" "^3.164.0"
+    "@tanstack/react-virtual" "3.0.0-beta.54"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    fuzzy "^0.1.3"
+    react-dnd "11.1.1"
+    react-dnd-html5-backend "11.1.1"
+    react-transition-group "^4.4.1"
+    warning "^4.0.3"
+
 "@clayui/data-provider@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/data-provider/-/data-provider-3.163.0.tgz#10ec501259b65fc61f8db11b9753b41af30ebe36"
@@ -373,6 +424,16 @@
   dependencies:
     "@clayui/provider" "^3.163.0"
     "@clayui/shared" "^3.163.0"
+    fast-json-stable-stringify "^2.1.0"
+    warning "^4.0.3"
+
+"@clayui/data-provider@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/data-provider/-/data-provider-3.164.0.tgz#1f0d72dc2625255908f2ae937590913810f92de5"
+  integrity sha512-xdbwCWgvqJsAv9l7zPqzT19LCsF1pmgiN801j6o6+/uX611rwssIA9SGr/XmU+hdZ5P/gOUYbIuKyEx8nu/wlw==
+  dependencies:
+    "@clayui/provider" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
     fast-json-stable-stringify "^2.1.0"
     warning "^4.0.3"
 
@@ -406,6 +467,21 @@
     react-transition-group "^4.4.1"
     warning "^4.0.3"
 
+"@clayui/drop-down@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.164.0.tgz#a6b44b8cc3567e5d93f3def25273e1f2d52a08ad"
+  integrity sha512-6puLq4V8vUX47+mVXsH0S/3JuI5mKIIMHEpMxFxuzn9Z+SwrpQfJqOtwqVub4jEGN7RctmuoDN5Q3N4zk8a2Bw==
+  dependencies:
+    "@clayui/button" "^3.164.0"
+    "@clayui/core" "^3.164.0"
+    "@clayui/form" "^3.164.0"
+    "@clayui/icon" "^3.164.0"
+    "@clayui/link" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    classnames "2.3.1"
+    react-transition-group "^4.4.1"
+    warning "^4.0.3"
+
 "@clayui/empty-state@^3.159.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/empty-state/-/empty-state-3.163.0.tgz#a3f76ed34d5c1da18aeaed866e3fc716a13baaa7"
@@ -423,10 +499,28 @@
     "@clayui/shared" "^3.163.0"
     classnames "2.3.1"
 
+"@clayui/form@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/form/-/form-3.164.0.tgz#01e07db19b458a3ce4fba1cede405b9fc1073065"
+  integrity sha512-9EsSUPhP7g2hp8EWyFle0G8mxRD5QnPu0zd//r/KVvvzTQEzwR6588MOyXgU440Is5lhNSo+BNQccCjas4Dzfg==
+  dependencies:
+    "@clayui/button" "^3.164.0"
+    "@clayui/icon" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    classnames "2.3.1"
+
 "@clayui/icon@^3.159.0", "@clayui/icon@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.163.0.tgz#5fb90f3a58cce3186f3157388745d376a979fd84"
   integrity sha512-0E3Nba4gXGYFcKDG1gs8j4AvadFAlBCxj8LFkJr8rwV3CMZFesZBSw397XoQoK8lJuJ3cNp+WYdHggAVS88ong==
+  dependencies:
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/icon@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.164.0.tgz#97dcebb106591cc305b9fd56318819798b899d3d"
+  integrity sha512-gqR3OUq6mWNLlUwFjXCPLF/d6Nq6wMik9yliPmPjq3/kJHipPVOf1aGXLGILYPGGz+sO/DgL5Jf6mBPlphjaPw==
   dependencies:
     classnames "2.3.1"
     warning "^4.0.3"
@@ -440,10 +534,27 @@
     "@clayui/link" "^3.163.0"
     classnames "2.3.1"
 
+"@clayui/label@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/label/-/label-3.164.0.tgz#3b0f8a3327d1a24f8934b6ad9b8929570bb13e04"
+  integrity sha512-VT8XZBWeOFXED/p79FprCTHoJqfB57w2RUHOcKLsdtmiGaF/aD5e1GHueLxyn6xaDIOHr4vHoYt1D/5y+1I8IA==
+  dependencies:
+    "@clayui/icon" "^3.164.0"
+    "@clayui/link" "^3.164.0"
+    classnames "2.3.1"
+
 "@clayui/layout@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/layout/-/layout-3.163.0.tgz#50de6d85a173c37fbf4d5335bfad37e1c38cc66e"
   integrity sha512-Dzw+j8c2H7mfmrqtxuP4tnThmACItXlAiBDWSytvkZSrNDOyVsYT/CQvkfRXNJQLe2lq5CZz+zF8lFaQw8PDzg==
+  dependencies:
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/layout@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/layout/-/layout-3.164.0.tgz#4ab35aa235e183bfe195d02f2852d9ac29ec8a2f"
+  integrity sha512-461Z0nxG/ORGjrEJvpMP+66yepWMG0HzPl6H914r2qSbh1dMfk5F4aMwEHbeVLpd15RvZRsPcdtSn7b6A8aHCg==
   dependencies:
     classnames "2.3.1"
     warning "^4.0.3"
@@ -455,10 +566,24 @@
   dependencies:
     classnames "2.3.1"
 
+"@clayui/link@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.164.0.tgz#74053f9222882f87be6101c601f1827b9a182629"
+  integrity sha512-UgNfL5Ctje1K8wb//fw8XPI+JXNNbhiBSUu4nbFf8/PTCZFAXjbzXHUscRYG14tWJorpx8Fk8jTZvcw3Q1jDvQ==
+  dependencies:
+    classnames "2.3.1"
+
 "@clayui/loading-indicator@^3.159.0", "@clayui/loading-indicator@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.163.0.tgz#e3117a02e6391f606934cd2ab402816ebdc288be"
   integrity sha512-qAxfqLcKfiU35sHJWQkstt4ajRdHZwM1jFLQhoMFUw98Ktu//8t1akrLaP+SWP2KMPgQkj3S6bK1yiiLiLbHPA==
+  dependencies:
+    classnames "2.3.1"
+
+"@clayui/loading-indicator@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.164.0.tgz#779c654956bdd35ae4c364887829f2f6ab0ef587"
+  integrity sha512-vXoxKOngtn52no9a0wKGR3KTdUhZMvOPxCWie9hnfw4D4VCEDHm7KTiip1jLaUStJxcMjTClrOlkeYpfVMH68A==
   dependencies:
     classnames "2.3.1"
 
@@ -481,6 +606,34 @@
     aria-hidden "^1.2.2"
     classnames "2.3.1"
     warning "^4.0.3"
+
+"@clayui/modal@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/modal/-/modal-3.164.0.tgz#afa83cd2f10d2abb0303fa1c519b36f19e26a652"
+  integrity sha512-RHOJ8CrO+oqNUEpywfkyRnOu9tdpDZ3KbY24Mq9JjVSoW5OHfXWVbd0kSMIi+qpJyLS8HeZ/qwz+zkYkB4s97Q==
+  dependencies:
+    "@clayui/button" "^3.164.0"
+    "@clayui/icon" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    warning "^4.0.3"
+
+"@clayui/multi-select@^3.159.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/multi-select/-/multi-select-3.164.0.tgz#424fcb6a497e8e4b9e915d416bc8916694908c2b"
+  integrity sha512-he+A2O1PIXqH9wn1f8lFv7fJ1vdBiZAhxVjMEwLZZycUlu72W/tSuM8gCLyCuUJTP9z62j31bbvhJofdSL3S3w==
+  dependencies:
+    "@clayui/autocomplete" "^3.164.0"
+    "@clayui/button" "^3.164.0"
+    "@clayui/drop-down" "^3.164.0"
+    "@clayui/form" "^3.164.0"
+    "@clayui/icon" "^3.164.0"
+    "@clayui/label" "^3.164.0"
+    "@clayui/loading-indicator" "^3.164.0"
+    "@clayui/shared" "^3.164.0"
+    classnames "2.3.1"
+    fuzzy "^0.1.3"
 
 "@clayui/pagination-bar@^3.159.0":
   version "3.163.0"
@@ -515,6 +668,13 @@
   dependencies:
     "@clayui/icon" "^3.163.0"
 
+"@clayui/provider@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/provider/-/provider-3.164.0.tgz#962293d85069ae0e502f9347a701ad38b1491402"
+  integrity sha512-oABupPw2k+DZVs0OBwYHhx9Dp3pF2u6ptPJNDQS7CdlXCTKF7V7BhtcoRIk1MxZIilXwsTt4ExIGi6ebgH6Q1Q==
+  dependencies:
+    "@clayui/icon" "^3.164.0"
+
 "@clayui/shared@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.163.0.tgz#ff7a4ebc3274930bea8c19670a434fc1a286dc31"
@@ -528,10 +688,30 @@
     dom-align "^1.12.2"
     warning "^4.0.3"
 
+"@clayui/shared@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.164.0.tgz#f99feb8e2bb09719035f5f0097a54795246b46e1"
+  integrity sha512-J9DQqoUxn9bgcosLhUvFChFC4by8X/nJpbgf4/RXFMVXld8Tw8ZYvSDIueUsc5MYomhSHvyv2VA1KEZBuP9W+Q==
+  dependencies:
+    "@clayui/button" "^3.164.0"
+    "@clayui/link" "^3.164.0"
+    "@clayui/provider" "^3.164.0"
+    aria-hidden "^1.2.2"
+    classnames "2.3.1"
+    dom-align "^1.12.2"
+    warning "^4.0.3"
+
 "@clayui/table@^3.159.0", "@clayui/table@^3.163.0":
   version "3.163.0"
   resolved "https://registry.yarnpkg.com/@clayui/table/-/table-3.163.0.tgz#f2f8057047fdea2f071ff17ea788d0373e7a7822"
   integrity sha512-igiVsk4mSwNFWp2t3uakXs+V/uO1CPpBJJHivpZLSiyNf6owp4z2h8BTn1IW5Fy6DsXLySDAmqvVcq8qcoSK6Q==
+  dependencies:
+    classnames "2.3.1"
+
+"@clayui/table@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/table/-/table-3.164.0.tgz#9fd48bf1dadb63202fb17bc99fda3504461da064"
+  integrity sha512-oNRlEpSpans2fawq2Qi5vKO3CVvQ8eb5EoSz1U/o6gb2tFiqVwsOwa8fBs2Ix3q20Aozyc+OyBl8mXtyvYOoaQ==
   dependencies:
     classnames "2.3.1"
 
@@ -552,6 +732,16 @@
   integrity sha512-eBK5sIexywkZtJKiwWp6lpJ5NgispjGa35O4oFkSBSQKdARl0Vh2m1SIJIK23nthJGCYYCXEpYrBzTSbbiAI5Q==
   dependencies:
     "@clayui/shared" "^3.163.0"
+    classnames "2.3.1"
+    dom-align "^1.12.2"
+    warning "^4.0.3"
+
+"@clayui/tooltip@^3.164.0":
+  version "3.164.0"
+  resolved "https://registry.yarnpkg.com/@clayui/tooltip/-/tooltip-3.164.0.tgz#07a6b53fbb8d2c0ff638fca48843c0c019906c5d"
+  integrity sha512-6VPn6tXPoCrL4zX4+LjFB80rmT1YmWuuVkrHwB5gq/99+SL45SWDUANirY+Ol0X4t4SBJ7sJ/85VfCLNJrMTDw==
+  dependencies:
+    "@clayui/shared" "^3.164.0"
     classnames "2.3.1"
     dom-align "^1.12.2"
     warning "^4.0.3"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91516

## What is being fixed

The migrated Trials page lists trials but cannot create a new trial or view trial details — the New Trial and View Details modals have not been ported. Separately, the Select component merged with ssa-form-infra (LPD-88257) was missing its Select.scss, leaving a broken style import that these modals are the first to exercise.

## How it is being fixed

Ports the Trials New Trial and View Details modals as a near-verbatim lift-and-shift: NewTrialModal, TrialDetailsModal, the modal-enabled TrialTable (row actions: view details, go to trial, delete) and the useTrialProducts hook, wired into the Trials page. Adds @clayui/autocomplete and @clayui/multi-select used by the New Trial form. Also includes the missing Select.scss for the shared Select component (a gap in the already-merged ssa-form-infra) that these modals first consume.

## Why are there no tests?

Mechanical lift-and-shift migration; the original marketplace modals ship no automated coverage and this ports them verbatim. Verification is manual via the Trials dashboard.

**pr-check: PASS** — tested on `48d2054b0539b743e1e7c71b6865a9dcfa9f2ccd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "48d2054b0539b743e1e7c71b6865a9dcfa9f2ccd"} -->
