### PR TITLE
LPD-89821 Migrate Marketplace Finance Orders and Payments pages

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/BackLink.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/BackLink.tsx
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import {ReactNode} from 'react';
+import {Link} from 'react-router-dom';
+
+type BackLinkProps = {
+	children: ReactNode;
+	path?: string;
+};
+
+export default function BackLink({children, path = '..'}: BackLinkProps) {
+	return (
+		<Link className="align-items-center d-flex text-dark" to={path}>
+			<ClayIcon
+				aria-label="arrow left"
+				className="mr-2"
+				symbol="order-arrow-left"
+			/>
+
+			<span className="h5 mt-1">{children}</span>
+		</Link>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/DetailedCard/DetailedCard.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/DetailedCard/DetailedCard.scss
@@ -1,0 +1,33 @@
+.detailed-card {
+	&-container {
+		border: 1px solid #e2e2e4;
+		border-radius: 0.625rem;
+		padding: 2.125rem 1.5rem;
+
+		&-larger {
+			width: 700px !important;
+		}
+	}
+
+	&-header {
+		align-items: center;
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+
+		&-clay-icon {
+			height: 20px;
+			width: 20px;
+		}
+
+		&-icon-container {
+			align-items: center;
+			background: #e2e2e4;
+			border-radius: 50%;
+			display: flex;
+			height: 40px;
+			justify-content: center;
+			width: 40px;
+		}
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/DetailedCard/DetailedCard.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/DetailedCard/DetailedCard.tsx
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import {ReactNode} from 'react';
+
+import './DetailedCard.scss';
+
+type DetailedCardProps = {
+	cardIcon?: string;
+	cardIconAltText: string;
+	cardTitle: string;
+	children: ReactNode;
+	className?: string;
+	clayIcon?: string;
+	headerActions?: ReactNode;
+	sizing?: 'lg';
+};
+
+export function DetailedCard({
+	cardIcon,
+	cardIconAltText,
+	cardTitle,
+	children,
+	className,
+	clayIcon,
+	headerActions,
+}: DetailedCardProps) {
+	return (
+		<div className={className}>
+			<div className="detailed-card-container">
+				<div className="detailed-card-header">
+					<h2>{cardTitle}</h2>
+
+					{headerActions && (
+						<div className="align-items-center d-flex ml-auto mr-4">
+							{headerActions}
+						</div>
+					)}
+
+					<div className="detailed-card-header-icon-container">
+						{clayIcon ? (
+							<ClayIcon
+								className="detailed-card-header-clay-icon"
+								symbol={clayIcon}
+							/>
+						) : (
+							<img alt={cardIconAltText} src={cardIcon} />
+						)}
+					</div>
+				</div>
+
+				{children}
+			</div>
+		</div>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/enums/CurrencyAbbreviation.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/enums/CurrencyAbbreviation.ts
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export enum CurrencyAbbreviation {
+	USD = 'USD',
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useAdminOrderProduct.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useAdminOrderProduct.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {SWRConfiguration} from 'swr';
+
+import SearchBuilder from '../core/SearchBuilder';
+import HeadlessCommerceAdminCatalog from '../services/rest/HeadlessCommerceAdminCatalog';
+import HeadlessCommerceAdminOrder from '../services/rest/HeadlessCommerceAdminOrder';
+import HeadlessCommerceAdminPayment from '../services/rest/HeadlessCommerceAdminPayment';
+
+const useAdminOrderProduct = (
+	orderId: string,
+	swrOptions?: SWRConfiguration
+) => {
+	return useSWR(
+		`/admin-order/${orderId}`,
+		async () => {
+			const [order, payments] = await Promise.all([
+				HeadlessCommerceAdminOrder.getOrder(
+					orderId,
+					new URLSearchParams({
+						nestedFields: 'account,billingAddress,orderItems',
+					})
+				),
+				HeadlessCommerceAdminPayment.getPayment(
+					new URLSearchParams({
+						filter: new SearchBuilder()
+							.eq('relatedItemId', orderId, {unquote: true})
+							.build(),
+					})
+				),
+			]);
+
+			const sku = await HeadlessCommerceAdminCatalog.getSku(
+				order.orderItems[0].skuId
+			);
+
+			const product = await HeadlessCommerceAdminCatalog.getProduct(
+				sku.productId,
+				new URLSearchParams({nestedFields: 'productSpecifications'})
+			);
+
+			return {
+				order,
+				payments,
+				product,
+			};
+		},
+		swrOptions
+	);
+};
+
+export default useAdminOrderProduct;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherSalesSummaryObject.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherSalesSummaryObject.ts
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {SWRConfiguration} from 'swr';
+
+import HeadlessAdminUser from '../services/rest/HeadlessAdminUser';
+import HeadlessCommerceAdminOrder from '../services/rest/HeadlessCommerceAdminOrder';
+import HeadlessCommerceDeliveryOrder from '../services/rest/HeadlessCommerceDeliveryOrder';
+import PublisherSalesSummary from '../services/rest/PublisherSalesSummary';
+
+type ExtendedOrderItems = OrderItem & {
+	account: {
+		id: number;
+		name: string;
+		taxId: string;
+		type: string;
+	};
+	currencyCode: string;
+	finalPrice?: number;
+	finalPriceWithTaxAmount?: number;
+};
+
+type ExtendedPlacedOrderItems = PlacedOrderItems & {
+	author: string;
+};
+
+const usePublisherSalesSummaryObject = (
+	entryId: string,
+	swrOptions?: SWRConfiguration
+) => {
+	return useSWR(
+		`/publisher-sales-summary/${entryId}`,
+		async () => {
+			const publisherSalesSummary =
+				await PublisherSalesSummary.getPublisherSalesSummaryById(
+					entryId,
+					new URLSearchParams({
+						nestedFields: 'publisherToCommerceOrder',
+					})
+				);
+
+			const [publisherAccount, postalAddresses, placedOrders, orders] =
+				await Promise.all([
+					HeadlessAdminUser.getAccount(
+						publisherSalesSummary.r_accountToPublisher_accountEntryId
+					),
+					HeadlessAdminUser.getAccountPostalAddresses(
+						publisherSalesSummary.r_accountToPublisher_accountEntryId
+					),
+					Promise.all(
+						publisherSalesSummary.publisherToCommerceOrder.map(
+							(order) =>
+								HeadlessCommerceDeliveryOrder.getPlacedOrder(
+									order.id
+								)
+						)
+					),
+					Promise.all(
+						publisherSalesSummary.publisherToCommerceOrder.map(
+							(order) =>
+								HeadlessCommerceAdminOrder.getOrder(
+									order.id,
+									new URLSearchParams({
+										nestedFields: 'account,orderItems',
+									})
+								)
+						)
+					),
+				]);
+
+			const orderItems: ExtendedOrderItems[] = [];
+			const placedOrderItems: ExtendedPlacedOrderItems[] = [];
+
+			orders.forEach((order) =>
+				order.orderItems.forEach((orderItem) =>
+					orderItems.push({
+						...orderItem,
+						account: order.account,
+						currencyCode: order.currencyCode,
+					})
+				)
+			);
+
+			placedOrders.forEach((placedOrder) =>
+				placedOrder.placedOrderItems.forEach((placedOrderItem) =>
+					placedOrderItems.push({
+						...placedOrderItem,
+						author: placedOrder.author,
+					})
+				)
+			);
+
+			const completeOrderItems = orderItems.map((orderItem, index) => ({
+				orderItem,
+				placedOrderItem: placedOrderItems[index],
+			}));
+
+			return {
+				account: publisherAccount,
+				completeOrderItems,
+				postalAddresses,
+				publisherSalesSummary,
+			};
+		},
+		swrOptions
+	);
+};
+
+export default usePublisherSalesSummaryObject;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/DetailsHeader/DetailsHeader.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/DetailsHeader/DetailsHeader.tsx
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Button from '@clayui/button';
+
+import BackLink from '../../../../../components/BackLink';
+import i18n from '../../../../../i18n';
+import PaymentStatus from '../PaymentStatus/PaymentStatusBadge';
+
+type DetailsHeaderProps = {
+	backLink: string;
+	onClick: () => void;
+	paymentStatusCode: number;
+	showButton: boolean;
+	title: string;
+};
+
+const DetailsHeader = ({
+	backLink,
+	onClick,
+	paymentStatusCode,
+	showButton,
+	title,
+}: DetailsHeaderProps) => {
+	return (
+		<div className="align-items-center d-flex justify-content-between">
+			<div>
+				<BackLink path={backLink}>
+					{i18n.translate('back-to-last-transaction')}
+				</BackLink>
+
+				<h2 className="mt-2">{title}</h2>
+
+				<PaymentStatus paymentStatus={paymentStatusCode} />
+			</div>
+
+			{showButton && (
+				<Button displayType="secondary" onClick={onClick}>
+					{i18n.translate('mark-as-paid')}
+				</Button>
+			)}
+		</div>
+	);
+};
+
+export default DetailsHeader;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/PaymentStatus/PaymentStatusBadge.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/PaymentStatus/PaymentStatusBadge.tsx
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+
+import {PaymentStatus as PaymentStatusCode} from '../../../../../enums/Order';
+import i18n from '../../../../../i18n';
+
+import './index.scss';
+
+const paymentStatusLabel = {
+	[PaymentStatusCode.CANCELED]: i18n.translate('canceled'),
+	[PaymentStatusCode.FAILED]: i18n.translate('failed'),
+	[PaymentStatusCode.PAID]: i18n.translate('paid'),
+	[PaymentStatusCode.PAYMENT_PENDING]: i18n.translate('unpaid'),
+	[PaymentStatusCode.PENDING]: i18n.translate('unpaid'),
+};
+
+const PaymentStatusBadge = ({paymentStatus}: {paymentStatus: number}) => (
+	<div>
+		<ClayIcon
+			className={classNames('mr-2 payment-status-icon', {
+				'text-danger': [
+					PaymentStatusCode.CANCELED,
+					PaymentStatusCode.FAILED,
+				].includes(paymentStatus),
+				'text-success': paymentStatus === PaymentStatusCode.PAID,
+				'text-warning': [
+					PaymentStatusCode.PAYMENT_PENDING,
+					PaymentStatusCode.PENDING,
+				].includes(paymentStatus),
+			})}
+			symbol="circle"
+		/>
+
+		<span>
+			{paymentStatusLabel[paymentStatus as PaymentStatusCode] ||
+				paymentStatusLabel[PaymentStatusCode.PAID]}
+		</span>
+	</div>
+);
+
+export default PaymentStatusBadge;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/PaymentStatus/index.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/components/PaymentStatus/index.scss
@@ -1,0 +1,8 @@
+.payment-status-icon {
+	height: 0.5rem;
+	width: 0.5rem;
+
+	&.text-warning {
+		color: #b95000 !important;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/util/finance.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/util/finance.ts
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {CurrencyAbbreviation} from '../../../../enums/CurrencyAbbreviation';
+
+type NumericKeys<T> = {
+	[K in keyof T]: T[K] extends number | undefined ? K : never;
+}[keyof T];
+
+export function formatCurrency(currencyCode: string, price: number) {
+	if (!price) {
+		return '-';
+	}
+
+	return price.toLocaleString(currencyCode, {
+		currency: currencyCode,
+		currencyDisplay: 'narrowSymbol',
+		maximumFractionDigits: 2,
+		minimumFractionDigits: 2,
+		style: 'currency',
+	});
+}
+
+export function getTotalByOrderKey(
+	field: NumericKeys<Order>,
+	orders: Order[],
+	multiplier = 1
+) {
+	if (!orders?.length) {
+		return 0;
+	}
+
+	const totals: number[] = orders.map((order) => {
+		const {currencyCode} = order;
+		const value = order[field as keyof Order];
+
+		if (
+			currencyCode !== CurrencyAbbreviation.USD ||
+			typeof value !== 'number'
+		) {
+			return 0;
+		}
+
+		return value * multiplier;
+	});
+
+	const total = totals.reduce((prev, curr) => prev + curr, 0);
+
+	return formatCurrency(CurrencyAbbreviation.USD, total);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/util/util.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/FinanceDashboard/util/util.tsx
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Liferay} from '../../../../liferay/liferay';
+
+export function formatAddress(address: BillingAddress) {
+	if (!address || !Object.keys(address).length) {
+		return '-';
+	}
+
+	const displayNames = new Intl.DisplayNames(
+		[Liferay.ThemeDisplay.getBCP47LanguageId()],
+		{type: 'region'}
+	);
+
+	return [
+		address.street1,
+		address.city,
+		address.regionISOCode,
+		address.zip,
+		displayNames.of(address.countryISOCode as string),
+	]
+		.filter(Boolean)
+		.join(', ');
+}
+
+export function formatDate(date: string | undefined) {
+	if (!date) {
+		return '-';
+	}
+
+	return new Date(date).toLocaleDateString('en-US', {
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+		month: 'short',
+		year: 'numeric',
+	});
+}
+
+export function textWrapper(content: string | number | undefined) {
+	if (content === undefined || content === null || content === '') {
+		return <p className="mb-2 mt-1">-</p>;
+	}
+
+	return <p className="mb-2 mt-1">{content}</p>;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPFinanceOrders/MPFinanceOrders.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPFinanceOrders/MPFinanceOrders.tsx
@@ -3,6 +3,161 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export default function MPFinanceOrders() {
-	return <div />;
+import {useNavigate} from 'react-router-dom';
+import {KeyedMutator} from 'swr';
+
+import ListView from '../../../components/ListView';
+import Page from '../../../components/Page';
+import SearchBuilder from '../../../core/SearchBuilder';
+import {PaymentStatus} from '../../../enums/Order';
+import i18n from '../../../i18n';
+import {Liferay} from '../../../liferay/liferay';
+import HeadlessCommerceAdminOrder from '../../../services/rest/HeadlessCommerceAdminOrder';
+import PaymentStatusBadge from '../FinanceDashboard/components/PaymentStatus/PaymentStatusBadge';
+
+async function onClickMarkAsPaid(order: Order, mutate: KeyedMutator<any>) {
+	try {
+		await HeadlessCommerceAdminOrder.patchOrder(order.id, {
+			paymentStatus: PaymentStatus.PAID,
+		});
+
+		mutate((response: Order) => response, {
+			revalidate: true,
+		});
+
+		Liferay.Util.openToast({
+			message: i18n.translate('order-marked-as-paid'),
+			type: 'success',
+		});
+	}
+	catch {
+		Liferay.Util.openToast({
+			message: i18n.translate('oops-something-went-wrong'),
+			type: 'danger',
+		});
+	}
 }
+
+const MPFinanceOrders = () => {
+	const navigate = useNavigate();
+
+	return (
+		<Page
+			description={i18n.translate(
+				'section-that-shows-the-latest-sales-made'
+			)}
+			pageRendererProps={{
+				className: 'border py-2 rounded-lg mb-8',
+			}}
+			title={i18n.translate('last-orders')}
+		>
+			<ListView<Order>
+				emptyStateProps={{title: i18n.translate('no-orders-yet')}}
+				id="finance-dashboard-orders"
+				managementToolbarProps={{
+					filterSchema: 'financeDashboardOrders',
+					searchVisible: true,
+					visible: true,
+				}}
+				resource={`o/headless-commerce-admin-order/v1.0/orders?nestedFields=account,orderItems&sort=createDate:desc&filter=${SearchBuilder.gt('totalAmount', 0)}`}
+				tableProps={{
+					actions: [
+						{
+							disabled(order) {
+								return [
+									PaymentStatus.CANCELED,
+									PaymentStatus.PAID,
+								].includes(order.paymentStatus);
+							},
+							name: i18n.translate('mark-as-paid'),
+							onClick: onClickMarkAsPaid,
+						},
+						{
+							name: i18n.translate('view-details'),
+							onClick: (order) =>
+								navigate('/mp-finance-orders/' + order.id),
+						},
+					],
+					columns: [
+						{
+							clickable: true,
+							id: 'id',
+							name: i18n.translate('id'),
+							render: (id) => <b>{id}</b>,
+						},
+						{
+							id: 'orderDate',
+							name: 'Date',
+							render: (orderDate) => {
+								const date = new Date(orderDate as string);
+
+								return (
+									<div className="d-flex flex-column justify-content-center">
+										<p className="mb-0 pt-1">
+											{date.toLocaleDateString('en-US', {
+												day: 'numeric',
+												month: 'short',
+												year: 'numeric',
+											})}
+										</p>
+										<p className="mb-0 text-muted">
+											{date.toLocaleTimeString('en-US', {
+												hour: 'numeric',
+												minute: '2-digit',
+											})}
+										</p>
+									</div>
+								);
+							},
+						},
+						{
+							id: 'account',
+							name: i18n.translate('account'),
+							render: (account, {creatorEmailAddress}) => (
+								<div className="d-flex flex-column justify-content-center">
+									<p className="mb-0 pt-1">{account.name}</p>
+									<p className="mb-0 text-muted">
+										{creatorEmailAddress}
+									</p>
+								</div>
+							),
+						},
+						{
+							id: 'orderItems',
+							name: i18n.translate('app'),
+							render: (orderItems) => orderItems[0].name?.en_US,
+						},
+						{
+							id: 'paymentStatusInfo',
+							name: i18n.translate('payment-status'),
+							render: (paymentStatusInfo, {paymentMethod}) => (
+								<div className="d-flex flex-column justify-content-center">
+									<p className="mb-0 pt-1">
+										<PaymentStatusBadge
+											paymentStatus={
+												paymentStatusInfo.code
+											}
+										/>
+									</p>
+
+									<p className="mb-0 text-muted">
+										{paymentMethod === 'paypal-integration'
+											? 'PayPal'
+											: 'Offline Payment'}
+									</p>
+								</div>
+							),
+						},
+						{
+							id: 'totalFormatted',
+							name: i18n.translate('total'),
+						},
+					],
+					navigateTo: (order) => `/mp-finance-orders/${order.id}`,
+				}}
+			/>
+		</Page>
+	);
+};
+
+export default MPFinanceOrders;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPFinanceOrders/OrderDetails.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MPFinanceOrders/OrderDetails.tsx
@@ -1,0 +1,305 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useParams} from 'react-router-dom';
+
+import {DetailedCard} from '../../../components/DetailedCard/DetailedCard';
+import {PageRenderer} from '../../../components/Page';
+import QATable, {Orientation} from '../../../components/QATable';
+import Table from '../../../components/Table/Table';
+import {CurrencyAbbreviation} from '../../../enums/CurrencyAbbreviation';
+import {
+	OrderCustomFields,
+	PaymentStatus as PaymentStatusCode,
+} from '../../../enums/Order';
+import {ProductSpecificationKey} from '../../../enums/Product';
+import useAdminOrderProduct from '../../../hooks/useAdminOrderProduct';
+import i18n from '../../../i18n';
+import {Liferay} from '../../../liferay/liferay';
+import HeadlessCommerceAdminOrder from '../../../services/rest/HeadlessCommerceAdminOrder';
+import {safeJSONParse} from '../../../utils/util';
+import DetailsHeader from '../FinanceDashboard/components/DetailsHeader/DetailsHeader';
+import PaymentStatusBadge from '../FinanceDashboard/components/PaymentStatus/PaymentStatusBadge';
+import {formatCurrency} from '../FinanceDashboard/util/finance';
+import {
+	formatAddress,
+	formatDate,
+	textWrapper,
+} from '../FinanceDashboard/util/util';
+
+const OrderDetails = () => {
+	const {orderId} = useParams();
+
+	const {data, error, isLoading, mutate} = useAdminOrderProduct(orderId!!);
+
+	const {order, payments, product} = data || {};
+
+	const koroneikiProjects = safeJSONParse(
+		order?.customFields![OrderCustomFields.KORONEIKI_PROJECT] || '[]',
+		[]
+	);
+
+	const koroneikiProjectNames = koroneikiProjects.map(
+		(project: {name: string}) => project?.name
+	);
+
+	const currencyCode = order?.currencyCode || CurrencyAbbreviation.USD;
+
+	return (
+		<PageRenderer
+			className="app-details-header d-flex flex-column w-100"
+			error={error}
+			isLoading={isLoading}
+		>
+			<DetailsHeader
+				backLink="/mp-finance-orders"
+				onClick={async () =>
+					HeadlessCommerceAdminOrder.patchOrder(orderId as string, {
+						paymentStatus: PaymentStatusCode.PAID,
+					})
+						.then((updatedOrder) => {
+							mutate(
+								{
+									...data!,
+									order: {
+										...data!.order,
+										...updatedOrder,
+										paymentStatus: PaymentStatusCode.PAID,
+									},
+								},
+								{revalidate: false}
+							);
+
+							Liferay.Util.openToast({
+								message: 'Order marked as paid.',
+								type: 'success',
+							});
+						})
+						.catch(() =>
+							Liferay.Util.openToast({
+								message: 'Oops! Something went wrong.',
+								type: 'danger',
+							})
+						)
+				}
+				paymentStatusCode={order?.paymentStatusInfo.code as number}
+				showButton={[
+					PaymentStatusCode.FAILED,
+					PaymentStatusCode.PAYMENT_PENDING,
+					PaymentStatusCode.PENDING,
+				].includes(order?.paymentStatusInfo.code as number)}
+				title={orderId as string}
+			/>
+
+			<div className="d-flex mt-5">
+				<DetailedCard
+					cardIconAltText="order-form-pencil"
+					cardTitle={i18n.translate('account-details')}
+					className="mr-5 w-100"
+					clayIcon="order-form-pencil"
+				>
+					<QATable
+						items={[
+							{
+								title: i18n.translate('account-name'),
+								value: textWrapper(order?.account?.name),
+							},
+							{
+								title: i18n.translate('user-email'),
+								value: textWrapper(order?.creatorEmailAddress),
+							},
+							{
+								title: i18n.translate('project'),
+								value: textWrapper(
+									koroneikiProjectNames?.length
+										? koroneikiProjectNames.join(', ')
+										: '-'
+								),
+							},
+							{
+								title: i18n.translate('address'),
+								value: textWrapper(
+									formatAddress(
+										order?.billingAddress as BillingAddress
+									)
+								),
+							},
+							{
+								title: i18n.translate('vat-number'),
+								value: textWrapper(order?.account?.taxId),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+
+				<DetailedCard
+					cardIconAltText="change-list"
+					cardTitle={i18n.translate('transaction-details')}
+					className="w-100"
+					clayIcon="change-list"
+				>
+					<QATable
+						items={[
+							{
+								title: i18n.translate('purchase-date'),
+								value: textWrapper(
+									formatDate(order?.createDate)
+								),
+							},
+							{
+								title: i18n.translate('payment-method'),
+								value: textWrapper(
+									order?.paymentMethod ===
+										'paypal-integration'
+										? 'Paypal Integration'
+										: 'Offline Payment'
+								),
+							},
+							{
+								title: i18n.translate('transaction-id'),
+								value: textWrapper(order?.transactionId),
+							},
+							{
+								title: i18n.translate('fulfillment-date'),
+								value: textWrapper(
+									formatDate(order?.orderDate)
+								),
+							},
+							{
+								title: i18n.translate('payment-status'),
+								value: (
+									<PaymentStatusBadge
+										paymentStatus={
+											order?.paymentStatusInfo
+												.code as number
+										}
+									/>
+								),
+							},
+							{
+								title: i18n.translate('error-details'),
+								value: payments?.items[0]?.errorMessages,
+								visible:
+									!!payments?.items[0]?.errorMessages &&
+									order?.paymentStatus ===
+										PaymentStatusCode.FAILED,
+							},
+							{
+								className: 'mt-2',
+								title: i18n.translate('paid-date'),
+								value: textWrapper(
+									formatDate(payments?.items?.[0]?.createDate)
+								),
+								visible:
+									order?.paymentStatus ===
+									PaymentStatusCode.PAID,
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+			</div>
+
+			<DetailedCard
+				cardIconAltText="order-form"
+				cardTitle={i18n.translate('order-details')}
+				className="mt-5 pb-0 w-100"
+				clayIcon="order-form"
+			>
+				<Table
+					className="table-borderless"
+					columns={[
+						{
+							key: 'options',
+							render: (options, {quantity}) => {
+								const [skuOption] = safeJSONParse(options, [
+									{
+										skuOptionValueKey: 'Standard',
+										skuOptionValueName: 'Standard',
+									},
+								]);
+
+								return (
+									<div className="pt-2">
+										<div className="d-flex">
+											<img
+												alt="App Icon"
+												className="mr-2 order-details-app-icon rounded"
+												draggable={false}
+												src={product?.thumbnail}
+											/>
+
+											<span className="d-flex flex-column">
+												<span className="font-weight-bold">
+													{product?.name.en_US}
+												</span>
+
+												<small className="finance-dashboard-secondary-text mb-0 pb-0 text-capitalize text-muted">
+													{`${quantity} ${
+														skuOption?.skuOptionValueKey ||
+														skuOption?.skuOptionValueName
+													} license`}
+												</small>
+											</span>
+										</div>
+									</div>
+								);
+							},
+							title: i18n.translate('app-name'),
+						},
+						{
+							key: 'id',
+							render: () =>
+								textWrapper(
+									product?.productSpecifications?.find(
+										(specification) =>
+											specification.specificationKey ===
+											ProductSpecificationKey.APP_DEVELOPER_NAME
+									)?.value.en_US || ''
+								),
+							title: i18n.translate('publisher'),
+						},
+						{
+							key: 'finalPrice',
+							render: (finalPrice) =>
+								textWrapper(
+									formatCurrency(currencyCode, finalPrice)
+								),
+							title: i18n.translate('net-price'),
+						},
+						{
+							key: 'finalPriceWithTaxAmount',
+							render: (finalPriceWithTaxAmount, order) =>
+								textWrapper(
+									formatCurrency(
+										currencyCode,
+										finalPriceWithTaxAmount -
+											order?.finalPrice
+									)
+								),
+							title: i18n.translate('vat'),
+						},
+						{
+							key: 'finalPriceWithTaxAmount',
+							render: (finalPriceWithTaxAmount) =>
+								textWrapper(
+									formatCurrency(
+										currencyCode,
+										finalPriceWithTaxAmount
+									)
+								),
+							title: i18n.translate('total'),
+						},
+					]}
+					hasHover={false}
+					rows={order?.orderItems || []}
+				/>
+			</DetailedCard>
+		</PageRenderer>
+	);
+};
+
+export default OrderDetails;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Payments/PaymentDetails.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Payments/PaymentDetails.tsx
@@ -1,0 +1,435 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import ClayTable from '@clayui/table';
+import {useParams} from 'react-router-dom';
+
+import {DetailedCard} from '../../../components/DetailedCard/DetailedCard';
+import {PageRenderer} from '../../../components/Page';
+import QATable, {Orientation} from '../../../components/QATable';
+import Table from '../../../components/Table/Table';
+import {PaymentStatus as PaymentStatusCode} from '../../../enums/Order';
+import usePublisherSalesSummaryObject from '../../../hooks/usePublisherSalesSummaryObject';
+import i18n from '../../../i18n';
+import {Liferay} from '../../../liferay/liferay';
+import PublisherSalesSummary from '../../../services/rest/PublisherSalesSummary';
+import {exportToCSV} from '../../../utils/csv';
+import {safeJSONParse} from '../../../utils/util';
+import DetailsHeader from '../FinanceDashboard/components/DetailsHeader/DetailsHeader';
+import PaymentStatusBadge from '../FinanceDashboard/components/PaymentStatus/PaymentStatusBadge';
+import {
+	formatCurrency,
+	getTotalByOrderKey,
+} from '../FinanceDashboard/util/finance';
+import {formatDate, textWrapper} from '../FinanceDashboard/util/util';
+import {PublisherPayoutStatus} from './Payments';
+
+enum Payouts {
+	MP_COMMISSION = 0.2,
+	PUBLISHER_PAYOUT = 0.8,
+}
+
+export function formatPostalAddress(
+	address: AccountPostalAddresses | undefined
+) {
+	if (!address || !Object.keys(address).length) {
+		return '-';
+	}
+
+	return [
+		address.streetAddressLine1,
+		address.addressLocality,
+		address.addressRegion,
+		address.postalCode,
+		address.addressCountry,
+	]
+		.filter(Boolean)
+		.join(', ');
+}
+
+const PaymentDetails = () => {
+	const {entryId} = useParams();
+
+	const {data, error, isLoading, mutate} = usePublisherSalesSummaryObject(
+		entryId as string
+	);
+
+	const {
+		account,
+		completeOrderItems,
+		postalAddresses = {items: []},
+		publisherSalesSummary,
+	} = data || {};
+
+	const postalAddress = postalAddresses.items.find(
+		(address) => address.addressType === 'billing'
+	);
+
+	const emailAddress = account?.customFields?.find(
+		(customField) => customField.name === 'Contact Email'
+	)?.customValue?.data;
+
+	const paymentStatus = publisherSalesSummary?.paymentStatus.key;
+
+	const paymentStatusCode =
+		paymentStatus === PublisherPayoutStatus.PAID
+			? PaymentStatusCode.PAID
+			: PaymentStatusCode.PENDING;
+
+	function exportOrdersCSV() {
+		if (!completeOrderItems?.length) {
+			return;
+		}
+
+		const _formatNumber = (price: number): string => {
+			if (!price) {
+				return '0.00';
+			}
+
+			return price.toLocaleString(undefined, {
+				maximumFractionDigits: 2,
+				minimumFractionDigits: 2,
+			});
+		};
+
+		const headers = [
+			i18n.translate('app-name'),
+			i18n.translate('account'),
+			i18n.translate('quantity'),
+			i18n.translate('net-price'),
+			i18n.translate('vat'),
+			i18n.translate('total'),
+			i18n.translate('currency-code'),
+		];
+
+		const rows = completeOrderItems.map(({orderItem, placedOrderItem}) => {
+			const finalPrice = orderItem.finalPrice ?? 0;
+			const finalPriceWithTax = orderItem.finalPriceWithTaxAmount ?? 0;
+			const vat = finalPriceWithTax - finalPrice;
+
+			return [
+				placedOrderItem.name || '',
+				orderItem.account?.name || '',
+				placedOrderItem.quantity,
+				_formatNumber(finalPrice),
+				_formatNumber(vat),
+				_formatNumber(finalPriceWithTax),
+				orderItem.currencyCode,
+			];
+		});
+
+		exportToCSV(`orders.${Date.now()}.csv`, headers, rows);
+	}
+
+	return (
+		<PageRenderer
+			className="app-details-header d-flex flex-column w-100"
+			error={error}
+			isLoading={isLoading}
+		>
+			<DetailsHeader
+				backLink="/mp-payments"
+				onClick={() =>
+					PublisherSalesSummary.patchPublisherSalesSummary(
+						{
+							paidBy: Liferay.ThemeDisplay.getUserName(),
+							paidDate: new Date().toISOString(),
+							paymentStatus: {
+								key: PublisherPayoutStatus.PAID,
+							},
+						},
+						entryId!
+					).then((updatedPublisherSalesSummary) => {
+						mutate(
+							{
+								...data!,
+								publisherSalesSummary: {
+									...data!.publisherSalesSummary,
+									...updatedPublisherSalesSummary,
+								},
+							},
+							{revalidate: false}
+						);
+					})
+				}
+				paymentStatusCode={paymentStatusCode}
+				showButton={paymentStatus !== PublisherPayoutStatus.PAID}
+				title={publisherSalesSummary?.publisherName as string}
+			/>
+
+			<div className="d-flex mt-5">
+				<DetailedCard
+					cardIconAltText="order-form-pencil"
+					cardTitle={i18n.translate('publisher-details')}
+					className="mr-5 w-100"
+					clayIcon="order-form-pencil"
+				>
+					<QATable
+						items={[
+							{
+								title: i18n.translate('publisher-name'),
+								value: textWrapper(account?.name),
+							},
+							{
+								title: i18n.translate('email'),
+								value: textWrapper(emailAddress as string),
+							},
+							{
+								title: i18n.translate('billing-address'),
+								value: textWrapper(
+									formatPostalAddress(postalAddress)
+								),
+							},
+							{
+								title: i18n.translate('vat-number'),
+								value: textWrapper(account?.taxId),
+							},
+							{
+								title: i18n.translate('quarter'),
+								value: textWrapper(
+									publisherSalesSummary?.quarter
+								),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+
+				<DetailedCard
+					cardIconAltText="paste-plaintext"
+					cardTitle={i18n.translate('payment-summary')}
+					className="w-100"
+					clayIcon="paste-plaintext"
+				>
+					<QATable
+						items={[
+							{
+								title: i18n.translate('apps-sold'),
+								value: textWrapper(
+									publisherSalesSummary
+										?.publisherToCommerceOrder?.length
+								),
+							},
+							{
+								title: i18n.translate('net-price'),
+								value: textWrapper(
+									getTotalByOrderKey(
+										'subtotalAmount',
+										publisherSalesSummary?.publisherToCommerceOrder!
+									)
+								),
+							},
+							{
+								title: i18n.translate('total'),
+								value: textWrapper(
+									getTotalByOrderKey(
+										'totalAmount',
+										publisherSalesSummary?.publisherToCommerceOrder!
+									)
+								),
+							},
+							{
+								title: i18n.translate('mp-commission'),
+								value: textWrapper(
+									getTotalByOrderKey(
+										'totalAmount',
+										publisherSalesSummary?.publisherToCommerceOrder!,
+										Payouts.MP_COMMISSION
+									)
+								),
+							},
+							{
+								title: i18n.translate('publisher-payout'),
+								value: textWrapper(
+									getTotalByOrderKey(
+										'totalAmount',
+										publisherSalesSummary?.publisherToCommerceOrder!,
+										Payouts.PUBLISHER_PAYOUT
+									)
+								),
+							},
+							{
+								title: i18n.translate('status'),
+								value: (
+									<PaymentStatusBadge
+										paymentStatus={paymentStatusCode}
+									/>
+								),
+							},
+							{
+								className: 'mt-2',
+								title: i18n.translate('paid-date'),
+								value: textWrapper(
+									formatDate(publisherSalesSummary?.paidDate)
+								),
+								visible:
+									paymentStatus ===
+									PublisherPayoutStatus.PAID,
+							},
+							{
+								title: i18n.translate('paid-by'),
+								value: textWrapper(
+									publisherSalesSummary?.paidBy
+								),
+								visible:
+									paymentStatus ===
+									PublisherPayoutStatus.PAID,
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+			</div>
+
+			<DetailedCard
+				cardIconAltText="order-form"
+				cardTitle={i18n.translate('apps-sold')}
+				className="mt-5 pb-0 w-100"
+				clayIcon="price-tag"
+				headerActions={
+					<ClayButton
+						className="export-csv-button"
+						disabled={!completeOrderItems?.length}
+						displayType="unstyled"
+						onClick={exportOrdersCSV}
+					>
+						<ClayIcon
+							aria-hidden="true"
+							className="inline-item inline-item-before"
+							symbol="download"
+						/>
+
+						<span className="font-weight-semi-bold">
+							{i18n.translate('export-csv')}
+						</span>
+					</ClayButton>
+				}
+			>
+				<Table
+					className="table-borderless"
+					columns={[
+						{
+							key: 'placedOrderItem',
+							render: (placedOrderItem) => {
+								const [skuOption] = safeJSONParse(
+									placedOrderItem.options,
+									[
+										{
+											skuOptionValueKey: 'Standard',
+											skuOptionValueName: 'Standard',
+										},
+									]
+								);
+
+								return (
+									<div className="pt-2">
+										<div className="d-flex">
+											<img
+												alt="App Icon"
+												className="mr-2 order-details-app-icon rounded"
+												draggable={false}
+												src={placedOrderItem.thumbnail}
+											/>
+
+											<span className="d-flex flex-column">
+												<span className="font-weight-bold">
+													{placedOrderItem.name}
+												</span>
+
+												<small className="finance-dashboard-secondary-text mb-0 pb-0 text-capitalize text-muted">
+													{`${placedOrderItem.quantity} ${
+														skuOption?.skuOptionValueKey ||
+														skuOption?.skuOptionValueName
+													} license`}
+												</small>
+											</span>
+										</div>
+									</div>
+								);
+							},
+							title: i18n.translate('app-name'),
+						},
+						{
+							key: 'placedOrderItem',
+							render: (placedOrderItem, order) => (
+								<div className="d-flex flex-column justify-content-center">
+									<p className="mb-0">
+										{order.orderItem.account.name}
+									</p>
+									<p className="finance-dashboard-secondary-text mb-0">
+										{placedOrderItem.author}
+									</p>
+								</div>
+							),
+							title: i18n.translate('account'),
+						},
+						{
+							key: 'orderItem',
+							render: (orderItem) =>
+								formatCurrency(
+									orderItem.currencyCode,
+									orderItem.finalPrice
+								),
+
+							title: i18n.translate('net-price'),
+						},
+						{
+							key: 'orderItem',
+							render: (orderItem) =>
+								formatCurrency(
+									orderItem.currencyCode,
+									orderItem.finalPriceWithTaxAmount -
+										orderItem.finalPrice
+								),
+							title: i18n.translate('vat'),
+						},
+						{
+							key: 'orderItem',
+							render: (orderItem) =>
+								formatCurrency(
+									orderItem.currencyCode,
+									orderItem?.finalPriceWithTaxAmount
+								),
+							title: i18n.translate('total'),
+						},
+					]}
+					hasHover={false}
+					rows={completeOrderItems || []}
+				>
+					<ClayTable.Row className="publisher-payout-footer w-100">
+						<ClayTable.Cell colSpan={2}>
+							<b>{i18n.translate('total')}</b>
+						</ClayTable.Cell>
+
+						<ClayTable.Cell>
+							{getTotalByOrderKey(
+								'subtotalAmount',
+								publisherSalesSummary?.publisherToCommerceOrder!
+							)}
+						</ClayTable.Cell>
+
+						<ClayTable.Cell>
+							{getTotalByOrderKey(
+								'taxAmountValue',
+								publisherSalesSummary?.publisherToCommerceOrder!
+							)}
+						</ClayTable.Cell>
+
+						<ClayTable.Cell>
+							{getTotalByOrderKey(
+								'totalAmount',
+								publisherSalesSummary?.publisherToCommerceOrder!
+							)}
+						</ClayTable.Cell>
+					</ClayTable.Row>
+				</Table>
+			</DetailedCard>
+		</PageRenderer>
+	);
+};
+
+export default PaymentDetails;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Payments/Payments.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Payments/Payments.tsx
@@ -3,10 +3,166 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useProperties} from '../../../context/PropertiesContext';
+import {useNavigate} from 'react-router-dom';
+import {KeyedMutator} from 'swr';
 
-export default function Payments() {
-	const {accountId} = useProperties();
+import ListView from '../../../components/ListView';
+import Page from '../../../components/Page';
+import {PaymentStatus as PaymentStatusCode} from '../../../enums/Order';
+import i18n from '../../../i18n';
+import {Liferay} from '../../../liferay/liferay';
+import PublisherSalesSummary from '../../../services/rest/PublisherSalesSummary';
+import PaymentStatus from '../FinanceDashboard/components/PaymentStatus/PaymentStatusBadge';
+import {getTotalByOrderKey} from '../FinanceDashboard/util/finance';
 
-	return <div>{accountId}</div>;
+export enum PublisherPayoutStatus {
+	PAID = 'paid',
+	UNPAID = 'unpaid',
 }
+
+async function onClickMarkAsPaid(
+	entry: PublisherSalesSummaryEntry,
+	mutate: KeyedMutator<any>
+) {
+	try {
+		await PublisherSalesSummary.patchPublisherSalesSummary(
+			{
+				paidBy: Liferay.ThemeDisplay.getUserName(),
+				paidDate: new Date().toISOString(),
+				paymentStatus: {
+					key: PublisherPayoutStatus.PAID,
+				},
+			},
+			entry.id
+		);
+
+		mutate((response: PublisherSalesSummaryEntry) => response, {
+			revalidate: true,
+		});
+
+		Liferay.Util.openToast({
+			message: i18n.translate('marked-as-paid'),
+			type: 'success',
+		});
+	}
+	catch {
+		Liferay.Util.openToast({
+			message: i18n.translate('oops-something-went-wrong'),
+			type: 'danger',
+		});
+	}
+}
+
+const Payments = () => {
+	const navigate = useNavigate();
+
+	return (
+		<Page
+			description={i18n.translate('section-that-shows-the-payments')}
+			pageRendererProps={{
+				className: 'border mb-8 py-2 rounded-lg',
+			}}
+			title={i18n.translate('payments')}
+		>
+			<ListView<PublisherSalesSummaryEntry>
+				emptyStateProps={{title: i18n.translate('no-orders-yet')}}
+				id="finance-dashboard-orders"
+				managementToolbarProps={{
+					filterSchema: 'financeDashboardPayments',
+					searchVisible: true,
+					visible: true,
+				}}
+				resource="/o/c/publishersalessummaries?nestedFields=accountToPublisher,publisherToCommerceOrder"
+				tableProps={{
+					actions: [
+						{
+							name: i18n.translate('view-details'),
+							onClick: (entry) =>
+								navigate('/mp-payments/' + entry.id),
+						},
+						{
+							disabled: (entry) =>
+								entry.paymentStatus.key ===
+								PublisherPayoutStatus.PAID,
+							name: i18n.translate('mark-as-paid'),
+							onClick: onClickMarkAsPaid,
+						},
+					],
+					columns: [
+						{
+							clickable: true,
+							id: 'publisherName',
+							name: i18n.translate('publisher'),
+							render: (publisherName) => <b>{publisherName}</b>,
+						},
+						{
+							id: 'quarter',
+							name: i18n.translate('quarter'),
+						},
+						{
+							id: 'publisherToCommerceOrder',
+							name: i18n.translate('apps-sold'),
+							render: (publisherToCommerceOrder) =>
+								publisherToCommerceOrder?.length,
+						},
+						{
+							id: 'publisherToCommerceOrder',
+							name: i18n.translate('total'),
+							render: (publisherToCommerceOrder) =>
+								getTotalByOrderKey(
+									'totalAmount',
+									publisherToCommerceOrder
+								),
+						},
+						{
+							id: 'publisherToCommerceOrder',
+							name: i18n.translate('net-price'),
+							render: (publisherToCommerceOrder) =>
+								getTotalByOrderKey(
+									'subtotalAmount',
+									publisherToCommerceOrder
+								),
+						},
+						{
+							id: 'publisherToCommerceOrder',
+							name: i18n.translate('mp-commission'),
+							render: (publisherToCommerceOrder) =>
+								getTotalByOrderKey(
+									'subtotalAmount',
+									publisherToCommerceOrder,
+									0.2
+								),
+						},
+						{
+							id: 'publisherToCommerceOrder',
+							name: i18n.translate('publisher-payout'),
+							render: (publisherToCommerceOrder) =>
+								getTotalByOrderKey(
+									'subtotalAmount',
+									publisherToCommerceOrder,
+									0.8
+								),
+						},
+						{
+							id: 'paymentStatus',
+							name: i18n.translate('status'),
+							render: (paymentStatus) => (
+								<PaymentStatus
+									paymentStatus={
+										paymentStatus?.key ===
+										PublisherPayoutStatus.PAID
+											? PaymentStatusCode.PAID
+											: PaymentStatusCode.PENDING
+									}
+								/>
+							),
+						},
+					],
+					navigateTo: (entry) => `/mp-payments/${entry.id}`,
+				}}
+			/>
+		</Page>
+	);
+};
+
+export default Payments;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
@@ -20,7 +20,9 @@ const MessageQueue = lazy(() => import('./MessageQueue/MessageQueue'));
 const MPFinanceOrders = lazy(() => import('./MPFinanceOrders/MPFinanceOrders'));
 const MPSummary = lazy(() => import('./MPSummary/MPSummary'));
 const MySsaSaasDemo = lazy(() => import('./MySsaSaasDemo/MySsaSaasDemo'));
+const OrderDetails = lazy(() => import('./MPFinanceOrders/OrderDetails'));
 const Orders = lazy(() => import('./Orders/Orders'));
+const PaymentDetails = lazy(() => import('./Payments/PaymentDetails'));
 const Payments = lazy(() => import('./Payments/Payments'));
 const PublisherRequests = lazy(
 	() => import('./PublisherRequests/PublisherRequests')
@@ -58,9 +60,17 @@ export const adminRoutes: AppRoute[] = [
 		path: 'mp-finance-orders',
 	},
 	{
+		element: <OrderDetails />,
+		path: 'mp-finance-orders/:orderId',
+	},
+	{
 		element: <Payments />,
 		nav: {icon: 'order-form', label: 'Marketplace Payments'},
 		path: 'mp-payments',
+	},
+	{
+		element: <PaymentDetails />,
+		path: 'mp-payments/:entryId',
 	},
 	{
 		element: <Publishers />,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -8,9 +8,10 @@ import {Params} from 'react-router-dom';
 import SearchBuilder, {Operators} from '../core/SearchBuilder';
 import {AccountType} from '../enums/Account';
 import {MarketplaceCategory} from '../enums/Categories';
-import {OrderWorkflowStatusCode} from '../enums/Order';
+import {OrderWorkflowStatusCode, PaymentStatus} from '../enums/Order';
 import {ProductType, ProductWorkflowStatusCode} from '../enums/Product';
 import i18n from '../i18n';
+import {PublisherPayoutStatus} from '../pages/Admin/Payments/Payments';
 
 const LIFERAY_VERSION_PICKLIST = 'LIFERAY-VERSIONS';
 
@@ -339,6 +340,96 @@ export const filterSchema: FilterSchemas = {
 			}),
 		],
 		name: 'administratorSolutions',
+	},
+	financeDashboardOrders: {
+		fields: [
+			baseFilters.dateCreated,
+			overrides(baseFilters.dateCreated, {
+				label: i18n.translate('modified-date'),
+				name: 'modifiedDate',
+			}),
+			overrides(baseFilters.status, {
+				label: i18n.translate('payment-status'),
+				name: 'paymentStatusInfo/code',
+				options: [
+					{
+						label: i18n.translate('canceled'),
+						value: `${PaymentStatus.CANCELED}`,
+					},
+					{
+						label: i18n.translate('failed'),
+						value: `${PaymentStatus.FAILED}`,
+					},
+					{
+						label: i18n.translate('paid'),
+						value: `${PaymentStatus.PAID}`,
+					},
+					{
+						label: i18n.translate('unpaid'),
+						value: `${PaymentStatus.PENDING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'multiselect',
+			}),
+			overrides(baseFilters.status, {
+				label: i18n.translate('order-status'),
+				name: 'orderStatus',
+				options: [
+					{
+						label: i18n.translate('canceled'),
+						value: `${OrderWorkflowStatusCode.CANCELLED}`,
+					},
+					{
+						label: i18n.translate('completed'),
+						value: `${OrderWorkflowStatusCode.COMPLETED}`,
+					},
+					{
+						label: i18n.translate('in-progress'),
+						value: `${OrderWorkflowStatusCode.IN_PROGRESS}`,
+					},
+					{
+						label: i18n.translate('on-hold'),
+						value: `${OrderWorkflowStatusCode.ON_HOLD}`,
+					},
+					{
+						label: i18n.translate('pending'),
+						value: `${OrderWorkflowStatusCode.PENDING}`,
+					},
+					{
+						label: i18n.translate('processing'),
+						value: `${OrderWorkflowStatusCode.PROCESSING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'multiselect',
+			}),
+		],
+		name: 'financeOrders',
+	},
+	financeDashboardPayments: {
+		fields: [
+			overrides(baseFilters.dateCreated, {
+				name: 'dateCreated',
+			}),
+			overrides(baseFilters.status, {
+				label: i18n.translate('payment-status'),
+				name: 'paymentStatus',
+				operator: 'eq',
+				options: [
+					{
+						label: i18n.translate('paid'),
+						value: PublisherPayoutStatus.PAID,
+					},
+					{
+						label: i18n.translate('unpaid'),
+						value: PublisherPayoutStatus.UNPAID,
+					},
+				],
+				type: 'select',
+			}),
+		],
+		name: 'financePayments',
 	},
 };
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceAdminPayment.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceAdminPayment.ts
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+export default class HeadlessCommerceAdminPayment {
+	static getPayment(searchParams = new URLSearchParams()) {
+		return fetcher<APIResponse>(
+			`o/headless-commerce-admin-payment/v1.0/payments?${searchParams.toString()}`
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/PublisherSalesSummary.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/PublisherSalesSummary.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+export default class PublisherSalesSummary {
+	static async getPublisherSalesSummaryById(
+		entryId: string | number,
+		params = new URLSearchParams()
+	) {
+		return fetcher<PublisherSalesSummaryEntry>(
+			`/o/c/publishersalessummaries/${entryId}?${params}`
+		);
+	}
+
+	static async patchPublisherSalesSummary(
+		body: Partial<PublisherSalesSummary>,
+		entryId: number | string
+	) {
+		return fetcher.patch<APIResponse<PublisherSalesSummaryEntry>>(
+			`o/c/publishersalessummaries/${entryId}`,
+			body
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/csv.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/csv.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+const escapeCSV = (value: string | number): string => {
+	const str = String(value);
+
+	return '"' + str.replace(/"/g, '""') + '"';
+};
+
+export function exportToCSV(
+	filename: string,
+	headers: string[],
+	rows: (string | number)[][]
+): void {
+	let csv = '\uFEFF' + headers.map(escapeCSV).join(',') + '\n';
+
+	for (const row of rows) {
+		csv += row.map(escapeCSV).join(',') + '\n';
+	}
+
+	const blob = new Blob([csv], {type: 'text/csv;charset=utf-8;'});
+
+	const url = URL.createObjectURL(blob);
+
+	const downloadLink = document.createElement('a');
+	downloadLink.href = url;
+	downloadLink.download = filename;
+	downloadLink.click();
+
+	URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89821

## What is being fixed

The Admin dashboard's Finance pages in liferay-one-custom-element (Finance Orders and Payments) are still placeholders; the Marketplace Finance Dashboard — order/payment listings, detail views, and publisher sales summaries — has not been ported into the new workspace.

## How it is being fixed

Ports the Marketplace Finance Dashboard from the marketplace workspace into liferay-one as a near-verbatim lift-and-shift, in three commits: (1) shared Finance utilities, REST services (HeadlessCommerceAdminPayment, PublisherSalesSummary), detail components (DetailedCard, DetailsHeader, PaymentStatusBadge, BackLink) and hooks; (2) the Finance Orders and Payments list pages plus their OrderDetails/PaymentDetails views and routes; (3) the financeDashboardOrders and financeDashboardPayments filter schemas. Builds on the ListView, QATable and commerce-delivery services already merged. No backend changes.

## Why are there no tests?

Mechanical lift-and-shift migration of the Marketplace admin UI into liferay-one. The original marketplace screens ship no automated coverage; this ports them verbatim without altering behavior, and verification is manual against the Finance dashboard.

**pr-check: PASS** — tested on `25811302f0a9a8d18bccdf0a5cc3a2ea59a0a57d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "25811302f0a9a8d18bccdf0a5cc3a2ea59a0a57d"} -->
