### PR TITLE
LPD-89424 Add object, commerce, and expando batch definitions

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/00-list-type-definition.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/00-list-type-definition.batch-engine-data.json
@@ -11,94 +11,6 @@
 	},
 	"items": [
 		{
-			"externalReferenceCode": "LT_ACCOUNT_REGION",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_ACCOUNT_REGION_AMERICAS",
-					"key": "americas",
-					"name": "Americas"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_REGION_EMEA",
-					"key": "eMEA",
-					"name": "EMEA"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_REGION_APAC",
-					"key": "aPAC",
-					"name": "APAC"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_REGION_LATAM",
-					"key": "lATAM",
-					"name": "LATAM"
-				}
-			],
-			"name": "Account Region"
-		},
-		{
-			"externalReferenceCode": "LT_ACCOUNT_TIER",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_PLATINUM",
-					"key": "platinum",
-					"name": "Platinum"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_GOLD",
-					"key": "gold",
-					"name": "Gold"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_SILVER",
-					"key": "silver",
-					"name": "Silver"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_BRONZE",
-					"key": "bronze",
-					"name": "Bronze"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_TRIAL",
-					"key": "trial",
-					"name": "Trial"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_TIER_COMMUNITY",
-					"key": "community",
-					"name": "Community"
-				}
-			],
-			"name": "Account Tier"
-		},
-		{
-			"externalReferenceCode": "LT_ACCOUNT_STATUS",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_ACCOUNT_STATUS_ACTIVE",
-					"key": "active",
-					"name": "Active"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_STATUS_SUSPENDED",
-					"key": "suspended",
-					"name": "Suspended"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_STATUS_CANCELLED",
-					"key": "cancelled",
-					"name": "Cancelled"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_STATUS_EXPIRED",
-					"key": "expired",
-					"name": "Expired"
-				}
-			],
-			"name": "Account Status"
-		},
-		{
 			"externalReferenceCode": "LT_ACCOUNT_FLAG_CODE",
 			"listTypeEntries": [
 			],
@@ -109,22 +21,6 @@
 			"listTypeEntries": [
 			],
 			"name": "Account Flag Value"
-		},
-		{
-			"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE_GENERAL",
-					"key": "general",
-					"name": "General"
-				},
-				{
-					"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE_SALES",
-					"key": "sales",
-					"name": "Sales"
-				}
-			],
-			"name": "Account Note Type"
 		},
 		{
 			"externalReferenceCode": "LT_ACCOUNT_NOTE_PRIORITY",
@@ -157,6 +53,131 @@
 				}
 			],
 			"name": "Account Note Status"
+		},
+		{
+			"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE_GENERAL",
+					"key": "general",
+					"name": "General"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_NOTE_TYPE_SALES",
+					"key": "sales",
+					"name": "Sales"
+				}
+			],
+			"name": "Account Note Type"
+		},
+		{
+			"externalReferenceCode": "LT_ACCOUNT_REGION",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_ACCOUNT_REGION_AMERICAS",
+					"key": "americas",
+					"name": "Americas"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_REGION_APAC",
+					"key": "apac",
+					"name": "APAC"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_REGION_EMEA",
+					"key": "emea",
+					"name": "EMEA"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_REGION_LATAM",
+					"key": "latam",
+					"name": "LATAM"
+				}
+			],
+			"name": "Account Region"
+		},
+		{
+			"externalReferenceCode": "LT_ACCOUNT_STATUS",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_ACCOUNT_STATUS_ACTIVE",
+					"key": "active",
+					"name": "Active"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_STATUS_CANCELLED",
+					"key": "cancelled",
+					"name": "Cancelled"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_STATUS_EXPIRED",
+					"key": "expired",
+					"name": "Expired"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_STATUS_SUSPENDED",
+					"key": "suspended",
+					"name": "Suspended"
+				}
+			],
+			"name": "Account Status"
+		},
+		{
+			"externalReferenceCode": "LT_ACCOUNT_TIER",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_BRONZE",
+					"key": "bronze",
+					"name": "Bronze"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_COMMUNITY",
+					"key": "community",
+					"name": "Community"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_GOLD",
+					"key": "gold",
+					"name": "Gold"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_PLATINUM",
+					"key": "platinum",
+					"name": "Platinum"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_SILVER",
+					"key": "silver",
+					"name": "Silver"
+				},
+				{
+					"externalReferenceCode": "LT_ACCOUNT_TIER_TRIAL",
+					"key": "trial",
+					"name": "Trial"
+				}
+			],
+			"name": "Account Tier"
+		},
+		{
+			"externalReferenceCode": "LT_CONTRACT_TYPE",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_CONTRACT_TYPE_AMENDMENT",
+					"key": "amendment",
+					"name": "Amendment"
+				},
+				{
+					"externalReferenceCode": "LT_CONTRACT_TYPE_INITIAL",
+					"key": "initial",
+					"name": "Initial"
+				},
+				{
+					"externalReferenceCode": "LT_CONTRACT_TYPE_RENEWAL",
+					"key": "renewal",
+					"name": "Renewal"
+				}
+			],
+			"name": "Contract Type"
 		},
 		{
 			"externalReferenceCode": "LT_ENTITLEMENT_RULE_TYPE",
@@ -212,88 +233,6 @@
 			"name": "Environment Type"
 		},
 		{
-			"externalReferenceCode": "LT_PRODUCT_FAMILY",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_DXP",
-					"key": "dXP",
-					"name": "DXP"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_PORTAL",
-					"key": "portal",
-					"name": "Portal"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_ANALYTICS",
-					"key": "analytics",
-					"name": "Analytics"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_COMMERCE",
-					"key": "commerce",
-					"name": "Commerce"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_AI_HUB",
-					"key": "aIHub",
-					"name": "AIHub"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_CMP",
-					"key": "cMP",
-					"name": "CMP"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_PARTNER",
-					"key": "partner",
-					"name": "Partner"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_SUPPORT",
-					"key": "support",
-					"name": "Support"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_TRAINING",
-					"key": "training",
-					"name": "Training"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_ENTERPRISE_SEARCH",
-					"key": "enterpriseSearch",
-					"name": "Enterprise Search"
-				},
-				{
-					"externalReferenceCode": "LT_PRODUCT_FAMILY_OTHER",
-					"key": "other",
-					"name": "Other"
-				}
-			],
-			"name": "Product Family"
-		},
-		{
-			"externalReferenceCode": "LT_ENVIRONMENT_TYPE",
-			"listTypeEntries": [
-				{
-					"externalReferenceCode": "LT_ENVIRONMENT_TYPE_PRODUCTION",
-					"key": "production",
-					"name": "Production"
-				},
-				{
-					"externalReferenceCode": "LT_ENVIRONMENT_TYPE_NON_PRODUCTION",
-					"key": "nonProduction",
-					"name": "Non-Production"
-				},
-				{
-					"externalReferenceCode": "LT_ENVIRONMENT_TYPE_BACKUP",
-					"key": "backup",
-					"name": "Backup"
-				}
-			],
-			"name": "Environment Type"
-		},
-		{
 			"externalReferenceCode": "LT_PAYMENT_STATUS",
 			"listTypeEntries": [
 				{
@@ -310,12 +249,94 @@
 			"name": "Payment Status"
 		},
 		{
+			"externalReferenceCode": "LT_PRODUCT_FAMILY",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_AI_HUB",
+					"key": "aiHub",
+					"name": "AIHub"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_ANALYTICS",
+					"key": "analytics",
+					"name": "Analytics"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_CMP",
+					"key": "cmp",
+					"name": "CMP"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_COMMERCE",
+					"key": "commerce",
+					"name": "Commerce"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_DXP",
+					"key": "dxp",
+					"name": "DXP"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_ENTERPRISE_SEARCH",
+					"key": "enterpriseSearch",
+					"name": "Enterprise Search"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_OTHER",
+					"key": "other",
+					"name": "Other"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_PARTNER",
+					"key": "partner",
+					"name": "Partner"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_PORTAL",
+					"key": "portal",
+					"name": "Portal"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_SUPPORT",
+					"key": "support",
+					"name": "Support"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_FAMILY_TRAINING",
+					"key": "training",
+					"name": "Training"
+				}
+			],
+			"name": "Product Family"
+		},
+		{
+			"externalReferenceCode": "LT_PRODUCT_TYPE",
+			"listTypeEntries": [
+				{
+					"externalReferenceCode": "LT_PRODUCT_TYPE_ADD_ON",
+					"key": "addOn",
+					"name": "Add-on"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_TYPE_PRIMARY",
+					"key": "primary",
+					"name": "Primary"
+				},
+				{
+					"externalReferenceCode": "LT_PRODUCT_TYPE_REGULAR",
+					"key": "regular",
+					"name": "Regular"
+				}
+			],
+			"name": "Product Type"
+		},
+		{
 			"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE",
 			"listTypeEntries": [
 				{
-					"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE_SOURCE_CODE",
-					"key": "sourceCode",
-					"name": "Source Code"
+					"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE_LPKG",
+					"key": "lpkg",
+					"name": "Liferay Package (LPKG)"
 				},
 				{
 					"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE_PACKAGE",
@@ -323,9 +344,9 @@
 					"name": "Package (jar, war, zip)"
 				},
 				{
-					"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE_LPKG",
-					"key": "lpkg",
-					"name": "Liferay Package (LPKG)"
+					"externalReferenceCode": "LT_PUBLISHER_ASSET_ATTACHMENT_TYPE_SOURCE_CODE",
+					"key": "sourceCode",
+					"name": "Source Code"
 				}
 			],
 			"name": "Publisher Asset Attachment Type"
@@ -350,9 +371,9 @@
 			"externalReferenceCode": "LT_REQUEST_STATUS",
 			"listTypeEntries": [
 				{
-					"externalReferenceCode": "LT_REQUEST_STATUS_OPEN",
-					"key": "open",
-					"name": "Open"
+					"externalReferenceCode": "LT_REQUEST_STATUS_COMPLETED",
+					"key": "completed",
+					"name": "Completed"
 				},
 				{
 					"externalReferenceCode": "LT_REQUEST_STATUS_IN_PROGRESS",
@@ -360,9 +381,9 @@
 					"name": "In Progress"
 				},
 				{
-					"externalReferenceCode": "LT_REQUEST_STATUS_COMPLETED",
-					"key": "completed",
-					"name": "Completed"
+					"externalReferenceCode": "LT_REQUEST_STATUS_OPEN",
+					"key": "open",
+					"name": "Open"
 				},
 				{
 					"externalReferenceCode": "LT_REQUEST_STATUS_REJECTED",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/02-system-object-field.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/02-system-object-field.batch-engine-data.json
@@ -11,6 +11,27 @@
 	},
 	"items": [
 		{
+			"externalReferenceCode": "L_COMMERCE_ORDER_ITEM",
+			"name": "CommerceOrderItem",
+			"objectActions": [
+				{
+					"active": true,
+					"description": "Triggers Spring Boot CX to generate Entitlements per the matching EntitlementDefinitions on the order item's product.",
+					"externalReferenceCode": "OA_COMMERCE_ORDER_ITEM_ENTITLEMENT_GENERATION",
+					"name": "EntitlementGeneration",
+					"objectActionExecutorKey": "function#liferay-one-etc-spring-boot-object-action-commerce-order-item-entitlement-generation",
+					"objectActionTriggerKey": "onAfterAdd",
+					"parameters": {
+					}
+				}
+			],
+			"objectFields": [
+			],
+			"objectRelationships": [
+			],
+			"system": true
+		},
+		{
 			"externalReferenceCode": "L_COMMERCE_PRODUCT_DEFINITION",
 			"name": "CPDefinition",
 			"objectFields": [
@@ -53,6 +74,24 @@
 				},
 				{
 					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "L_COMMERCE_PRODUCT_DEFINITION_METRIC_COVERAGE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Metric Coverage"
+					},
+					"name": "metricCoverage",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
 					"businessType": "Picklist",
 					"externalReferenceCode": "L_COMMERCE_PRODUCT_DEFINITION_PRODUCT_FAMILY",
 					"indexed": true,
@@ -69,252 +108,6 @@
 					"state": false,
 					"system": false,
 					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_PRODUCT_DEFINITION_METRIC_COVERAGE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Metric Coverage"
-					},
-					"name": "metricCoverage",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				}
-			],
-			"objectRelationships": [
-			],
-			"system": true
-		},
-		{
-			"externalReferenceCode": "L_COMMERCE_ORDER",
-			"name": "CommerceOrder",
-			"objectFields": [
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_LDP_WORKSPACE_NAME",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "LDP Workspace Name"
-					},
-					"name": "ldpWorkspaceName",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				}
-			],
-			"objectRelationships": [
-			],
-			"system": true
-		},
-		{
-			"externalReferenceCode": "L_COMMERCE_ORDER_ITEM",
-			"name": "CommerceOrderItem",
-			"objectFields": [
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_CLOUD_REGION",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Cloud Region"
-					},
-					"name": "cloudRegion",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_CUSTOM_STATUS",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Status"
-					},
-					"name": "customStatus",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "Date",
-					"businessType": "DateTime",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_EFFECTIVE_END_DATE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Effective End Date"
-					},
-					"name": "effectiveEndDate",
-					"objectFieldSettings": [
-						{
-							"name": "timeStorage",
-							"value": "convertToUTC"
-						}
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Date"
-				},
-				{
-					"DBType": "Date",
-					"businessType": "DateTime",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_END_DATE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "End Date"
-					},
-					"name": "endDate",
-					"objectFieldSettings": [
-						{
-							"name": "timeStorage",
-							"value": "convertToUTC"
-						}
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Date"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_MACHINE_TYPE",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Machine Type"
-					},
-					"name": "machineType",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_OPPORTUNITY_SOLD_BY",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Opportunity Sold By"
-					},
-					"name": "opportunitySoldBy",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_ORDER_TYPE",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Order Type"
-					},
-					"name": "orderType",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "Integer",
-					"businessType": "Integer",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_SIZING",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Sizing"
-					},
-					"name": "sizing",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Integer"
-				},
-				{
-					"DBType": "Double",
-					"businessType": "Decimal",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_SPEND_LIMIT",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Spend Limit"
-					},
-					"name": "spendLimit",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Double"
-				},
-				{
-					"DBType": "Date",
-					"businessType": "DateTime",
-					"externalReferenceCode": "L_COMMERCE_ORDER_ITEM_START_DATE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Start Date"
-					},
-					"name": "startDate",
-					"objectFieldSettings": [
-						{
-							"name": "timeStorage",
-							"value": "convertToUTC"
-						}
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Date"
 				}
 			],
 			"objectRelationships": [

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
@@ -11,8 +11,6 @@
 	},
 	"items": [
 		{
-			"accountEntryRestricted": true,
-			"accountEntryRestrictedObjectFieldName": "r_accountEntryToAccountNote_accountEntryId",
 			"active": true,
 			"className": "com.liferay.object.model.ObjectDefinition#C_ACCOUNT_NOTE",
 			"enableCategorization": true,
@@ -666,128 +664,6 @@
 		},
 		{
 			"active": true,
-			"enableCategorization": false,
-			"enableComments": false,
-			"enableObjectEntryHistory": false,
-			"externalReferenceCode": "C_SALES_REQUEST",
-			"label": {
-				"en_US": "Sales Request"
-			},
-			"name": "SalesRequest",
-			"objectFields": [
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_SALES_REQUEST_ACCOUNT_NAME",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Account Name"
-					},
-					"name": "accountName",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "Clob",
-					"businessType": "LongText",
-					"externalReferenceCode": "C_SALES_REQUEST_ADDITIONAL_APPS_REQUESTED",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Additional Apps Requested"
-					},
-					"name": "additionalAppsRequested",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Clob"
-				},
-				{
-					"DBType": "Clob",
-					"businessType": "LongText",
-					"externalReferenceCode": "C_SALES_REQUEST_COMMENTS",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Comments"
-					},
-					"name": "comments",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Clob"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_SALES_REQUEST_EMAIL",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Email"
-					},
-					"name": "email",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_SALES_REQUEST_NAME",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Name"
-					},
-					"name": "name",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				}
-			],
-			"objectFolderExternalReferenceCode": "C_REQUESTS_FOLDER",
-			"objectRelationships": [
-			],
-			"objectValidationRules": [
-			],
-			"panelCategoryKey": "applications_menu.applications.content",
-			"pluralLabel": {
-				"en_US": "Sales Requests"
-			},
-			"portlet": true,
-			"restContextPath": "/o/c/salesrequests",
-			"scope": "company",
-			"status": {
-				"code": 0,
-				"label": "approved",
-				"label_i18n": "Approved"
-			},
-			"system": false,
-			"titleObjectFieldName": "email"
-		},
-		{
-			"active": true,
 			"className": "com.liferay.object.model.ObjectDefinition#C_CONTRACT",
 			"enableCategorization": true,
 			"enableComments": false,
@@ -799,6 +675,25 @@
 			},
 			"name": "Contract",
 			"objectFields": [
+				{
+					"DBType": "Boolean",
+					"businessType": "Boolean",
+					"defaultValue": "false",
+					"externalReferenceCode": "C_CONTRACT_ACTIVE_CONTRACT",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Active Contract"
+					},
+					"name": "activeContract",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Boolean"
+				},
 				{
 					"DBType": "Integer",
 					"businessType": "Integer",
@@ -834,6 +729,25 @@
 					"state": false,
 					"system": false,
 					"type": "Integer"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Picklist",
+					"externalReferenceCode": "C_CONTRACT_CONTRACT_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Contract Type"
+					},
+					"listTypeDefinitionExternalReferenceCode": "LT_CONTRACT_TYPE",
+					"name": "contractType",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
 				},
 				{
 					"DBType": "String",
@@ -874,6 +788,24 @@
 					"state": false,
 					"system": false,
 					"type": "Date"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_CONTRACT_NAME",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Name"
+					},
+					"name": "name",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
 				},
 				{
 					"DBType": "Integer",
@@ -1517,22 +1449,26 @@
 			"name": "Entitlement",
 			"objectFields": [
 				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_ENTITLEMENT_NAME",
+					"DBType": "Date",
+					"businessType": "DateTime",
+					"externalReferenceCode": "C_ENTITLEMENT_END_DATE",
 					"indexed": true,
 					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
+					"indexedLanguageId": "",
 					"label": {
-						"en_US": "Name"
+						"en_US": "End Date"
 					},
-					"name": "name",
+					"name": "endDate",
 					"objectFieldSettings": [
+						{
+							"name": "timeStorage",
+							"value": "convertToUTC"
+						}
 					],
-					"required": true,
+					"required": false,
 					"state": false,
 					"system": false,
-					"type": "String"
+					"type": "Date"
 				},
 				{
 					"DBType": "String",
@@ -1548,6 +1484,42 @@
 					"objectFieldSettings": [
 					],
 					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Double",
+					"businessType": "Decimal",
+					"externalReferenceCode": "C_ENTITLEMENT_MAX_QUANTITY",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Max Quantity"
+					},
+					"name": "maxQuantity",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Double"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_ENTITLEMENT_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Name"
+					},
+					"name": "name",
+					"objectFieldSettings": [
+					],
+					"required": true,
 					"state": false,
 					"system": false,
 					"type": "String"
@@ -1571,24 +1543,6 @@
 					"type": "Double"
 				},
 				{
-					"DBType": "Double",
-					"businessType": "Decimal",
-					"externalReferenceCode": "C_ENTITLEMENT_MAX_QUANTITY",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Max Quantity"
-					},
-					"name": "maxQuantity",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Double"
-				},
-				{
 					"DBType": "Date",
 					"businessType": "DateTime",
 					"externalReferenceCode": "C_ENTITLEMENT_START_DATE",
@@ -1599,28 +1553,6 @@
 						"en_US": "Start Date"
 					},
 					"name": "startDate",
-					"objectFieldSettings": [
-						{
-							"name": "timeStorage",
-							"value": "convertToUTC"
-						}
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Date"
-				},
-				{
-					"DBType": "Date",
-					"businessType": "DateTime",
-					"externalReferenceCode": "C_ENTITLEMENT_END_DATE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "End Date"
-					},
-					"name": "endDate",
 					"objectFieldSettings": [
 						{
 							"name": "timeStorage",
@@ -1666,76 +1598,23 @@
 			"name": "EntitlementDefinition",
 			"objectFields": [
 				{
-					"DBType": "Long",
-					"businessType": "LongInteger",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_USAGE_DEFINITION_ID",
+					"DBType": "Boolean",
+					"businessType": "Boolean",
+					"defaultValue": "true",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_ACTIVE",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "",
 					"label": {
-						"en_US": "Usage Definition ID"
+						"en_US": "Active"
 					},
-					"name": "usageDefinitionId",
+					"name": "active",
 					"objectFieldSettings": [
 					],
 					"required": false,
 					"state": false,
 					"system": false,
-					"type": "Long"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_NAME",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Name"
-					},
-					"name": "name",
-					"objectFieldSettings": [
-					],
-					"required": true,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_DISPLAY_NAME",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Display Name"
-					},
-					"name": "displayName",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_UNIT",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Unit"
-					},
-					"name": "unit",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
+					"type": "Boolean"
 				},
 				{
 					"DBType": "Double",
@@ -1758,6 +1637,24 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_DISPLAY_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Display Name"
+					},
+					"name": "displayName",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
 					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_GRANT_TYPE",
 					"indexed": true,
 					"indexedAsKeyword": true,
@@ -1776,14 +1673,50 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_MACHINE_TYPE",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_NAME",
 					"indexed": true,
 					"indexedAsKeyword": true,
 					"indexedLanguageId": "",
 					"label": {
-						"en_US": "Machine Type"
+						"en_US": "Name"
 					},
-					"name": "machineType",
+					"name": "name",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_PRODUCT_OPTIONS",
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Product Options"
+					},
+					"name": "productOptions",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Clob"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_UNIT",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Unit"
+					},
+					"name": "unit",
 					"objectFieldSettings": [
 					],
 					"required": false,
@@ -1792,23 +1725,22 @@
 					"type": "String"
 				},
 				{
-					"DBType": "Boolean",
-					"businessType": "Boolean",
-					"defaultValue": "true",
-					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_ACTIVE",
+					"DBType": "Long",
+					"businessType": "LongInteger",
+					"externalReferenceCode": "C_ENTITLEMENT_DEFINITION_USAGE_DEFINITION_ID",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "",
 					"label": {
-						"en_US": "Active"
+						"en_US": "Usage Definition ID"
 					},
-					"name": "entitlementDefinitionActive",
+					"name": "usageDefinitionId",
 					"objectFieldSettings": [
 					],
 					"required": false,
 					"state": false,
 					"system": false,
-					"type": "Boolean"
+					"type": "Long"
 				}
 			],
 			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
@@ -1832,8 +1764,6 @@
 			"titleObjectFieldName": "name"
 		},
 		{
-			"accountEntryRestricted": true,
-			"accountEntryRestrictedObjectFieldName": "r_accountEntryToLicenseKey_accountEntryId",
 			"active": true,
 			"enableCategorization": false,
 			"enableComments": false,
@@ -2060,6 +1990,28 @@
 					"type": "Boolean"
 				},
 				{
+					"DBType": "Date",
+					"businessType": "DateTime",
+					"externalReferenceCode": "C_LICENSE_KEY_CUSTOM_EXPIRATION_DATE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Expiration Date"
+					},
+					"name": "customExpirationDate",
+					"objectFieldSettings": [
+						{
+							"name": "timeStorage",
+							"value": "convertToUTC"
+						}
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Date"
+				},
+				{
 					"DBType": "String",
 					"businessType": "Text",
 					"externalReferenceCode": "C_LICENSE_KEY_DESCRIPTION",
@@ -2112,28 +2064,6 @@
 					"state": false,
 					"system": false,
 					"type": "Long"
-				},
-				{
-					"DBType": "Date",
-					"businessType": "DateTime",
-					"externalReferenceCode": "C_LICENSE_KEY_EXPIRATION_DATE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Expiration Date"
-					},
-					"name": "customExpirationDate",
-					"objectFieldSettings": [
-						{
-							"name": "timeStorage",
-							"value": "convertToUTC"
-						}
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Date"
 				},
 				{
 					"DBType": "String",
@@ -2693,8 +2623,6 @@
 			"titleObjectFieldName": "bundleName"
 		},
 		{
-			"accountEntryRestricted": true,
-			"accountEntryRestrictedObjectFieldName": "r_accountToOAuth2DxpAuthorization_accountEntryId",
 			"active": true,
 			"enableCategorization": false,
 			"enableComments": false,
@@ -2994,6 +2922,82 @@
 		},
 		{
 			"active": true,
+			"className": "com.liferay.object.model.ObjectDefinition#C_PROJECT",
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableObjectEntryHistory": false,
+			"externalReferenceCode": "C_PROJECT",
+			"label": {
+				"en_US": "Project"
+			},
+			"name": "Project",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PROJECT_NAME",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Name"
+					},
+					"name": "name",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				}
+			],
+			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
+			"objectRelationships": [
+			],
+			"objectValidationRules": [
+			],
+			"objectViews": [
+				{
+					"defaultObjectView": true,
+					"name": {
+						"en_US": "Default View"
+					},
+					"objectDefinitionExternalReferenceCode": "C_PROJECT",
+					"objectViewColumns": [
+						{
+							"label": {
+								"en_US": "ERC"
+							},
+							"objectFieldName": "externalReferenceCode",
+							"priority": 0
+						},
+						{
+							"label": {
+								"en_US": "Name"
+							},
+							"objectFieldName": "name",
+							"priority": 1
+						}
+					]
+				}
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"pluralLabel": {
+				"en_US": "Projects"
+			},
+			"portlet": true,
+			"restContextPath": "/o/c/projects",
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldName": "name"
+		},
+		{
+			"active": true,
 			"className": "com.liferay.object.model.ObjectDefinition#C_PROPERTY",
 			"enableCategorization": false,
 			"enableComments": false,
@@ -3004,24 +3008,6 @@
 			},
 			"name": "Property",
 			"objectFields": [
-				{
-					"DBType": "Long",
-					"businessType": "LongInteger",
-					"externalReferenceCode": "C_PROPERTY_CLASS_NAME_ID",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Class Name ID"
-					},
-					"name": "classNameId",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Long"
-				},
 				{
 					"DBType": "String",
 					"businessType": "Text",
@@ -3043,6 +3029,24 @@
 				{
 					"DBType": "Long",
 					"businessType": "LongInteger",
+					"externalReferenceCode": "C_PROPERTY_CLASS_NAME_ID",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Class Name ID"
+					},
+					"name": "classNameId",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Long"
+				},
+				{
+					"DBType": "Long",
+					"businessType": "LongInteger",
 					"externalReferenceCode": "C_PROPERTY_CLASS_PK",
 					"indexed": true,
 					"indexedAsKeyword": false,
@@ -3057,6 +3061,24 @@
 					"state": false,
 					"system": false,
 					"type": "Long"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "C_PROPERTY_METADATA_JSON",
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Metadata JSON"
+					},
+					"name": "metadataJson",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Clob"
 				},
 				{
 					"DBType": "String",
@@ -3093,30 +3115,72 @@
 					"state": false,
 					"system": false,
 					"type": "String"
-				},
-				{
-					"DBType": "Clob",
-					"businessType": "LongText",
-					"externalReferenceCode": "C_PROPERTY_METADATA_JSON",
-					"indexed": false,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Metadata JSON"
-					},
-					"name": "metadataJson",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "Clob"
 				}
 			],
 			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
 			"objectRelationships": [
 			],
 			"objectValidationRules": [
+			],
+			"objectViews": [
+				{
+					"defaultObjectView": true,
+					"name": {
+						"en_US": "Default View"
+					},
+					"objectDefinitionExternalReferenceCode": "C_PROPERTY",
+					"objectViewColumns": [
+						{
+							"label": {
+								"en_US": "ERC"
+							},
+							"objectFieldName": "externalReferenceCode",
+							"priority": 0
+						},
+						{
+							"label": {
+								"en_US": "Class Name ID"
+							},
+							"objectFieldName": "classNameId",
+							"priority": 1
+						},
+						{
+							"label": {
+								"en_US": "Class Name"
+							},
+							"objectFieldName": "className",
+							"priority": 2
+						},
+						{
+							"label": {
+								"en_US": "Class PK"
+							},
+							"objectFieldName": "classPK",
+							"priority": 3
+						},
+						{
+							"label": {
+								"en_US": "Name"
+							},
+							"objectFieldName": "name",
+							"priority": 4
+						},
+						{
+							"label": {
+								"en_US": "Value"
+							},
+							"objectFieldName": "value",
+							"priority": 5
+						},
+						{
+							"label": {
+								"en_US": "Metadata JSON"
+							},
+							"objectFieldName": "metadataJson",
+							"priority": 6
+						}
+					]
+				}
 			],
 			"panelCategoryKey": "applications_menu.applications.content",
 			"pluralLabel": {
@@ -3132,6 +3196,253 @@
 			},
 			"system": false,
 			"titleObjectFieldName": "name"
+		},
+		{
+			"active": true,
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableObjectEntryHistory": false,
+			"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST",
+			"label": {
+				"en_US": "Publisher Account Request"
+			},
+			"name": "PublisherAccountRequest",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_EMAIL_ADDRESS",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Email Address"
+					},
+					"name": "emailAddress",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_EXTENSION",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Extension"
+					},
+					"name": "extension",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_FIRST_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "First Name"
+					},
+					"name": "firstName",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_INTL_CODE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Intl Code"
+					},
+					"name": "intlCode",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_LAST_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Last Name"
+					},
+					"name": "lastName",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_PHONE_NUMBER",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Phone Number"
+					},
+					"name": "phoneNumber",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "MultiselectPicklist",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_PUBLISHER_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Publisher Type"
+					},
+					"listTypeDefinitionExternalReferenceCode": "LT_PUBLISHER_TYPE",
+					"name": "publisherType",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_REQUEST_DESCRIPTION",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Request Description"
+					},
+					"name": "requestDescription",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Clob"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Picklist",
+					"defaultValue": "open",
+					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_REQUEST_STATUS",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Request Status"
+					},
+					"listTypeDefinitionExternalReferenceCode": "LT_REQUEST_STATUS",
+					"name": "requestStatus",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				}
+			],
+			"objectFolderExternalReferenceCode": "C_REQUESTS_FOLDER",
+			"objectRelationships": [
+			],
+			"objectValidationRules": [
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"pluralLabel": {
+				"en_US": "Publisher Account Requests"
+			},
+			"portlet": true,
+			"restContextPath": "/o/c/publisheraccountrequests",
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldName": "emailAddress"
+		},
+		{
+			"active": true,
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableObjectEntryHistory": false,
+			"externalReferenceCode": "C_PUBLISHER_ASSETS",
+			"label": {
+				"en_US": "Publisher Assets"
+			},
+			"name": "PublisherAssets",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_ASSETS_VERSION",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Version"
+					},
+					"name": "version",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				}
+			],
+			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
+			"objectRelationships": [
+			],
+			"objectValidationRules": [
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"pluralLabel": {
+				"en_US": "Publisher Assets"
+			},
+			"portlet": true,
+			"restContextPath": "/o/c/publisherassets",
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldName": "version"
 		},
 		{
 			"active": true,
@@ -3216,12 +3527,12 @@
 							"value": "zip,war,jar"
 						},
 						{
-							"name": "maximumFileSize",
-							"value": 200
-						},
-						{
 							"name": "fileSource",
 							"value": "userComputerToDocumentsAndMedia"
+						},
+						{
+							"name": "maximumFileSize",
+							"value": 200
 						},
 						{
 							"name": "showFilesInLibrary",
@@ -3253,58 +3564,6 @@
 			},
 			"system": false,
 			"titleObjectFieldName": "name"
-		},
-		{
-			"accountEntryRestricted": true,
-			"accountEntryRestrictedObjectFieldName": "r_accountEntryToPublisherAssets_accountEntryId",
-			"active": true,
-			"enableCategorization": false,
-			"enableComments": false,
-			"enableObjectEntryHistory": false,
-			"externalReferenceCode": "C_PUBLISHER_ASSETS",
-			"label": {
-				"en_US": "Publisher Assets"
-			},
-			"name": "PublisherAssets",
-			"objectFields": [
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ASSETS_VERSION",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Version"
-					},
-					"name": "version",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				}
-			],
-			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
-			"objectRelationships": [
-			],
-			"objectValidationRules": [
-			],
-			"panelCategoryKey": "applications_menu.applications.content",
-			"pluralLabel": {
-				"en_US": "Publisher Assets"
-			},
-			"portlet": true,
-			"restContextPath": "/o/c/publisherassets",
-			"scope": "company",
-			"status": {
-				"code": 0,
-				"label": "approved",
-				"label_i18n": "Approved"
-			},
-			"system": false,
-			"titleObjectFieldName": "version"
 		},
 		{
 			"active": true,
@@ -3392,7 +3651,7 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_DETAILS_NAME",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_PUBLISHER_NAME",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "en_US",
@@ -3410,7 +3669,7 @@
 				{
 					"DBType": "Clob",
 					"businessType": "LongText",
-					"externalReferenceCode": "C_PUBLISHER_DETAILS_PROFILE_IMAGE",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_PUBLISHER_PROFILE_IMAGE_URL",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "",
@@ -3450,7 +3709,7 @@
 				{
 					"DBType": "Boolean",
 					"businessType": "Boolean",
-					"externalReferenceCode": "C_PUBLISHER_DETAILS_SHOW_ON_HOME",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_SHOW_ON_HOME_PAGE",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "",
@@ -3704,132 +3963,23 @@
 			"enableCategorization": false,
 			"enableComments": false,
 			"enableObjectEntryHistory": false,
-			"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST",
+			"externalReferenceCode": "C_SALES_REQUEST",
 			"label": {
-				"en_US": "Publisher Account Request"
+				"en_US": "Sales Request"
 			},
-			"name": "PublisherAccountRequest",
+			"name": "SalesRequest",
 			"objectFields": [
 				{
 					"DBType": "String",
 					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_EMAIL_ADDRESS",
+					"externalReferenceCode": "C_SALES_REQUEST_ACCOUNT_NAME",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "en_US",
 					"label": {
-						"en_US": "Email Address"
+						"en_US": "Account Name"
 					},
-					"name": "emailAddress",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_EXTENSION",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Extension"
-					},
-					"name": "extension",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_FIRST_NAME",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "First Name"
-					},
-					"name": "firstName",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_INTL_CODE",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Intl Code"
-					},
-					"name": "intlCode",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_LAST_NAME",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Last Name"
-					},
-					"name": "lastName",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_PHONE_NUMBER",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "en_US",
-					"label": {
-						"en_US": "Phone Number"
-					},
-					"name": "phoneNumber",
-					"objectFieldSettings": [
-					],
-					"required": false,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "String",
-					"businessType": "MultiselectPicklist",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_PUBLISHER_TYPE",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Publisher Type"
-					},
-					"listTypeDefinitionExternalReferenceCode": "LT_PUBLISHER_TYPE",
-					"name": "publisherType",
+					"name": "accountName",
 					"objectFieldSettings": [
 					],
 					"required": false,
@@ -3840,14 +3990,32 @@
 				{
 					"DBType": "Clob",
 					"businessType": "LongText",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_REQUEST_DESCRIPTION",
+					"externalReferenceCode": "C_SALES_REQUEST_ADDITIONAL_APPS_REQUESTED",
 					"indexed": true,
 					"indexedAsKeyword": false,
 					"indexedLanguageId": "en_US",
 					"label": {
-						"en_US": "Request Description"
+						"en_US": "Additional Apps Requested"
 					},
-					"name": "requestDescription",
+					"name": "additionalAppsRequested",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Clob"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "C_SALES_REQUEST_COMMENTS",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Comments"
+					},
+					"name": "comments",
 					"objectFieldSettings": [
 					],
 					"required": false,
@@ -3857,17 +4025,33 @@
 				},
 				{
 					"DBType": "String",
-					"businessType": "Picklist",
-					"defaultValue": "open",
-					"externalReferenceCode": "C_PUBLISHER_ACCOUNT_REQUEST_REQUEST_STATUS",
+					"businessType": "Text",
+					"externalReferenceCode": "C_SALES_REQUEST_EMAIL",
 					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
 					"label": {
-						"en_US": "Request Status"
+						"en_US": "Email"
 					},
-					"listTypeDefinitionExternalReferenceCode": "LT_REQUEST_STATUS",
-					"name": "requestStatus",
+					"name": "email",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_SALES_REQUEST_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Name"
+					},
+					"name": "name",
 					"objectFieldSettings": [
 					],
 					"required": false,
@@ -3883,10 +4067,10 @@
 			],
 			"panelCategoryKey": "applications_menu.applications.content",
 			"pluralLabel": {
-				"en_US": "Publisher Account Requests"
+				"en_US": "Sales Requests"
 			},
 			"portlet": true,
-			"restContextPath": "/o/c/publisheraccountrequests",
+			"restContextPath": "/o/c/salesrequests",
 			"scope": "company",
 			"status": {
 				"code": 0,
@@ -3894,11 +4078,311 @@
 				"label_i18n": "Approved"
 			},
 			"system": false,
-			"titleObjectFieldName": "emailAddress"
+			"titleObjectFieldName": "email"
 		},
 		{
-			"accountEntryRestricted": true,
-			"accountEntryRestrictedObjectFieldName": "r_accountToTrialExtensionRequest_accountEntryId",
+			"active": true,
+			"className": "com.liferay.object.model.ObjectDefinition#C_SUBSCRIPTION_ENTRY",
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableObjectEntryHistory": false,
+			"externalReferenceCode": "C_SUBSCRIPTION_ENTRY",
+			"label": {
+				"en_US": "Subscription Entry"
+			},
+			"name": "SubscriptionEntry",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_CLASS_NAME",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Class Name"
+					},
+					"name": "className",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Long",
+					"businessType": "LongInteger",
+					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_CLASS_PK",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Class PK"
+					},
+					"name": "classPK",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "Long"
+				},
+				{
+					"DBType": "Long",
+					"businessType": "LongInteger",
+					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_CUSTOM_USER_ID",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "User ID"
+					},
+					"name": "customUserId",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "Long"
+				}
+			],
+			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
+			"objectRelationships": [
+			],
+			"objectValidationRules": [
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"pluralLabel": {
+				"en_US": "Subscription Entries"
+			},
+			"portlet": true,
+			"restContextPath": "/o/c/subscriptionentries",
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldName": "classPK"
+		},
+		{
+			"active": true,
+			"className": "com.liferay.object.model.ObjectDefinition#C_TICKET_ATTACHMENT",
+			"enableCategorization": false,
+			"enableComments": false,
+			"enableObjectEntryDraft": true,
+			"enableObjectEntryHistory": false,
+			"externalReferenceCode": "C_TICKET_ATTACHMENT",
+			"friendlyURLSeparator": "cpta",
+			"label": {
+				"en_US": "Ticket Attachment"
+			},
+			"name": "TicketAttachment",
+			"objectFields": [
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_ACCOUNT_KEY",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Account Key"
+					},
+					"name": "accountKey",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Clob",
+					"businessType": "LongText",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_DRAFT_COMMENT_BODY",
+					"indexed": false,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "en_US",
+					"label": {
+						"en_US": "Draft Comment Body"
+					},
+					"name": "draftCommentBody",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Clob"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_FILE_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "File Name"
+					},
+					"name": "fileName",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_FILE_SIZE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "File Size"
+					},
+					"name": "fileSize",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_GCS_BUCKET_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Google Cloud Storage Bucket Name"
+					},
+					"name": "gcsBucketName",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_JIRA_ISSUE_KEY",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Jira Issue"
+					},
+					"name": "jiraIssueKey",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_MD5_CHECKSUM",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "MD5 Checksum"
+					},
+					"name": "md5Checksum",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "Long",
+					"businessType": "LongInteger",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_STATE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "State"
+					},
+					"name": "state",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "Long"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_STORAGE_PROVIDER",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Storage Provider"
+					},
+					"name": "storageProvider",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_TICKET_ATTACHMENT_TYPE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Type"
+					},
+					"name": "type",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				}
+			],
+			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
+			"objectRelationships": [
+			],
+			"objectValidationRules": [
+			],
+			"panelCategoryKey": "applications_menu.applications.content",
+			"pluralLabel": {
+				"en_US": "Ticket Attachments"
+			},
+			"portlet": true,
+			"restContextPath": "/o/c/ticketattachments",
+			"scope": "company",
+			"status": {
+				"code": 0,
+				"label": "approved",
+				"label_i18n": "Approved"
+			},
+			"system": false,
+			"titleObjectFieldName": "fileName"
+		},
+		{
 			"active": true,
 			"enableCategorization": false,
 			"enableComments": false,
@@ -4002,93 +4486,6 @@
 			},
 			"system": false,
 			"titleObjectFieldName": "projectId"
-		},
-		{
-			"active": true,
-			"className": "com.liferay.object.model.ObjectDefinition#C_SUBSCRIPTION_ENTRY",
-			"enableCategorization": false,
-			"enableComments": false,
-			"enableObjectEntryHistory": false,
-			"externalReferenceCode": "C_SUBSCRIPTION_ENTRY",
-			"label": {
-				"en_US": "Subscription Entry"
-			},
-			"name": "SubscriptionEntry",
-			"objectFields": [
-				{
-					"DBType": "String",
-					"businessType": "Text",
-					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_CLASS_NAME",
-					"indexed": true,
-					"indexedAsKeyword": true,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Class Name"
-					},
-					"name": "className",
-					"objectFieldSettings": [
-					],
-					"required": true,
-					"state": false,
-					"system": false,
-					"type": "String"
-				},
-				{
-					"DBType": "Long",
-					"businessType": "LongInteger",
-					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_CLASS_PK",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "Class PK"
-					},
-					"name": "classPK",
-					"objectFieldSettings": [
-					],
-					"required": true,
-					"state": false,
-					"system": false,
-					"type": "Long"
-				},
-				{
-					"DBType": "Long",
-					"businessType": "LongInteger",
-					"externalReferenceCode": "C_SUBSCRIPTION_ENTRY_USER_ID",
-					"indexed": true,
-					"indexedAsKeyword": false,
-					"indexedLanguageId": "",
-					"label": {
-						"en_US": "User ID"
-					},
-					"name": "customUserId",
-					"objectFieldSettings": [
-					],
-					"required": true,
-					"state": false,
-					"system": false,
-					"type": "Long"
-				}
-			],
-			"objectFolderExternalReferenceCode": "C_LIFERAY_ONE_FOLDER",
-			"objectRelationships": [
-			],
-			"objectValidationRules": [
-			],
-			"panelCategoryKey": "applications_menu.applications.content",
-			"pluralLabel": {
-				"en_US": "Subscription Entries"
-			},
-			"portlet": true,
-			"restContextPath": "/o/c/subscriptionentries",
-			"scope": "company",
-			"status": {
-				"code": 0,
-				"label": "approved",
-				"label_i18n": "Approved"
-			},
-			"system": false,
-			"titleObjectFieldName": "classPK"
 		}
 	]
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/04-object-relationship.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/04-object-relationship.batch-engine-data.json
@@ -46,6 +46,17 @@
 		},
 		{
 			"deletionType": "cascade",
+			"externalReferenceCode": "R_ACCOUNT_ENTRY_TO_PROJECT",
+			"label": {
+				"en_US": "Account Entry to Project"
+			},
+			"name": "accountEntryToProject",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectDefinitionExternalReferenceCode2": "C_PROJECT",
+			"type": "oneToMany"
+		},
+		{
+			"deletionType": "cascade",
 			"externalReferenceCode": "R_ACCOUNT_ENTRY_TO_PROPERTY",
 			"label": {
 				"en_US": "Account Entry to Property"
@@ -75,6 +86,17 @@
 			"name": "accountEntryToPublisherDetails",
 			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
 			"objectDefinitionExternalReferenceCode2": "C_PUBLISHER_DETAILS",
+			"type": "oneToMany"
+		},
+		{
+			"deletionType": "cascade",
+			"externalReferenceCode": "R_ACCOUNT_ENTRY_TO_TICKET_ATTACHMENT",
+			"label": {
+				"en_US": "Account Entry to Ticket Attachment"
+			},
+			"name": "accountEntryToTicketAttachment",
+			"objectDefinitionExternalReferenceCode1": "L_ACCOUNT",
+			"objectDefinitionExternalReferenceCode2": "C_TICKET_ATTACHMENT",
 			"type": "oneToMany"
 		},
 		{
@@ -243,6 +265,17 @@
 			"type": "oneToMany"
 		},
 		{
+			"deletionType": "disassociate",
+			"externalReferenceCode": "R_ORIGINAL_CONTRACT_TO_CONTRACT",
+			"label": {
+				"en_US": "Original Contract to Contract"
+			},
+			"name": "originalContractToContract",
+			"objectDefinitionExternalReferenceCode1": "C_CONTRACT",
+			"objectDefinitionExternalReferenceCode2": "C_CONTRACT",
+			"type": "oneToMany"
+		},
+		{
 			"deletionType": "cascade",
 			"externalReferenceCode": "R_PRODUCT_ENTRY_TO_PRODUCT_FEEDBACK",
 			"label": {
@@ -262,6 +295,17 @@
 			"name": "productEntryToPublisherAssets",
 			"objectDefinitionExternalReferenceCode1": "L_COMMERCE_PRODUCT_DEFINITION",
 			"objectDefinitionExternalReferenceCode2": "C_PUBLISHER_ASSETS",
+			"type": "oneToMany"
+		},
+		{
+			"deletionType": "disassociate",
+			"externalReferenceCode": "R_PROJECT_TO_CONTRACT",
+			"label": {
+				"en_US": "Project to Contract"
+			},
+			"name": "projectToContract",
+			"objectDefinitionExternalReferenceCode1": "C_PROJECT",
+			"objectDefinitionExternalReferenceCode2": "C_CONTRACT",
 			"type": "oneToMany"
 		},
 		{

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/05-commerce-catalog.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/05-commerce-catalog.batch-engine-data.json
@@ -1,0 +1,19 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.commerce.admin.catalog.dto.v1_0.Catalog",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"currencyCode": "USD",
+			"externalReferenceCode": "SALESFORCE_CATALOG",
+			"name": "Salesforce"
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/06-commerce-currency.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/06-commerce-currency.batch-engine-data.json
@@ -1,0 +1,41 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.commerce.admin.catalog.dto.v1_0.Currency",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "INSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"active": true,
+			"code": "HUF",
+			"externalReferenceCode": "HUF",
+			"name": {
+				"en_US": "Hungarian Forint"
+			},
+			"rate": 1.0
+		},
+		{
+			"active": true,
+			"code": "NZD",
+			"externalReferenceCode": "NZD",
+			"name": {
+				"en_US": "New Zealand Dollar"
+			},
+			"rate": 1.0
+		},
+		{
+			"active": true,
+			"code": "SGD",
+			"externalReferenceCode": "SGD",
+			"name": {
+				"en_US": "Singapore Dollar"
+			},
+			"rate": 1.0
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/07-commerce-specification.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/07-commerce-specification.batch-engine-data.json
@@ -1,0 +1,26 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"description": {
+				"en_US": "Designates the product's classification from Salesforce (Add-on, Primary, Regular)."
+			},
+			"facetable": true,
+			"key": "product-type",
+			"priority": 0,
+			"title": {
+				"en_US": "Product Type"
+			},
+			"visible": true
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/08-commerce-price-list.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/08-commerce-price-list.batch-engine-data.json
@@ -1,0 +1,110 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.commerce.admin.pricing.dto.v2_0.PriceList",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "AUD",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_AUD",
+			"name": "Salesforce AUD",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "BRL",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_BRL",
+			"name": "Salesforce BRL",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "CAD",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_CAD",
+			"name": "Salesforce CAD",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "CNY",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_CNY",
+			"name": "Salesforce CNY",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "EUR",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_EUR",
+			"name": "Salesforce EUR",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "GBP",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_GBP",
+			"name": "Salesforce GBP",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "HUF",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_HUF",
+			"name": "Salesforce HUF",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "INR",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_INR",
+			"name": "Salesforce INR",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "JPY",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_JPY",
+			"name": "Salesforce JPY",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "NZD",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_NZD",
+			"name": "Salesforce NZD",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "SGD",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_SGD",
+			"name": "Salesforce SGD",
+			"type": "price-list"
+		},
+		{
+			"active": true,
+			"catalogExternalReferenceCode": "SALESFORCE_CATALOG",
+			"currencyCode": "USD",
+			"externalReferenceCode": "SALESFORCE_PRICE_LIST_USD",
+			"name": "Salesforce USD",
+			"type": "price-list"
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/09-object-definition-account-entry-restricted.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/09-object-definition-account-entry-restricted.batch-engine-data.json
@@ -1,0 +1,39 @@
+{
+	"configuration": {
+		"className": "com.liferay.object.admin.rest.dto.v1_0.ObjectDefinition",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"accountEntryRestricted": true,
+			"accountEntryRestrictedObjectFieldName": "r_accountEntryToAccountNote_accountEntryId",
+			"externalReferenceCode": "C_ACCOUNT_NOTE"
+		},
+		{
+			"accountEntryRestricted": true,
+			"accountEntryRestrictedObjectFieldName": "r_accountToOAuth2DxpAuthorization_accountEntryId",
+			"externalReferenceCode": "C_OAUTH2_DXP_AUTHORIZATION"
+		},
+		{
+			"accountEntryRestricted": true,
+			"accountEntryRestrictedObjectFieldName": "r_accountEntryToPublisherAssets_accountEntryId",
+			"externalReferenceCode": "C_PUBLISHER_ASSETS"
+		},
+		{
+			"accountEntryRestricted": true,
+			"accountEntryRestrictedObjectFieldName": "r_accountEntryToTicketAttachment_accountEntryId",
+			"externalReferenceCode": "C_TICKET_ATTACHMENT"
+		},
+		{
+			"accountEntryRestricted": true,
+			"accountEntryRestrictedObjectFieldName": "r_accountToTrialExtensionRequest_accountEntryId",
+			"externalReferenceCode": "C_TRIAL_EXTENSION_REQUEST"
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/10-commerce-channel.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/10-commerce-channel.batch-engine-data.json
@@ -1,0 +1,20 @@
+{
+	"configuration": {
+		"className": "com.liferay.headless.commerce.admin.channel.dto.v1_0.Channel",
+		"parameters": {
+			"containsHeaders": "true",
+			"createStrategy": "UPSERT",
+			"onErrorFail": "false",
+			"taskItemDelegateName": "DEFAULT",
+			"updateStrategy": "PARTIAL_UPDATE"
+		}
+	},
+	"items": [
+		{
+			"currencyCode": "USD",
+			"externalReferenceCode": "SALESFORCE_CHANNEL",
+			"name": "Salesforce Channel",
+			"type": "site"
+		}
+	]
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/client-extension.yaml
@@ -10,7 +10,10 @@ liferay-one-batch-oahs:
     .serviceScheme: http
     name: Liferay One Batch OAuth Application Headless Server
     scopes:
+        -   c_project.everything
+        -   c_property.everything
         -   Liferay.Headless.Admin.List.Type.everything
+        -   Liferay.Headless.Admin.User.everything
         -   Liferay.Headless.Batch.Engine.everything
         -   Liferay.Object.Admin.REST.everything
     type: oAuthApplicationHeadlessServer

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
@@ -80,6 +80,45 @@
 	{
 		"dataType": 15,
 		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "accountOwnerEmailAddress",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "accountOwnerFirstName",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "accountOwnerLastName",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
 		"name": "cloudProjectName",
 		"properties": {
 			"hidden": false,
@@ -106,7 +145,163 @@
 	{
 		"dataType": 15,
 		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "dossieraProjectKey",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "gsInvolved",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "ldpWorkspaceName",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
 		"name": "marketplaceOrderType",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "opportunityProductFamily",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "opportunitySoldBy",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "opportunityStageName",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "opportunityTerritory",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "opportunityType",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "partnerAccount",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "partnerFirstLineSupport",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "projectDescription",
+		"properties": {
+			"hidden": false,
+			"indexType": 1,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "projectKey",
 		"properties": {
 			"hidden": false,
 			"indexType": 2,
@@ -123,6 +318,162 @@
 		"properties": {
 			"hidden": false,
 			"indexType": 1,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "projectSolution",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 1,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "renewal",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "cloudRegion",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "customStatus",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 3,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "effectiveEndDate",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 3,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "endDate",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "machineType",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "opportunitySoldBy",
+		"properties": {
+			"hidden": false,
+			"indexType": 1,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "orderType",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 9,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "sizing",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 5,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "spendLimit",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 3,
+		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
+		"name": "startDate",
+		"properties": {
+			"hidden": false,
+			"indexType": 0,
 			"localizeField": false,
 			"localizeFieldName": true,
 			"secret": false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89424

## What Is Being Fixed

The liferay-one data-model layer — object definitions, list types, system object fields, relationships, commerce batch data, and expando columns — exists only interleaved across many tickets on the team's master-temp branch. It needs to land on master, in a single coherent change, for review and forwarding upstream.

## How It Is Being Fixed

Consolidates the data-model definitions into one change: the liferay-one-batch batch-engine-data files (list types, system object fields, object definitions and relationships, and the commerce catalog, currency, specification, price-list, and channel data, plus the account-entry-restricted object definition) and the site-initializer expando-columns. The content is a flattened replay of the corresponding master-temp work (LPD-89032, LPD-89034, LPD-89259, LPD-89424, LPD-90459, LPD-90489, LPD-92220) rebased onto the current master, so history is intentionally squashed for a clean diff.

## Why Are There No Tests?

The change is declarative object/list-type/relationship batch-engine data and expando column definitions — configuration with no executable logic to unit test. It is validated by the client-extension build and the site-initializer / batch-engine import at deploy time.

## PR Check

**pr-check: PASS** — tested on `3ac54ecd8771be1f051e9b4001002d639a2feee9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "3ac54ecd8771be1f051e9b4001002d639a2feee9"} -->