### PR TITLE
LPD-89753 Migrate SSA dashboard pages and Trial Details

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
@@ -23,6 +23,7 @@
 		"@hookform/resolvers": "^3.1.1",
 		"classnames": "^2.3.2",
 		"date-fns": "^2.30.0",
+		"dompurify": "^3.3.1",
 		"formik": "^2.2.9",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
@@ -35,6 +36,7 @@
 		"zod": "^3.21.4"
 	},
 	"devDependencies": {
+		"@types/dompurify": "^3.0.2",
 		"@types/react": "^18.2.6",
 		"@types/react-dom": "^18.0.9",
 		"@vitejs/plugin-react": "^3.0.0",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/alert": "^3.159.0",
 		"@clayui/autocomplete": "^3.159.0",
 		"@clayui/button": "^3.159.0",
 		"@clayui/core": "^3.159.0",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ExternalLink.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/ExternalLink.tsx
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLink from '@clayui/link';
+import {ComponentProps} from 'react';
+
+type ExternalLinkProps = {
+	showShortcut?: boolean;
+} & ComponentProps<typeof ClayLink>;
+
+export default function ExternalLink({
+	children,
+	showShortcut = true,
+	...otherProps
+}: ExternalLinkProps) {
+	return (
+		<ClayLink displayType="secondary" target="_blank" {...otherProps}>
+			{children}
+
+			{showShortcut && (
+				<ClayIcon className="ml-1" fontSize={8} symbol="shortcut" />
+			)}
+		</ClayLink>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Input/formInput/index.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Input/formInput/index.scss
@@ -1,0 +1,13 @@
+.custom-input {
+	background-color: #fff;
+	border: 1px solid #b1b2b9;
+	border-radius: 8px;
+
+	&::placeholder {
+		opacity: 40%;
+	}
+}
+
+.text-muted {
+	font-size: 13px !important;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Input/formInput/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Input/formInput/index.tsx
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import {InputHTMLAttributes} from 'react';
+
+import BaseWrapper from '../base/BaseWrapper';
+
+import './index.scss';
+
+import classNames from 'classnames';
+
+export type InputProps = {
+	boldLabel?: boolean;
+	className?: string;
+	component?: string;
+	description?: string;
+	disabled?: boolean;
+	errors?: any;
+	helpMessage?: string;
+	id?: string;
+	label?: string;
+	name: string;
+	options?: {label: string; value: string} | [];
+	register?: any;
+	required?: boolean;
+	type?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+const FormInput: React.FC<InputProps> = ({
+	boldLabel,
+	className,
+	description,
+	disabled = false,
+	errors = {},
+	helpMessage,
+	label,
+	name,
+	register = () => {},
+	id = name,
+	type,
+	value,
+	required = false,
+	onBlur,
+	...otherProps
+}) => {
+	return (
+		<BaseWrapper
+			boldLabel={boldLabel}
+			description={description}
+			disabled={disabled}
+			error={errors[name]?.message}
+			helpMessage={helpMessage}
+			id={id}
+			label={label}
+			required={required}
+		>
+			<ClayInput
+				className={classNames('rounded-xs custom-input', className)}
+				component={type === 'textarea' ? 'textarea' : 'input'}
+				disabled={disabled}
+				id={id}
+				name={name}
+				type={type}
+				value={value}
+				{...otherProps}
+				{...register(name, {onBlur, required})}
+			/>
+		</BaseWrapper>
+	);
+};
+
+export default FormInput;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/MultiSelect/MultiSelect.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/MultiSelect/MultiSelect.tsx
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayMultiSelect from '@clayui/multi-select';
+
+import {getIconSpriteMap} from '../../liferay/constants';
+import {FieldBase} from '../FieldBase';
+
+type MultiSelectProps<T> = {
+	ariaLabel?: string;
+	className?: string;
+	disabledClearAll?: boolean;
+	errorMessage?: string;
+	helpMessage?: string;
+	hideFeedback?: boolean;
+	inputName: string;
+	label?: string;
+	localized?: boolean;
+	multiselectKey: string;
+	onChange?: (values: T) => void;
+	onItemsChange: (values: T) => void;
+	placeholder?: string;
+	required?: boolean;
+	selectedItems: T[];
+	sourceItems: T[];
+	tooltip?: string;
+	value?: string;
+};
+
+const MultiSelect: React.FC<MultiSelectProps<any>> = ({
+	ariaLabel,
+	className,
+	disabledClearAll = false,
+	errorMessage,
+	helpMessage,
+	hideFeedback,
+	inputName,
+	label,
+	localized,
+	multiselectKey,
+	onChange,
+	onItemsChange,
+	required,
+	selectedItems,
+	sourceItems,
+	tooltip,
+	value,
+}) => {
+	return (
+		<FieldBase
+			className={className}
+			errorMessage={errorMessage}
+			helpMessage={helpMessage}
+			hideFeedback={hideFeedback}
+			label={label}
+			localized={localized}
+			required={required}
+			tooltip={tooltip}
+		>
+			<ClayMultiSelect
+				aria-label={ariaLabel}
+				disabledClearAll={disabledClearAll}
+				inputName={inputName}
+				items={selectedItems}
+				key={multiselectKey}
+				onChange={onChange}
+				onItemsChange={onItemsChange}
+				sourceItems={sourceItems}
+				spritemap={getIconSpriteMap()}
+				value={value}
+			/>
+		</FieldBase>
+	);
+};
+
+export default MultiSelect;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsHeader.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsHeader.scss
@@ -1,0 +1,21 @@
+.order-details-publisher {
+	color: #6c6c75;
+	font-size: 16px;
+
+	&-icon {
+		border-radius: 8px;
+		max-height: 56px;
+		object-fit: contain;
+	}
+
+	&-table-icon {
+		border-radius: 4px;
+		max-height: 36px;
+		object-fit: contain;
+		width: 36px;
+	}
+
+	.header-description {
+		color: var(--neutral-08, #54555f);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsHeader.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsHeader.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import React from 'react';
+
+import OrderDetailsStatusDescription from './OrderDetailsStatusDescription';
+
+import './OrderDetailsHeader.scss';
+
+type OrderDetailsProps = {
+	beta?: string;
+	className?: string;
+	hasOrderDescription?: string;
+	hasOrderDetails?: boolean;
+	image?: string;
+	name?: string;
+	order?: PlacedOrder;
+	productOwner?: string;
+	version?: string;
+};
+
+const OrderDetailsHeader: React.FC<OrderDetailsProps> = ({
+	beta,
+	className,
+	hasOrderDescription = false,
+	hasOrderDetails = false,
+	image,
+	name,
+	order,
+	productOwner,
+	version,
+}) => (
+	<div className={className}>
+		<div className="d-flex flex-row">
+			<img
+				alt="App Icon"
+				className="order-details-publisher-icon"
+				draggable={false}
+				src={image}
+			/>
+
+			<div className="d-flex flex-column justify-content-between ml-4">
+				<div className="align-items-center d-flex justify-content-start">
+					<h2 className="m-0 text-weight-bold">{name}</h2>
+
+					{beta && (
+						<label className="beta-badge-label ml-2">{beta}</label>
+					)}
+					{version && <p className="ml-2 my-0">v{version}</p>}
+				</div>
+
+				{hasOrderDetails && (
+					<OrderDetailsStatusDescription
+						order={order}
+						productOwner={productOwner}
+					/>
+				)}
+
+				{hasOrderDescription && (
+					<div className="header-description text-capitalize">
+						{hasOrderDescription}
+					</div>
+				)}
+			</div>
+		</div>
+	</div>
+);
+
+export default OrderDetailsHeader;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsStatusDescription.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsStatusDescription.tsx
@@ -7,8 +7,8 @@ import ClayLabel from '@clayui/label';
 import classNames from 'classnames';
 
 import purchasedAppIcon from '../assets/icons/purchased_app_icon.svg';
-import OrderStatus from './OrderStatus';
 import {OrderTypes} from '../enums/Order';
+import OrderStatus from './OrderStatus';
 
 type OrderDetailsStatusDescriptionProps = {
 	order?: PlacedOrder;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsStatusDescription.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderDetailsStatusDescription.tsx
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayLabel from '@clayui/label';
+import classNames from 'classnames';
+
+import purchasedAppIcon from '../assets/icons/purchased_app_icon.svg';
+import OrderStatus from './OrderStatus';
+import {OrderTypes} from '../enums/Order';
+
+type OrderDetailsStatusDescriptionProps = {
+	order?: PlacedOrder;
+	productOwner?: string;
+};
+
+const getOrderDetailsType = (orderTypeExternalReferenceCode: string) => {
+	if (orderTypeExternalReferenceCode === OrderTypes.DXP_APP) {
+		return 'DXP APP';
+	}
+
+	if (orderTypeExternalReferenceCode === OrderTypes.CLOUD_APP) {
+		return 'CLOUD APP';
+	}
+};
+
+const OrderDetailsStatusDescription = ({
+	order,
+	productOwner,
+}: OrderDetailsStatusDescriptionProps) => {
+	const orderType = getOrderDetailsType(
+		order?.orderTypeExternalReferenceCode as string
+	);
+
+	return (
+		<div className="align-items-center d-flex">
+			<div
+				className={classNames(classNames, {
+					'order-details-publisher mr-3': productOwner,
+				})}
+			>
+				{productOwner}
+			</div>
+
+			{order && (
+				<div className="align-items-center app-details-status d-flex mr-3">
+					<OrderStatus placedOrder={order} />
+				</div>
+			)}
+
+			{orderType && (
+				<ClayLabel className="rounded" displayType="info" large>
+					<div className="align-items-center d-flex">
+						<img
+							alt="Purchased Order Icon"
+							className="mr-1"
+							src={purchasedAppIcon}
+						/>
+
+						{orderType}
+					</div>
+				</ClayLabel>
+			)}
+		</div>
+	);
+};
+
+export default OrderDetailsStatusDescription;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/OrderStatus.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/OrderStatus.scss
@@ -1,0 +1,24 @@
+.order-status-icon {
+	height: 0.5rem;
+	width: 0.5rem;
+
+	&-completed {
+		color: #4aab3b;
+	}
+
+	&-processing {
+		color: #2e5aac;
+	}
+
+	&-pending {
+		color: #b95000;
+	}
+}
+
+.order-status-text {
+	color: #6c6c75;
+	font-size: 0.813rem;
+	font-weight: 600;
+	line-height: 1rem;
+	text-transform: capitalize;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/OrderStatus.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/OrderStatus.tsx
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+
+import {
+	OrderTypes,
+	OrderWorkflowStatusCode,
+	getOrderStatusLabel,
+	orderWorkflowStatusCodeLabels,
+} from '../../enums/Order';
+
+import './OrderStatus.scss';
+
+type OrderStatusProps = {
+	placedOrder: PlacedOrder;
+};
+
+const OrderStatus = ({placedOrder}: OrderStatusProps) => {
+	const orderStatusLabel = getOrderStatusLabel(placedOrder);
+
+	const getOrderStatusClassName = () => {
+		const orderStatus = placedOrder.orderStatusInfo.code;
+
+		if (
+			placedOrder.orderStatusInfo.code !==
+				OrderWorkflowStatusCode.COMPLETED &&
+			placedOrder.orderTypeExternalReferenceCode === OrderTypes.AI_HUB
+		) {
+			return 'order-status-icon-processing';
+		}
+
+		if (
+			orderStatusLabel ===
+				orderWorkflowStatusCodeLabels[
+					OrderWorkflowStatusCode.PENDING_PAYMENT
+				] ||
+			OrderWorkflowStatusCode.PENDING === orderStatus
+		) {
+			return 'order-status-icon-pending';
+		}
+
+		if (OrderWorkflowStatusCode.COMPLETED === orderStatus) {
+			return 'order-status-icon-completed';
+		}
+
+		return 'order-status-icon-processing';
+	};
+
+	return (
+		<>
+			<ClayIcon
+				className={classNames(
+					'mr-2 order-status-icon',
+					getOrderStatusClassName()
+				)}
+				symbol="circle"
+			/>
+
+			<span className="order-status-text">{orderStatusLabel}</span>
+		</>
+	);
+};
+
+export default OrderStatus;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/OrderStatus/index.tsx
@@ -1,0 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export * from './OrderStatus';
+
+export {default} from './OrderStatus';

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceDeliveryOrder.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceDeliveryOrder.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	OrderCustomFields,
+	OrderTypes,
+	OrderWorkflowStatusCode,
+} from '../enums/Order';
+
+type CustomFields = {
+	[key in keyof typeof OrderCustomFields]: string;
+};
+
+export default class MarketplaceDeliveryOrder {
+	constructor(private order: PlacedOrder) {}
+
+	get canDownload() {
+		return [
+			OrderTypes.CLIENT_EXTENSION,
+			OrderTypes.COMPOSITE_APP,
+			OrderTypes.DXP_APP,
+			OrderTypes.LOW_CODE_CONFIGURATION,
+			OrderTypes.OTHER,
+		].includes(this.order.orderTypeExternalReferenceCode as OrderTypes);
+	}
+
+	get createDate() {
+		return this.order.createDate;
+	}
+
+	get canGenerateLicenses() {
+		return (
+			[
+				OrderTypes.CLIENT_EXTENSION,
+				OrderTypes.COMPOSITE_APP,
+				OrderTypes.DXP_APP,
+			].includes(
+				this.order.orderTypeExternalReferenceCode as OrderTypes
+			) && !this.isFreeApp
+		);
+	}
+	get customFields() {
+		const customFields = {} as CustomFields;
+
+		for (const key in OrderCustomFields) {
+			const keyValue = (OrderCustomFields as any)[key];
+
+			(customFields as any)[key] = this.order?.customFields?.[keyValue];
+		}
+
+		return customFields;
+	}
+
+	get isCancelled() {
+		return (
+			this.order?.orderStatusInfo?.code ===
+			OrderWorkflowStatusCode.CANCELLED
+		);
+	}
+
+	get isFreeApp() {
+		return this.order.placedOrderItems?.[0]?.price?.price === 0;
+	}
+
+	get isOrderCompleted() {
+		return (
+			this.order.orderStatusInfo?.code ===
+			OrderWorkflowStatusCode.COMPLETED
+		);
+	}
+
+	get placedOrderItems() {
+		return this.order?.placedOrderItems ?? [];
+	}
+
+	get productThumbnail() {
+		return this.placedOrderItems[0]?.thumbnail;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceDeliveryProduct.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/entity/MarketplaceDeliveryProduct.ts
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {
+	ProductLicense,
+	ProductLicenseType,
+	ProductPriceModel,
+	ProductSpecificationKey,
+	ProductType,
+	ProductTypeLabels,
+	ProductVocabulary,
+} from '../enums/Product';
+import i18n from '../i18n';
+import {ConsoleUserProject} from '../services/oauth/types';
+import {safeJSONParse} from '../utils/util';
+
+const productTypeIcons = {
+	cloud: 'cloud',
+	dxp: 'site-template',
+};
+
+export class MarketplaceDeliveryProduct {
+	constructor(protected product: DeliveryProduct) {}
+
+	get appSettings() {
+		return safeJSONParse(this.specificationValues.APP_SETTINGS, {
+			isDownloadable: false,
+		});
+	}
+
+	get appType() {
+		const {APP_TYPE} = this.specificationValues;
+
+		let type: string =
+			ProductTypeLabels[APP_TYPE as unknown as ProductType];
+
+		if (!type) {
+			const categories = this.getCategories(
+				ProductVocabulary.PRODUCT_TYPE
+			);
+
+			type = categories[0]?.name;
+		}
+
+		return type || APP_TYPE;
+	}
+
+	get appVersion() {
+		return this.specificationValues.APP_VERSION || '1.0.0';
+	}
+
+	get catalogName() {
+		return this.product.catalogName;
+	}
+
+	get createDate() {
+		return this.product.createDate;
+	}
+
+	get description() {
+		return this.product.description;
+	}
+
+	get friendlyURL() {
+		return this.product.urls.en_US;
+	}
+
+	public get isPerpetualLicense() {
+		const licenseType = this.specificationValues
+			.APP_LICENSING_TYPE as string;
+
+		return licenseType === ProductLicenseType.PERPETUAL;
+	}
+
+	get productImage() {
+		return this.product.urlImage;
+	}
+
+	get specificationValues() {
+		const _specifications = {} as {
+			[key in keyof typeof ProductSpecificationKey]: string;
+		};
+
+		for (const specificationKey in ProductSpecificationKey) {
+			const _key =
+				specificationKey as keyof typeof ProductSpecificationKey;
+
+			(_specifications as any)[_key] = this.getSpecificationValue(
+				ProductSpecificationKey[_key]
+			);
+		}
+
+		return _specifications;
+	}
+
+	public getCloudResourceLabel(consoleUserProject: ConsoleUserProject) {
+		let output = '';
+
+		if (!consoleUserProject) {
+			return output;
+		}
+
+		const round = (value: number) => {
+			if (!value) {
+				return 0;
+			}
+
+			return Math.floor(value);
+		};
+
+		output += `${consoleUserProject.environments.length} ${i18n.translate('environment')}, `;
+		output += `${round(consoleUserProject.rootProjectPlanUsage.cpu.free)} CPUs, `;
+		output += `${round(consoleUserProject.rootProjectPlanUsage.memory.free / 1000)} GB RAM`;
+
+		return output;
+	}
+
+	public getPrice() {
+		const priceModel = this.getPriceModel();
+
+		if (priceModel.toLowerCase() === ProductPriceModel.FREE.toLowerCase()) {
+			return ProductPriceModel.FREE;
+		}
+
+		const [purchasableSKU] = this.getPurchasableSKUs();
+
+		return purchasableSKU?.price?.priceFormatted;
+	}
+
+	public getPriceModel() {
+		return this.getSpecificationValue(
+			ProductSpecificationKey.APP_PRICING_MODEL,
+			'Free'
+		);
+	}
+
+	public getProductImages() {
+		return this.product.images
+			.filter((image) => image.priority !== 0)
+			.map((image) => image.src);
+	}
+
+	public getProductOptionKey() {
+		const optionsTypes = {
+			[ProductType.CLOUD]: ProductLicense.CLOUD,
+			[ProductType.DXP]: ProductLicense.DXP,
+		};
+
+		return (
+			optionsTypes[
+				this.specificationValues
+					.APP_TYPE as unknown as keyof typeof optionsTypes
+			] || ProductLicense.BASE
+		);
+	}
+
+	public getProductResourceLabel() {
+		const cpuSpecification = this.getSpecificationValue(
+			ProductSpecificationKey.APP_BUILD_NUMBER_OF_CPUS,
+			'0'
+		);
+
+		const ramSpecification = this.getSpecificationValue(
+			ProductSpecificationKey.APP_BUILD_RAM_IN_GBS,
+			'0'
+		);
+
+		return `${cpuSpecification}CPUs, ${ramSpecification}GB RAM`;
+	}
+
+	public getProductType() {
+		const type = this.getSpecificationValue(
+			ProductSpecificationKey.APP_TYPE
+		);
+
+		return {
+			icon:
+				(productTypeIcons as any)[
+					type as keyof typeof productTypeIcons
+				] || 'cog',
+			label: `${type} App`,
+			type,
+		};
+	}
+
+	public getPurchasableSKUs() {
+		return this.product.skus.filter(({purchasable}) => purchasable);
+	}
+
+	public getSolutionCategories() {
+		return this.getCategories(ProductVocabulary.SOLUTION_CATEGORY);
+	}
+
+	public getSpecification(
+		specificationKey: string | typeof ProductSpecificationKey
+	) {
+		return this.product.productSpecifications.find(
+			(specification) =>
+				specification.specificationKey === specificationKey
+		);
+	}
+
+	public hasEnoughResources(cloudUserProject: ConsoleUserProject) {
+		if (!cloudUserProject) {
+			return false;
+		}
+
+		if (!cloudUserProject.rootProjectPlanUsage.instance.free) {
+			return false;
+		}
+
+		const cpuSpecification = Number(
+			this.getSpecificationValue(
+				ProductSpecificationKey.APP_BUILD_NUMBER_OF_CPUS,
+				'0'
+			)
+		);
+
+		const ramSpecification = Number(
+			this.getSpecificationValue(
+				ProductSpecificationKey.APP_BUILD_RAM_IN_GBS,
+				'0'
+			)
+		);
+
+		if (
+			cloudUserProject.rootProjectPlanUsage.cpu.free < cpuSpecification ||
+			Math.floor(
+				cloudUserProject.rootProjectPlanUsage.memory.free / 1000
+			) < ramSpecification
+		) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public getLicenseTagText() {
+		if (!this.specificationValues.APP_LICENSING_TYPE) {
+			return '';
+		}
+
+		if (this.isPerpetualLicense) {
+			return 'One-Time';
+		}
+
+		return 'Anually';
+	}
+
+	protected getCategories(vocabulary: string) {
+		return this.product.categories.filter(
+			(category) =>
+				category.vocabulary?.toLowerCase() === vocabulary?.toLowerCase()
+		);
+	}
+
+	private getSpecificationValue(
+		specificationKey: string | typeof ProductSpecificationKey,
+		value = ''
+	) {
+		return this.getSpecification(specificationKey)?.value || value;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useGetProductByOrderId.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useGetProductByOrderId.ts
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {SWRConfiguration} from 'swr';
+
+import MarketplaceDeliveryOrder from '../entity/MarketplaceDeliveryOrder';
+import {MarketplaceDeliveryProduct} from '../entity/MarketplaceDeliveryProduct';
+import {ProductImageFallbackCategories} from '../enums/Product';
+import {Liferay} from '../liferay/liferay';
+import HeadlessCommerceDeliveryCatalog from '../services/rest/HeadlessCommerceDeliveryCatalog';
+import HeadlessCommerceDeliveryOrder from '../services/rest/HeadlessCommerceDeliveryOrder';
+import {
+	getProductFallback,
+	getProductImageFallback,
+} from '../utils/productUtils';
+
+const useGetProductByOrderId = (
+	orderId: string,
+	swrOptions?: SWRConfiguration
+) => {
+	return useSWR(
+		`/placed-order/${orderId}/product`,
+		async () => {
+			const placedOrder =
+				await HeadlessCommerceDeliveryOrder.getPlacedOrder(orderId);
+
+			if (placedOrder.placedOrderBillingAddressId > 0) {
+				placedOrder.placedOrderBillingAddress =
+					await HeadlessCommerceDeliveryOrder.getPlacedOrderBillingAddress(
+						orderId
+					);
+			}
+
+			let product;
+
+			try {
+				product = await HeadlessCommerceDeliveryCatalog.getProduct(
+					Liferay.CommerceContext.commerceChannelId,
+					placedOrder.placedOrderItems[0].productId,
+					new URLSearchParams({
+						'accountId': '-1',
+						'attachments.accountId': '-1',
+						'images.accountId': '-1',
+						'nestedFields':
+							'attachments,categories,images,productSpecifications',
+						'skus.accountId': '-1',
+					})
+				);
+			}
+			catch (error) {
+				console.error('Failed to fetch product:', error);
+
+				product = getProductFallback();
+				placedOrder.placedOrderItems[0].thumbnail =
+					getProductImageFallback(
+						ProductImageFallbackCategories.PRODUCT_IMAGE
+					);
+			}
+
+			return {
+				marketplaceDeliveryOrder: new MarketplaceDeliveryOrder(
+					placedOrder
+				),
+				marketplaceDeliveryProduct: new MarketplaceDeliveryProduct(
+					product
+				),
+				placedOrder,
+				product,
+			};
+		},
+		swrOptions
+	);
+};
+
+export default useGetProductByOrderId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Environments/Environments.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Environments/Environments.tsx
@@ -3,10 +3,41 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useProperties} from '../../../context/PropertiesContext';
+import ClayButton from '@clayui/button';
+import {useModal} from '@clayui/modal';
+
+import Page from '../../../components/Page';
+import i18n from '../../../i18n';
+import TrialListView from '../SSADashboard/components/TrialListView/TrialListView';
+import useSSAActions from '../SSADashboard/hooks/useSSAActions';
 
 export default function Environments() {
-	const {accountId} = useProperties();
+	const actions = useSSAActions();
+	const createTrialFormModal = useModal();
 
-	return <div>{accountId}</div>;
+	return (
+		<Page
+			description={i18n.translate('manage-your-teams-trial')}
+			pageRendererProps={{className: 'border py-2'}}
+			rightButton={
+				<ClayButton
+					onClick={() => createTrialFormModal.onOpenChange(true)}
+				>
+					{i18n.translate('add-new-trial')}
+				</ClayButton>
+			}
+			title="SaaS Demos"
+		>
+			<TrialListView
+				actions={actions}
+				createTrialFormModal={createTrialFormModal}
+				isSortable
+				managementToolbarProps={{
+					searchVisible: true,
+					visible: true,
+				}}
+				parentPath="/saas-trials"
+			/>
+		</Page>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
@@ -66,7 +66,8 @@ export default function ManageSsaSaasUsers() {
 								const filteredRoles =
 									ssaAccount?.roleBriefs.filter((item2) =>
 										ssaRoles.some(
-											(item1) => item1.value === item2.name
+											(item1) =>
+												item1.value === item2.name
 										)
 									);
 
@@ -86,7 +87,8 @@ export default function ManageSsaSaasUsers() {
 						{
 							id: 'lastLoginDate',
 							name: i18n.translate('last-login'),
-							render: (lastLoginDate) => formatDate(lastLoginDate),
+							render: (lastLoginDate) =>
+								formatDate(lastLoginDate),
 						},
 					],
 				}}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/ManageSsaSaasUsers/ManageSsaSaasUsers.tsx
@@ -3,6 +3,94 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {useEffect} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import ListView from '../../../components/ListView';
+import Page from '../../../components/Page';
+import {useOneContext} from '../../../context/OneContext';
+import i18n from '../../../i18n';
+import {formatDate} from '../../../utils/date';
+import {ssaRoles} from '../SSADashboard/constants';
+import useManageUserActions from '../SSADashboard/hooks/useManageUserActions';
+
 export default function ManageSsaSaasUsers() {
-	return <div />;
+	const {marketplaceUserAccount} = useOneContext();
+	const {properties} = useOneContext();
+	const actions = useManageUserActions();
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (!marketplaceUserAccount.isSSAAdmin) {
+			navigate('/');
+		}
+	}, [marketplaceUserAccount.isSSAAdmin, navigate]);
+
+	return (
+		<Page
+			description={i18n.translate(
+				'manage-members-and-access-for-ssa-accounts'
+			)}
+			pageRendererProps={{className: 'border py-2 rounded'}}
+			title={i18n.translate('manage-users')}
+		>
+			<ListView<UserAccount>
+				id="manage-ssa-users"
+				managementToolbarProps={{
+					searchVisible: true,
+					visible: true,
+				}}
+				resource={`o/headless-admin-user/v1.0/accounts/by-external-reference-code/${properties.accountExternalReferenceCode}/user-accounts?sort=name:asc`}
+				tableProps={{
+					actions,
+					columns: [
+						{
+							id: 'name',
+							name: i18n.translate('name'),
+							sortable: true,
+						},
+						{
+							id: 'emailAddress',
+							name: i18n.translate('email-address'),
+						},
+						{
+							id: 'accountBriefs',
+							name: i18n.translate('roles'),
+							render: (accountBriefs) => {
+								const ssaAccount = accountBriefs.find(
+									(accountBrief) =>
+										accountBrief.externalReferenceCode ===
+										properties.accountExternalReferenceCode
+								);
+
+								const filteredRoles =
+									ssaAccount?.roleBriefs.filter((item2) =>
+										ssaRoles.some(
+											(item1) => item1.value === item2.name
+										)
+									);
+
+								return (
+									<div className="d-flex flex-column">
+										{filteredRoles?.map((role, index) => {
+											return (
+												<p className="m-0" key={index}>
+													{role.name}
+												</p>
+											);
+										})}
+									</div>
+								);
+							},
+						},
+						{
+							id: 'lastLoginDate',
+							name: i18n.translate('last-login'),
+							render: (lastLoginDate) => formatDate(lastLoginDate),
+						},
+					],
+				}}
+			/>
+		</Page>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MySsaSaasDemo/MySsaSaasDemo.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/MySsaSaasDemo/MySsaSaasDemo.tsx
@@ -3,6 +3,83 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
+import {useModal} from '@clayui/modal';
+
+import EmptyState from '../../../components/EmptyState';
+import Page from '../../../components/Page';
+import {useOneContext} from '../../../context/OneContext';
+import useModalContext from '../../../hooks/useModalContext';
+import i18n from '../../../i18n';
+import {useSSADashboardOutlet} from '../SSADashboard/SSADashboardOutlet';
+import TrialListView from '../SSADashboard/components/TrialListView/TrialListView';
+import useSSAActions from '../SSADashboard/hooks/useSSAActions';
+
 export default function MySsaSaasDemo() {
-	return <div />;
+	const {marketplaceUserAccount} = useOneContext();
+	const {onOpenModal} = useModalContext();
+	const {myTrialsInProgress} = useSSADashboardOutlet();
+	const actions = useSSAActions();
+	const createTrialFormModal = useModal();
+
+	const isSSAAdmin = marketplaceUserAccount.isSSAAdmin;
+
+	const canCreateTrial = isSSAAdmin ? true : myTrialsInProgress < 3;
+
+	const hasSSAPermission = isSSAAdmin || marketplaceUserAccount.isSSAUser;
+
+	return (
+		<Page
+			description={i18n.translate('manage-your-current-trials')}
+			pageRendererProps={{className: 'border py-2'}}
+			rightButton={
+				<ClayButton
+					disabled={!hasSSAPermission}
+					onClick={() => {
+						if (canCreateTrial) {
+							return createTrialFormModal.onOpenChange(true);
+						}
+
+						onOpenModal({
+							body: (
+								<span>
+									{i18n.translate(
+										'you-have-reached-the-maximum-number-of-active-trials-allowed-to-start-a-new-trial-please-end-one-of-your-existing-trials-first'
+									)}
+								</span>
+							),
+							header: i18n.translate('ssa-trials-limit-reached'),
+						});
+					}}
+				>
+					{i18n.translate('add-new-trial')}
+				</ClayButton>
+			}
+			title="My SaaS Demos"
+		>
+			{hasSSAPermission ? (
+				<TrialListView
+					actions={actions}
+					authorOnlyTrials
+					createTrialFormModal={createTrialFormModal}
+					isSortable
+					managementToolbarProps={{
+						searchVisible: true,
+						visible: isSSAAdmin,
+					}}
+				/>
+			) : (
+				<EmptyState
+					description={
+						<p>
+							Reach out to the <strong>#help-ssa</strong> channel
+							on slack for permission to continue
+						</p>
+					}
+					title={i18n.translate('access-required')}
+					type="NO_ACCESS"
+				/>
+			)}
+		</Page>
+	);
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/SSADashboardOutlet.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/SSADashboardOutlet.ts
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {KeyedMutator} from 'swr';
+
+import {useOneContext} from '../../../context/OneContext';
+import SearchBuilder from '../../../core/SearchBuilder';
+import {OrderTypes, OrderWorkflowStatusCode} from '../../../enums/Order';
+import {usePlacedOrders} from '../../../hooks/data/usePlacedOrder';
+import HeadlessAdminUser from '../../../services/rest/HeadlessAdminUser';
+import {useSSATrialsExtend} from './hooks/useSSATrialsExtend';
+
+type SSADashboardOutletContext = {
+	myTrialsInProgress: number;
+	selectedAccountId: number;
+	ssaAccount: Account;
+	ssaTrialExtend: APIResponse<TrialExtend>;
+	ssaTrialExtendMutate: KeyedMutator<APIResponse<TrialExtend>>;
+};
+
+export function useSSADashboardOutlet(): SSADashboardOutletContext {
+	const {myUserAccount, properties} = useOneContext();
+
+	const {data: ssaAccount} = useSWR(
+		'/ssa-account',
+		() =>
+			HeadlessAdminUser.getAccountByExternalReferenceCode(
+				properties.accountExternalReferenceCode
+			)
+	);
+
+	const isFilterByAuthorIdEnabled =
+		properties.featureFlags?.includes('LPD-63837');
+
+	const authorFilter = isFilterByAuthorIdEnabled ? 'authorId' : 'author';
+
+	const authorFilterValue = isFilterByAuthorIdEnabled
+		? myUserAccount?.id
+		: myUserAccount?.name;
+
+	const {data: inProgressTrialResponse = {totalCount: 0}} = usePlacedOrders({
+		accountId: ssaAccount?.id as number,
+		filter: new SearchBuilder()
+			.eq(authorFilter, authorFilterValue, {
+				unquote: isFilterByAuthorIdEnabled,
+			})
+			.and()
+			.eq('orderTypeExternalReferenceCode', OrderTypes.SSA_SAAS)
+			.and()
+			.lambda('orderStatus', OrderWorkflowStatusCode.IN_PROGRESS, {
+				unquote: true,
+			})
+			.build(),
+		page: 1,
+		pageSize: 1,
+		shouldFetch: !!ssaAccount,
+	});
+
+	const {
+		data: ssaTrialExtend,
+		mutate: ssaTrialExtendMutate,
+	} = useSSATrialsExtend(ssaAccount!);
+
+	return {
+		myTrialsInProgress: inProgressTrialResponse.totalCount,
+		selectedAccountId: ssaAccount?.id as number,
+		ssaAccount: ssaAccount as Account,
+		ssaTrialExtend: ssaTrialExtend as APIResponse<TrialExtend>,
+		ssaTrialExtendMutate,
+	};
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/SSADashboardOutlet.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/SSADashboardOutlet.ts
@@ -23,12 +23,10 @@ type SSADashboardOutletContext = {
 export function useSSADashboardOutlet(): SSADashboardOutletContext {
 	const {myUserAccount, properties} = useOneContext();
 
-	const {data: ssaAccount} = useSWR(
-		'/ssa-account',
-		() =>
-			HeadlessAdminUser.getAccountByExternalReferenceCode(
-				properties.accountExternalReferenceCode
-			)
+	const {data: ssaAccount} = useSWR('/ssa-account', () =>
+		HeadlessAdminUser.getAccountByExternalReferenceCode(
+			properties.accountExternalReferenceCode
+		)
 	);
 
 	const isFilterByAuthorIdEnabled =
@@ -58,10 +56,8 @@ export function useSSADashboardOutlet(): SSADashboardOutletContext {
 		shouldFetch: !!ssaAccount,
 	});
 
-	const {
-		data: ssaTrialExtend,
-		mutate: ssaTrialExtendMutate,
-	} = useSSATrialsExtend(ssaAccount!);
+	const {data: ssaTrialExtend, mutate: ssaTrialExtendMutate} =
+		useSSATrialsExtend(ssaAccount!);
 
 	return {
 		myTrialsInProgress: inProgressTrialResponse.totalCount,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/ExtensionStatus/ExtensionStatus.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/ExtensionStatus/ExtensionStatus.scss
@@ -1,0 +1,25 @@
+.extension-status {
+	border-radius: 4px;
+	font-size: 13px;
+	padding: 0.25rem 0.5rem;
+
+	&-approved {
+		background-color: #e9f5e8;
+		color: #2c6723;
+	}
+
+	&-expired {
+		background-color: #fbe3e3;
+		color: #830c0c;
+	}
+
+	&-not-requested {
+		background-color: #e1e1e4;
+		color: #54555f;
+	}
+
+	&-pending {
+		background-color: #f7eae0;
+		color: #6f3000;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/ExtensionStatus/ExtensionStatus.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/ExtensionStatus/ExtensionStatus.tsx
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import classNames from 'classnames';
+
+import {EXTEND_TRIAL_STATUS_LABEL} from '../../constants';
+import {ExtendRequestStatus} from '../../enums/SSATrials';
+
+import './ExtensionStatus.scss';
+
+type ExtensionStatusProps = {
+	className?: string;
+	extensionStatus?: keyof typeof EXTEND_TRIAL_STATUS_LABEL;
+};
+
+const ExtensionStatus = ({
+	className,
+	extensionStatus,
+}: ExtensionStatusProps) => (
+	<div className={className}>
+		<span
+			className={classNames('extension-status', {
+				'extension-status-approved': [
+					ExtendRequestStatus.APPROVED,
+					ExtendRequestStatus.AUTO_APPROVED,
+				].includes(extensionStatus as ExtendRequestStatus),
+				'extension-status-expired': [
+					ExtendRequestStatus.EXTENSION_EXPIRED,
+					ExtendRequestStatus.REJECTED,
+				].includes(extensionStatus as ExtendRequestStatus),
+				'extension-status-not-requested':
+					extensionStatus === ExtendRequestStatus.NOT_REQUESTED ||
+					!extensionStatus,
+				'extension-status-pending':
+					extensionStatus === ExtendRequestStatus.PENDING,
+			})}
+		>
+			{EXTEND_TRIAL_STATUS_LABEL[extensionStatus ?? 'not-requested']}
+		</span>
+	</div>
+);
+export default ExtensionStatus;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialListView/TrialListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialListView/TrialListView.tsx
@@ -1,0 +1,243 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useMemo} from 'react';
+import {Link} from 'react-router-dom';
+
+import ListView, {ListViewProps} from '../../../../../components/ListView';
+import {ManagementToolbarProps} from '../../../../../components/ListView/components/ManagementToolbar';
+import {useOneContext} from '../../../../../context/OneContext';
+import SearchBuilder from '../../../../../core/SearchBuilder';
+import {
+	OrderCustomFields,
+	OrderStatus,
+	OrderTypes,
+} from '../../../../../enums/Order';
+import i18n from '../../../../../i18n';
+import {Liferay} from '../../../../../liferay/liferay';
+import {Action} from '../../../../../utils/constants';
+import {formatDate, formatDateTime} from '../../../../../utils/date';
+import {safeJSONParse} from '../../../../../utils/util';
+import {useSSADashboardOutlet} from '../../SSADashboardOutlet';
+import {EXTEND_TRIAL_STATUS_LABEL} from '../../constants';
+import CreateTrialModalForm from '../../modals/CreateTrialModalform';
+import ExtensionStatus from '../ExtensionStatus/ExtensionStatus';
+import TrialStatus from '../TrialStatus/TrialStatus';
+
+type TrialsListViewProps = {
+	actions: Action[];
+	authorOnlyTrials?: boolean;
+	createTrialFormModal: any;
+	isSortable?: boolean;
+	listViewProps?: Partial<ListViewProps<PlacedOrder>>;
+	managementToolbarProps?: {
+		visible?: boolean;
+	} & Omit<
+		ManagementToolbarProps,
+		| 'actions'
+		| 'onSelectAllRows'
+		| 'rowSelectable'
+		| 'tableProps'
+		| 'totalItems'
+	>;
+	parentPath?: string;
+};
+
+// Refresh the table every 60 seconds
+
+const refreshInterval = 60 * 1000;
+
+const getResourceURL = (accountId: number) =>
+	`/o/headless-commerce-delivery-order/v1.0/channels/${Liferay.CommerceContext.commerceChannelId}/accounts/${accountId}/placed-orders?${new URLSearchParams(
+		{
+			nestedFields: 'placedOrderItems',
+			sort: 'createDate:desc',
+		}
+	)}`;
+
+export default function TrialListView({
+	actions,
+	authorOnlyTrials,
+	createTrialFormModal,
+	listViewProps,
+	managementToolbarProps,
+	parentPath,
+}: TrialsListViewProps) {
+	const {ssaAccount, ssaTrialExtend} = useSSADashboardOutlet();
+	const {myUserAccount} = useOneContext();
+
+	const {properties} = useOneContext();
+
+	const isFilterByAuthorIdEnabled =
+		properties.featureFlags.includes('LPD-63837');
+
+	const authorFilter = isFilterByAuthorIdEnabled ? 'authorId' : 'author';
+
+	const authorFilterValue = isFilterByAuthorIdEnabled
+		? myUserAccount?.id
+		: myUserAccount?.name;
+
+	const searchBuilder = useMemo(() => {
+		const searchBuilder = new SearchBuilder().eq(
+			'orderTypeExternalReferenceCode',
+			OrderTypes.SSA_SAAS
+		);
+
+		if (authorOnlyTrials) {
+			searchBuilder.and().eq(authorFilter, authorFilterValue, {
+				unquote: isFilterByAuthorIdEnabled,
+			});
+		}
+
+		return searchBuilder;
+	}, [
+		authorFilter,
+		authorFilterValue,
+		authorOnlyTrials,
+		isFilterByAuthorIdEnabled,
+	]);
+
+	if (!ssaAccount) {
+		return null;
+	}
+
+	return (
+		<>
+			<ListView<PlacedOrder>
+				defaultFilters={{filter: searchBuilder.build()}}
+				emptyStateProps={{title: i18n.translate('no-trials-yet')}}
+				id="ssa-trials"
+				managementToolbarProps={{
+					filterSchema: 'administratorSSATrials',
+					...managementToolbarProps,
+				}}
+				refreshInterval={refreshInterval}
+				resource={getResourceURL(ssaAccount.id)}
+				tableProps={{
+					actions,
+					columns: [
+						{
+							id: 'placedOrderItems',
+							name: 'Project ID',
+							render: (_, {customFields, id}) => (
+								<Link
+									className="font-weight-semi-bold ml-2"
+									to={
+										parentPath
+											? `/details/${id}?from=${parentPath}`
+											: `/details/${id}`
+									}
+								>
+									{customFields &&
+										safeJSONParse(
+											customFields[
+												OrderCustomFields.TRIAL_SETTINGS
+											],
+											{projectId: id}
+										).projectId}
+								</Link>
+							),
+						},
+						{
+							id: 'author',
+							name: 'Created By',
+							render: (author, {createDate}) => (
+								<div className="d-flex flex-column">
+									<span className="dashboard-table-row-text">
+										{author}
+									</span>
+
+									<span className="dashboard-table-row-purchased-date">
+										{formatDate(createDate)}
+									</span>
+								</div>
+							),
+							sortable: true,
+						},
+						{
+							id: 'customFields',
+							name: 'Solution Type',
+							render: (customFields) =>
+								safeJSONParse(
+									customFields[
+										OrderCustomFields.TRIAL_SETTINGS
+									],
+									{siteInitializerKey: 'Blank Site'}
+								).siteInitializerKey,
+						},
+						{
+							id: 'createDate',
+							name: 'End Date',
+							render: (_, {customFields}) =>
+								formatDateTime(
+									customFields[
+										OrderCustomFields.TRIAL_END_DATE
+									],
+									'DNE'
+								),
+							sortable: true,
+						},
+						{
+							id: 'orderStatusInfo',
+							name: 'Trial Status',
+							render: (orderStatusInfo) => (
+								<TrialStatus
+									trialStatus={orderStatusInfo?.label}
+								/>
+							),
+						},
+						{
+							id: 'id',
+							name: 'Extension Status',
+							render: (orderId, placedOrder) => {
+								const ssaTrialsExtendRequests =
+									ssaTrialExtend.items;
+
+								const extendRequests =
+									ssaTrialsExtendRequests?.filter(
+										(extend: TrialExtend) => {
+											return (
+												extend.r_orderToTrialExtensionRequest_commerceOrderId ===
+												Number(orderId)
+											);
+										}
+									) as TrialExtend[];
+
+								if (
+									!extendRequests ||
+									extendRequests?.length === 0
+								) {
+									return (
+										<ExtensionStatus extensionStatus="not-requested" />
+									);
+								}
+
+								return (
+									<ExtensionStatus
+										extensionStatus={
+											placedOrder.orderStatusInfo
+												.label === OrderStatus.COMPLETED
+												? 'extension-expired'
+												: (extendRequests[0]?.dueStatus
+														.key as keyof typeof EXTEND_TRIAL_STATUS_LABEL)
+										}
+									/>
+								);
+							},
+						},
+					],
+				}}
+				{...listViewProps}
+			>
+				{(_, {mutate}) => (
+					<CreateTrialModalForm
+						modal={createTrialFormModal}
+						mutate={mutate}
+					/>
+				)}
+			</ListView>
+		</>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialStatus/TrialStatus.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialStatus/TrialStatus.scss
@@ -1,0 +1,32 @@
+.trial-status-icon {
+	height: 0.5rem;
+	width: 0.5rem;
+
+	&-completed {
+		color: #da1414;
+	}
+
+	&-in_progress {
+		color: #4aab3b;
+	}
+
+	&-on-hold {
+		color: #f0ad4e;
+	}
+
+	&-pending {
+		color: #ccc;
+	}
+
+	&-processing {
+		color: #2477fd;
+	}
+}
+
+.trial-status-text {
+	color: #6c6c75;
+	font-size: 0.813rem;
+	font-weight: 600;
+	line-height: 1rem;
+	text-transform: capitalize;
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialStatus/TrialStatus.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/TrialStatus/TrialStatus.tsx
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
+
+import {OrderStatus as Status} from '../../../../../enums/Order';
+import {TRIAL_STATUS_LABEL} from '../../constants';
+
+import './TrialStatus.scss';
+
+type TrialStatusProps = {
+	trialStatus: string;
+};
+
+const TrialStatus = ({trialStatus}: TrialStatusProps) => {
+	if (Status.PROCESSING === trialStatus) {
+		return (
+			<span className="d-flex trial-status-text">
+				<ClayLoadingIndicator
+					className="m-0 mr-1"
+					displayType="primary"
+				/>
+				{
+					TRIAL_STATUS_LABEL[
+						trialStatus as keyof typeof TRIAL_STATUS_LABEL
+					]
+				}
+			</span>
+		);
+	}
+
+	return (
+		<>
+			<ClayIcon
+				className={classNames('mr-2 trial-status-icon', {
+					'trial-status-icon-completed': [
+						Status.APPROVED,
+						Status.CANCELLED,
+						Status.COMPLETED,
+					].includes(trialStatus as Status),
+					'trial-status-icon-in_progress':
+						Status.IN_PROGRESS === trialStatus,
+					'trial-status-icon-on-hold': Status.ON_HOLD === trialStatus,
+					'trial-status-icon-pending': Status.PENDING === trialStatus,
+					'trial-status-icon-processing':
+						trialStatus === Status.PROCESSING,
+				})}
+				symbol="circle"
+			/>
+
+			<span className="trial-status-text">
+				{
+					TRIAL_STATUS_LABEL[
+						trialStatus as keyof typeof TRIAL_STATUS_LABEL
+					]
+				}
+			</span>
+		</>
+	);
+};
+
+export default TrialStatus;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/constants/index.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/constants/index.ts
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {AccountRoleType} from '../../../../enums/Account';
+
+export const defaultSiteInitializer = 'com.liferay.site.initializer.welcome';
+
+export const EXTEND_TYPES = {
+	ADMIN_REQUEST: 'admin-request',
+	AUTO_EXTEND: 'auto-extend',
+};
+
+export const EXTEND_OPTIONS = [
+	{
+		actionText: 'Submit',
+		actionUrl: '',
+		alertText: `The trial can be extended automatically once, with immediate effect. After that, any further extension will require admin approval.`,
+		alertType: 'info',
+		extendType: EXTEND_TYPES.AUTO_EXTEND,
+	},
+	{
+		actionText: 'Submit Request',
+		actionUrl: '',
+		alertText: `You've already extended your trial once. To extend it again, you’ll need to submit a request to your admin.`,
+		alertType: 'warning',
+		extendType: EXTEND_TYPES.ADMIN_REQUEST,
+	},
+] as const;
+
+export const EXTEND_TRIAL_STATUS_LABEL = {
+	'Approved': 'Approved',
+	'AutoApproved': 'Auto Approved',
+	'Pending': 'Request Pending',
+	'Rejected': 'Rejected',
+	'extension-expired': 'Extension Expired',
+	'not-requested': 'Not Requested',
+};
+
+export const siteInitializers = [
+	{
+		key: 'blank-site-initializer',
+		name: 'Blank Site',
+	},
+	{
+		key: 'com.liferay.site.initializer.masterclass',
+		name: 'Masterclass',
+	},
+	{
+		key: 'com.liferay.site.initializer.welcome',
+		name: 'Welcome',
+	},
+	{
+		key: 'minium-initializer',
+		name: 'Minium',
+	},
+	{
+		key: 'speedwell-initializer',
+		name: 'Speedwell',
+	},
+];
+
+export const ssaRoles = [
+	AccountRoleType.SSA_ADMIN,
+	AccountRoleType.SSA_USER,
+].map((role) => ({
+	key: role,
+	label: role,
+	value: role,
+}));
+
+export const TRIAL_STATUS_LABEL = {
+	'approved': 'Expired',
+	'cancelled': 'Cancelled',
+	'completed': 'Expired',
+	'in-progress': 'Active',
+	'on-hold': 'On Hold',
+	'pending': 'Not Processed',
+	'processing': 'Processing',
+};
+
+export const trialObjectives = [
+	{
+		days: 1,
+		key: 'quick-demo',
+		name: 'Demo',
+	},
+	{
+		days: 3,
+		key: 'feature-showcase',
+		name: 'Showcase',
+	},
+	{
+		days: 7,
+		key: 'proof-of-concept',
+		name: 'Proof of Concept',
+	},
+	{
+		days: 30,
+		key: 'pilot-project',
+		name: 'Pilot Project',
+	},
+	{
+		days: 90,
+		key: 'extended-evaluation',
+		name: 'Extended Evaluation',
+	},
+];

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/enums/SSATrials.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/enums/SSATrials.ts
@@ -1,0 +1,13 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export enum ExtendRequestStatus {
+	APPROVED = 'Approved',
+	AUTO_APPROVED = 'AutoApproved',
+	EXTENSION_EXPIRED = 'extension-expired',
+	NOT_REQUESTED = 'not-requested',
+	PENDING = 'Pending',
+	REJECTED = 'Rejected',
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useManageUserActions.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useManageUserActions.tsx
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Button from '@clayui/button';
+import {useMemo} from 'react';
+
+import {Tooltip} from '../../../../components/Tooltip/Tooltip';
+import {useOneContext} from '../../../../context/OneContext';
+import useModalContext from '../../../../hooks/useModalContext';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import HeadlessAdminUser from '../../../../services/rest/HeadlessAdminUser';
+import {Action} from '../../../../utils/constants';
+import {useSSADashboardOutlet} from '../SSADashboardOutlet';
+import {ssaRoles as ssaRolesValues} from '../constants';
+import ManageUserModal from '../modals/ManageUserRolesModal';
+
+function mutateUser(
+	accountERC: string,
+	userId: number,
+	userAccountPage: APIResponse<UserAccount>
+) {
+	return {
+		...userAccountPage,
+		items: userAccountPage.items.map((userAccount) => {
+			if (userAccount.id !== userId) {
+				return userAccount;
+			}
+
+			return {
+				...userAccount,
+				accountBriefs: userAccount.accountBriefs.map((account) =>
+					account.externalReferenceCode === accountERC
+						? {
+								...account,
+								roleBriefs: [],
+							}
+						: account
+				),
+			};
+		}),
+	};
+}
+
+const useManageUserActions = () => {
+	const {properties} = useOneContext();
+	const {ssaAccount} = useSSADashboardOutlet();
+	const modalContext = useModalContext();
+
+	return useMemo(
+		() =>
+			[
+				{
+					name: i18n.translate('manage-roles'),
+					onClick: (user: UserAccount, mutate) => {
+						modalContext.onOpenModal({
+							body: (
+								<ManageUserModal
+									accountERC={
+										properties.accountExternalReferenceCode
+									}
+									mutate={mutate}
+									onClose={modalContext.onClose}
+									user={user}
+								/>
+							),
+							footer: [
+								<Button
+									displayType="secondary"
+									key="cancel"
+									onClick={modalContext.onClose}
+								>
+									{i18n.translate('cancel')}
+								</Button>,
+								null,
+								<Button
+									form="manage-roles"
+									key="confirm"
+									type="submit"
+								>
+									{i18n.translate('apply')}
+								</Button>,
+							],
+							header: (
+								<div className="align-items-center d-flex">
+									<span className="mr-2">
+										{i18n.translate('manage-user-roles')}
+									</span>
+									<Tooltip
+										tooltip={i18n.translate(
+											'set-the-users-role-ssa-users-can-create-trials-while-ssa-admins-can-manage-users-roles-and-trials'
+										)}
+									/>
+								</div>
+							),
+						});
+					},
+				},
+				{
+					name: i18n.translate('remove-all-roles'),
+					onClick: (userAccount: UserAccount, mutate) => {
+						modalContext.onOpenModal({
+							body: (
+								<div>
+									{i18n.translate(
+										'you-are-about-to-remove-this-user-from-ssa-they-will-lose-access-to-their-account-and-all-associated-features-but-dont-worry-you-can-invite-them-again-later-if-needed'
+									)}
+								</div>
+							),
+							footer: [
+								<Button
+									displayType="secondary"
+									key="cancel"
+									onClick={modalContext.onClose}
+								>
+									{i18n.translate('cancel')}
+								</Button>,
+								null,
+								<Button
+									displayType="warning"
+									key="confirm"
+									onClick={async () => {
+										const {items: roles} =
+											await HeadlessAdminUser.getAccountRoles(
+												properties.accountExternalReferenceCode
+											);
+
+										const ssaRoles = roles.filter((role) =>
+											ssaRolesValues.some(
+												(ssaRole) =>
+													ssaRole.key === role.name
+											)
+										);
+
+										try {
+											await Promise.allSettled(
+												ssaRoles.map((role) =>
+													HeadlessAdminUser.deleteRoleAccountUser(
+														ssaAccount?.id,
+														role.id,
+														userAccount.id
+													)
+												)
+											);
+										}
+										catch {
+											return Liferay.Util.openToast({
+												message: i18n.translate(
+													'unable-to-remove-roles'
+												),
+												title: i18n.translate('error'),
+												type: 'danger',
+											});
+										}
+
+										Liferay.Util.openToast({
+											message: i18n.translate(
+												'successfully-removed-roles'
+											),
+										});
+
+										mutate(
+											(
+												usersPage: APIResponse<UserAccount>
+											) => {
+												return mutateUser(
+													properties.accountExternalReferenceCode,
+													userAccount.id,
+													usersPage
+												);
+											},
+											{revalidate: false}
+										);
+
+										modalContext.onClose();
+									}}
+								>
+									{i18n.translate('confirm')}
+								</Button>,
+							],
+							header: i18n.translate('remove-user'),
+							status: 'warning',
+						});
+					},
+				},
+			] as Action[],
+		[modalContext, properties.accountExternalReferenceCode, ssaAccount?.id]
+	);
+};
+
+export default useManageUserActions;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useSSAActions.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useSSAActions.tsx
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useMemo} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import {useOneContext} from '../../../../context/OneContext';
+import {OrderCustomFields, OrderStatus} from '../../../../enums/Order';
+import useModalContext from '../../../../hooks/useModalContext';
+import i18n from '../../../../i18n';
+import {Action} from '../../../../utils/constants';
+import {useSSADashboardOutlet} from '../SSADashboardOutlet';
+import {ExtendRequestStatus} from '../enums/SSATrials';
+import ExpireSSAModal from '../modals/ExpireSSAModal';
+import ExtendRequestModal from '../modals/ExtendRequestModal';
+import ExtendSSATrialModal from '../modals/ExtendSSATrialModal';
+
+const getOrderExtendRequests =
+	(trialExtendRequests: APIResponse<TrialExtend>['items']) =>
+	(order: PlacedOrder) =>
+		trialExtendRequests.filter(
+			(item) =>
+				item.r_orderToTrialExtensionRequest_commerceOrderId ===
+				Number(order.id)
+		);
+
+const useSSAActions = () => {
+	const {marketplaceUserAccount} = useOneContext();
+	const modalContext = useModalContext();
+	const navigate = useNavigate();
+
+	const {selectedAccountId, ssaTrialExtend, ssaTrialExtendMutate} =
+		useSSADashboardOutlet();
+
+	return useMemo(() => {
+		const _getOrderExtendRequests = getOrderExtendRequests(
+			ssaTrialExtend?.items ?? []
+		);
+
+		return [
+			{
+				name: i18n.translate('details'),
+				onClick: (order: PlacedOrder) =>
+					navigate(`/details/${order.id}`),
+			},
+			{
+				disabled: (order: PlacedOrder) =>
+					order.orderStatusInfo.label !== OrderStatus.IN_PROGRESS,
+				name: i18n.translate('go-to-trial'),
+				onClick: (order: PlacedOrder) =>
+					window.open(
+						`https://${
+							order?.customFields?.[
+								OrderCustomFields.TRIAL_VIRTUAL_HOST
+							] as string
+						}`
+					),
+			},
+			{
+				hidden: (order: PlacedOrder) => {
+					if (!marketplaceUserAccount.isSSAAdmin) {
+						return true;
+					}
+
+					const extendRequests = _getOrderExtendRequests(order);
+
+					return (
+						extendRequests[0]?.dueStatus?.key !==
+						ExtendRequestStatus.PENDING
+					);
+				},
+				name: i18n.translate('view-request'),
+				onClick: (order: PlacedOrder, orderMutate) => {
+					const extendRequests = _getOrderExtendRequests(order);
+
+					if (!extendRequests.length) {
+						return;
+					}
+
+					modalContext.onOpenModal({
+						body: (
+							<ExtendRequestModal
+								mutatePlacedOrderPage={orderMutate}
+								onClose={modalContext.onClose}
+								order={order}
+								ssaTrialExtendMutate={ssaTrialExtendMutate}
+								trialExtend={extendRequests[0]}
+								trialExtendCount={
+									extendRequests.filter(
+										({dueStatus}: TrialExtend) =>
+											[
+												ExtendRequestStatus.APPROVED,
+												ExtendRequestStatus.AUTO_APPROVED,
+											].includes(
+												dueStatus?.key as ExtendRequestStatus
+											)
+									).length
+								}
+							/>
+						),
+						center: true,
+					});
+				},
+			},
+			{
+				disabled: (order: PlacedOrder) => {
+					const extendRequests = _getOrderExtendRequests(order);
+
+					if (!extendRequests) {
+						return true;
+					}
+
+					return (
+						order.orderStatusInfo.label !==
+							OrderStatus.IN_PROGRESS ||
+						extendRequests[0]?.dueStatus.key ===
+							ExtendRequestStatus.PENDING
+					);
+				},
+				name: i18n.translate('extend-trial'),
+				onClick: (order: PlacedOrder, orderMutate) => {
+					const extendRequests = _getOrderExtendRequests(order);
+
+					modalContext.onOpenModal({
+						body: (
+							<ExtendSSATrialModal
+								accountId={selectedAccountId}
+								firstExtendRequest={!extendRequests?.length}
+								onClose={modalContext.onClose}
+								order={order}
+								orderMutate={orderMutate}
+								ssaTrialExtendMutate={ssaTrialExtendMutate}
+							/>
+						),
+						header: `Extend ${order.id} Trial`,
+					});
+				},
+			},
+			{
+				disabled: (order: PlacedOrder) =>
+					order.orderStatusInfo.label !== OrderStatus.IN_PROGRESS,
+				name: i18n.translate('expire-trial'),
+				onClick: (order: PlacedOrder, mutate) => {
+					modalContext.onOpenModal({
+						body: (
+							<ExpireSSAModal
+								accountId={selectedAccountId}
+								mutate={mutate}
+								onClose={modalContext.onClose}
+								order={order}
+							/>
+						),
+						header: `Expire ${order.id} Trial`,
+						status: undefined,
+					});
+				},
+			},
+		] as Action[];
+	}, [
+		marketplaceUserAccount.isSSAAdmin,
+		modalContext,
+		navigate,
+		selectedAccountId,
+		ssaTrialExtend?.items,
+		ssaTrialExtendMutate,
+	]);
+};
+
+export default useSSAActions;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useSSATrialsExtend.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/hooks/useSSATrialsExtend.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+import SearchBuilder from '../../../../core/SearchBuilder';
+import HeadlessTrialExtensionRequest from '../../../../services/rest/HeadlessTrialExtensionRequest';
+
+const useSSATrialsExtend = (account: Account) =>
+	useSWR(account?.id ? '/o/c/trialextensionrequests' : null, () =>
+		HeadlessTrialExtensionRequest.getTrialExtensionRequest(
+			new URLSearchParams({
+				filter: SearchBuilder.eq(
+					'r_accountToTrialExtensionRequest_accountEntryId',
+					account.id
+				),
+				page: '1',
+				pageSize: '-1',
+				sort: 'dateCreated:desc',
+			})
+		)
+	);
+
+export {useSSATrialsExtend};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/CreateTrialModalform.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/CreateTrialModalform.tsx
@@ -1,0 +1,376 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Button from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {Size} from '@clayui/modal/lib/types';
+import MultiSelect from '@clayui/multi-select';
+import {zodResolver} from '@hookform/resolvers/zod';
+import classNames from 'classnames';
+import {useCallback, useEffect, useMemo} from 'react';
+import {useForm} from 'react-hook-form';
+
+import {Input} from '../../../../components/Input/Input';
+import Loading from '../../../../components/Loading';
+import Form from '../../../../components/MarketplaceForm';
+import Modal from '../../../../components/Modal';
+import Select from '../../../../components/Select/Select';
+import {useOneContext} from '../../../../context/OneContext';
+import {
+	OrderCustomFields,
+	OrderStatus as Status,
+	OrderWorkflowStatusCode,
+} from '../../../../enums/Order';
+import {useDeliveryProduct} from '../../../../hooks/data/useProduct';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import zodSchema, {z} from '../../../../schema/zod';
+import trialOAuth2 from '../../../../services/oauth/Trial';
+import ProductPurchaseSSATrial from '../../../ProductPurchase/services/ProductPurchaseSSATrial';
+import {useSSADashboardOutlet} from '../SSADashboardOutlet';
+import {
+	defaultSiteInitializer,
+	siteInitializers,
+	trialObjectives,
+} from '../constants';
+
+const SectionTitle = ({title}: {title: string}) => (
+	<>
+		<h4>{title}</h4>
+		<hr className="mb-3" />
+	</>
+);
+
+type CreateTrialModalFormProps = {
+	modal: {
+		observer: any;
+		onClose: () => void;
+		open: boolean;
+	};
+	mutate: any;
+};
+
+type FormFields = z.infer<typeof zodSchema.ssaTrialForm>;
+
+type Item = {
+	key: string;
+	label: string;
+	value: string;
+};
+
+const CreateTrialModalForm: React.FC<CreateTrialModalFormProps> = ({
+	modal,
+	mutate,
+}) => {
+	const {ssaAccount} = useSSADashboardOutlet();
+	const {properties} = useOneContext();
+	const {data: product} = useDeliveryProduct(properties.productId);
+
+	const productPurchase = useMemo(() => {
+		if (!ssaAccount || !product) {
+			return null;
+		}
+
+		return new ProductPurchaseSSATrial(ssaAccount, product);
+	}, [ssaAccount, product]);
+
+	const {
+		formState: {errors, isSubmitting},
+		handleSubmit,
+		register,
+		setError,
+		setValue,
+		watch,
+	} = useForm<FormFields>({
+		defaultValues: {
+			duration: 1,
+			emailAddress: [],
+			objective: '',
+			projectId: '',
+			siteInitializerKey: defaultSiteInitializer,
+		},
+		resolver: zodResolver(zodSchema.ssaTrialForm),
+	});
+
+	const emails = watch('emailAddress');
+	const objective = watch('objective');
+	const projectId = watch('projectId');
+
+	useEffect(() => {
+		const suggestedDuration = trialObjectives.find(
+			(trialObjective) => trialObjective.key === objective
+		);
+
+		setValue('duration', suggestedDuration?.days || 1);
+	}, [objective, setValue]);
+
+	const onSubmit = useCallback(
+		async (data: FormFields) => {
+			const projectId = data.projectId.toLowerCase();
+
+			try {
+				await trialOAuth2.checkDomainAvailability(projectId);
+			}
+			catch (error: any) {
+				console.error(error.message);
+
+				if (error.status === 409) {
+					return setError('projectId', {
+						message: 'Project ID already exists',
+					});
+				}
+
+				return Liferay.Util.openToast({
+					message: i18n.translate('an-unexpected-error-occurred'),
+					type: 'danger',
+				});
+			}
+
+			const consoleInviteEmailAddresses = [
+				...new Set([
+					Liferay.ThemeDisplay.getUserEmailAddress(),
+					...(data.emailAddress as any[]).map(({value}) => value),
+				]),
+			];
+
+			try {
+				const order = await (
+					productPurchase as ProductPurchaseSSATrial
+				).createOrder({
+					customFields: {
+						[OrderCustomFields.TRIAL_SETTINGS]: JSON.stringify({
+							consoleInviteEmailAddresses,
+							duration: data.duration,
+							projectId,
+							siteInitializerKey: data.siteInitializerKey,
+						}),
+					},
+				} as Cart);
+
+				mutate(
+					(orders: APIResponse<PlacedOrder>) => ({
+						...orders,
+						items: [
+							{
+								...order,
+								orderStatusInfo: {
+									code: OrderWorkflowStatusCode.PROCESSING,
+									label: Status.PROCESSING,
+									label_i18n: Status.PROCESSING,
+								},
+							},
+							...orders.items,
+						],
+					}),
+					{revalidate: false}
+				);
+
+				if (!order) {
+					return;
+				}
+
+				await trialOAuth2.provisioningTrial(order.id);
+
+				mutate((response: APIResponse<PlacedOrder>) => response, {
+					revalidate: true,
+				});
+
+				Liferay.Util.openToast({
+					message: 'Trial successfully provisioned.',
+					title: i18n.translate('success'),
+					type: 'success',
+				});
+			}
+			catch (error) {
+				console.error(error);
+
+				Liferay.Util.openToast({
+					message: i18n.translate('an-unexpected-error-occurred'),
+					type: 'danger',
+				});
+			}
+
+			modal.onClose();
+		},
+		[modal, mutate, productPurchase, setError]
+	);
+
+	if (!modal.open) {
+		return null;
+	}
+
+	if (isSubmitting) {
+		return (
+			<Modal
+				observer={modal.observer}
+				size={'md' as any}
+				title={i18n.translate('ssa-trial-installation-in-progress')}
+				visible={modal.open}
+			>
+				<div className="m-8">
+					<Loading className="mb-3" />
+
+					<p className="mt-8 text-center">
+						{i18n.translate(
+							'the-installation-process-is-ongoing-and-may-take-some-time-navigating-to-other-sections-will-not-cancel-the-process'
+						)}
+					</p>
+				</div>
+
+				<hr className="mt-4" />
+
+				<div className="d-flex justify-content-end">
+					<Button displayType="secondary" onClick={modal.onClose}>
+						{i18n.translate('go-to-ssa-trial-listing')}
+					</Button>
+				</div>
+			</Modal>
+		);
+	}
+
+	return (
+		<Modal
+			observer={modal.observer}
+			size={'md' as Size}
+			title={i18n.translate('add-new-trial')}
+			visible={modal.open}
+		>
+			<ClayForm.Group className="mb-3 pr-2 w-100">
+				<Form.Label className="mb-2">
+					{i18n.translate('project-id')}
+				</Form.Label>
+
+				<ClayInput.Group
+					className={classNames({
+						'has-error': errors.projectId,
+					})}
+				>
+					<ClayInput.GroupItem prepend>
+						<ClayInput
+							{...register('projectId')}
+							className="custom-input mb-0"
+							maxLength={25}
+							required
+							type="text"
+						/>
+					</ClayInput.GroupItem>
+
+					<ClayInput.GroupItem append shrink>
+						<ClayInput.GroupText>
+							{properties.ssaProjectPrefix || '.lxc.liferay.com'}
+						</ClayInput.GroupText>
+					</ClayInput.GroupItem>
+				</ClayInput.Group>
+
+				{errors.projectId && (
+					<p className="field-base-feedback text-danger">
+						{errors.projectId?.message}
+					</p>
+				)}
+
+				<small className="mt-0 text-black-50">
+					{`${projectId?.length}/25`}
+				</small>
+			</ClayForm.Group>
+
+			<ClayForm.Group className="mb-3 mt-2 pr-2 w-100">
+				<Form.Label className="mb-2">
+					{i18n.translate('solution')}
+				</Form.Label>
+
+				<Select
+					{...register('siteInitializerKey')}
+					name="siteInitializerKey"
+					options={siteInitializers}
+				/>
+			</ClayForm.Group>
+
+			<ClayForm.Group className="mb-3">
+				<SectionTitle title="Usage" />
+
+				<div className="d-flex">
+					<div className="pr-2 w-100">
+						<Form.Label className="mb-2">
+							{i18n.translate('objective')}
+						</Form.Label>
+
+						<Select
+							{...register('objective')}
+							defaultOptionLabel="Select an option"
+							errors={errors}
+							name="objective"
+							options={trialObjectives}
+						/>
+					</div>
+
+					<div className="pr-2 w-100">
+						<Form.Label className="mb-2">
+							{i18n.translate('duration-days')}
+						</Form.Label>
+						<Input
+							{...register('duration')}
+							disabled={!objective}
+							errorMessage={errors.duration?.message}
+							max={60}
+							min={1}
+							type="number"
+						/>
+					</div>
+				</div>
+			</ClayForm.Group>
+
+			<div className="mb-3 pr-2 w-100">
+				<SectionTitle title={i18n.translate('additional-admin')} />
+
+				<Form.Label className="mb-2">
+					{i18n.translate('email-address')}
+				</Form.Label>
+
+				<MultiSelect
+					className="bg-white marketplace-form-select"
+					id="allowed-email-domains"
+					items={emails}
+					onItemsChange={(values: Item[]) => {
+						setValue('emailAddress', values);
+					}}
+				/>
+				{errors.emailAddress && (
+					<p className="text-danger">
+						{errors.emailAddress?.message}
+					</p>
+				)}
+			</div>
+
+			<hr />
+
+			<div className="d-flex justify-content-end">
+				<Button
+					className="mr-2"
+					disabled={isSubmitting}
+					displayType="secondary"
+					onClick={modal.onClose}
+				>
+					{i18n.translate('cancel')}
+				</Button>
+
+				<Button
+					disabled={isSubmitting}
+					displayType="primary"
+					onClick={handleSubmit(onSubmit)}
+				>
+					<div className="align-items-center d-flex">
+						{isSubmitting && (
+							<ClayLoadingIndicator className="mr-3 my-0" />
+						)}
+						{i18n.translate('create')}
+					</div>
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default CreateTrialModalForm;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExpireSSAModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExpireSSAModal.tsx
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {useState} from 'react';
+import {KeyedMutator} from 'swr';
+
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import trialOAuth2 from '../../../../services/oauth/Trial';
+
+type ExpireSSAModalProps = {
+	accountId: number;
+	mutate: KeyedMutator<Order | PlacedOrder>;
+	onClose: () => void;
+	order: Order | PlacedOrder;
+};
+
+const ExpireSSAModal: React.FC<ExpireSSAModalProps> = ({
+	mutate,
+	onClose,
+	order,
+}) => {
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	return (
+		<div>
+			<ClayAlert displayType="warning" role={null}>
+				{i18n.translate('this-action-cannot-be-undone')}
+			</ClayAlert>
+
+			<p>
+				{i18n.translate(
+					'are-you-sure-you-want-to-expire-this-trial-this-action-implies-the-permanent-end-of-the-test-environment'
+				)}
+			</p>
+
+			<div className="d-flex justify-content-end" key="footer-buttons">
+				<ClayButton
+					aria-label="cancel"
+					disabled={isSubmitting}
+					displayType="secondary"
+					key={0}
+					onClick={onClose}
+				>
+					{i18n.translate('cancel')}
+				</ClayButton>
+
+				<ClayButton
+					aria-label="close"
+					className="ml-4"
+					disabled={isSubmitting}
+					displayType="warning"
+					key={2}
+					onClick={async () => {
+						setIsSubmitting(true);
+						try {
+							await trialOAuth2.expireTrial(order.id);
+
+							mutate((orders) => orders);
+
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'trial-expired-successfully'
+								),
+								type: 'success',
+							});
+
+							setIsSubmitting(false);
+						}
+						catch {
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'failed-to-expire-the-trial'
+								),
+								type: 'danger',
+							});
+
+							setIsSubmitting(false);
+						}
+
+						onClose();
+					}}
+				>
+					<div className="align-items-center d-flex">
+						{isSubmitting && (
+							<ClayLoadingIndicator className="mr-3 my-0" />
+						)}
+						{i18n.translate('expire')}
+					</div>
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default ExpireSSAModal;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendRequestModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendRequestModal.tsx
@@ -11,7 +11,10 @@ import {ReactElement, useState} from 'react';
 import {KeyedMutator} from 'swr';
 
 import ButtonWithIcon from '../../../../components/ButtonWithIcon';
-import {OrderCustomFields, OrderStatus as Status} from '../../../../enums/Order';
+import {
+	OrderCustomFields,
+	OrderStatus as Status,
+} from '../../../../enums/Order';
 import i18n from '../../../../i18n';
 import {Liferay} from '../../../../liferay/liferay';
 import trialOAuth2 from '../../../../services/oauth/Trial';

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendRequestModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendRequestModal.tsx
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import classNames from 'classnames';
+import {add} from 'date-fns';
+import {ReactElement, useState} from 'react';
+import {KeyedMutator} from 'swr';
+
+import ButtonWithIcon from '../../../../components/ButtonWithIcon';
+import {OrderCustomFields, OrderStatus as Status} from '../../../../enums/Order';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import trialOAuth2 from '../../../../services/oauth/Trial';
+import HeadlessTrialExtensionRequest from '../../../../services/rest/HeadlessTrialExtensionRequest';
+import {formatDate} from '../../../../utils/date';
+import {safeJSONParse} from '../../../../utils/util';
+import {TRIAL_STATUS_LABEL} from '../constants';
+import {ExtendRequestStatus} from '../enums/SSATrials';
+
+type ExtendSSATrialModalProps = {
+	mutatePlacedOrderPage: KeyedMutator<any>;
+	onClose: () => void;
+	order: PlacedOrder;
+	ssaTrialExtendMutate: KeyedMutator<any>;
+	trialExtend: TrialExtend;
+	trialExtendCount: number;
+};
+
+type DetailsProps = {
+	children?: ReactElement | string;
+	title: string;
+};
+
+const Details: React.FC<DetailsProps> = ({children, title}) => (
+	<div className="d-flex flex-column mb-4">
+		<p className="font-weight-bold m-0 text-black-50">{title}</p>
+		<div className="d-inline-flex">{children}</div>
+	</div>
+);
+
+const ExtendRequestModal: React.FC<ExtendSSATrialModalProps> = ({
+	mutatePlacedOrderPage,
+	onClose,
+	order,
+	ssaTrialExtendMutate,
+	trialExtend,
+	trialExtendCount,
+}) => {
+	const [submitting, setSubmitting] = useState<null | 'approve' | 'reject'>(
+		null
+	);
+
+	const mutateTrialExtendRequest = (status: ExtendRequestStatus) => {
+		ssaTrialExtendMutate(
+			(data: any) => {
+				const updatedItems = data.items.map((item: TrialExtend) => {
+					if (item.id === trialExtend.id) {
+						return {
+							...item,
+							dueStatus: {
+								key: status,
+							},
+						};
+					}
+
+					return item;
+				});
+
+				return {
+					...data,
+					items: updatedItems,
+				};
+			},
+			{revalidate: true}
+		);
+	};
+
+	return (
+		<>
+			<div className="d-flex flex-column mb-9 provisioning-details">
+				<div className="align-items-center d-flex justify-content-between">
+					<span className="font-weight-bold text-primary">
+						{i18n.translate('extension-request').toUpperCase()}
+					</span>
+
+					<span>
+						<ButtonWithIcon
+							aria-label="Close"
+							borderless
+							className="text-dark"
+							onClick={onClose}
+							symbol="times"
+							title="Close"
+						/>
+					</span>
+				</div>
+
+				<div className="d-flex flex-column justify-content-start">
+					<h2 className="m-0 text-weight-bold">
+						{
+							safeJSONParse(
+								order.customFields[
+									OrderCustomFields.TRIAL_SETTINGS
+								],
+								{projectId: 'N/A'}
+							).projectId
+						}
+					</h2>
+					<p>{order.orderTypeExternalReferenceCode}</p>
+				</div>
+
+				<div className="d-flex flex-row mt-5">
+					<div className="col-6 p-0">
+						<p className="font-weight-bold">
+							{i18n.translate('details')}
+						</p>
+
+						<Details title={i18n.translate('start-date')}>
+							<span className="extend-request-info">
+								{formatDate(order.createDate)}
+							</span>
+						</Details>
+
+						<Details title={i18n.translate('expiration-date')}>
+							<span className="extend-request-info">
+								{formatDate(
+									order.customFields[
+										OrderCustomFields.TRIAL_END_DATE
+									],
+									'DNE'
+								)}
+							</span>
+						</Details>
+
+						<Details title={i18n.translate('status')}>
+							<span
+								className={classNames('extension-status', {
+									'extension-status-approved': [
+										Status.IN_PROGRESS,
+										Status.PROCESSING,
+									].includes(
+										order.orderStatusInfo.label as Status
+									),
+									'extension-status-expired': [
+										Status.COMPLETED,
+										Status.APPROVED,
+									].includes(
+										order.orderStatusInfo.label as Status
+									),
+									'extension-status-pending':
+										order.orderStatusInfo.label ===
+										Status.PENDING,
+								})}
+							>
+								{
+									TRIAL_STATUS_LABEL[
+										order.orderStatusInfo
+											.label as keyof typeof TRIAL_STATUS_LABEL
+									]
+								}
+							</span>
+						</Details>
+					</div>
+
+					<div className="col-6 p-0">
+						<p className="font-weight-bold">
+							{i18n.translate('extension')}
+						</p>
+
+						<Details
+							title={i18n.translate('times-already-extended')}
+						>
+							<span className="extend-request-info">
+								{trialExtendCount.toString()}
+							</span>
+						</Details>
+
+						<Details
+							title={i18n.translate('duration-of-the-extension')}
+						>
+							<span className="extend-request-info">
+								{trialExtend.duration.toString()}
+							</span>
+						</Details>
+
+						<Details
+							title={i18n.translate(
+								'new-potential-expiration-date'
+							)}
+						>
+							<span className="extend-request-info">
+								{formatDate(
+									add(
+										new Date(
+											order.customFields[
+												OrderCustomFields.TRIAL_END_DATE
+											]
+										),
+										{days: trialExtend.duration}
+									),
+									'DNE'
+								)}
+							</span>
+						</Details>
+					</div>
+				</div>
+				<div className="d-flex flex-row mb-7">
+					<div className="d-flex flex-column flex-grow-1 p-0">
+						<p className="font-weight-bold m-0 text-black-50">
+							{i18n.translate('reason')}
+						</p>
+						<p className="extend-request-info extend-request-reason">
+							{trialExtend.reason}
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<div className="d-flex justify-content-end pt-8">
+				<ClayButton
+					className="mr-4"
+					disabled={!!submitting}
+					displayType="secondary"
+					onClick={async () => {
+						setSubmitting('reject');
+
+						try {
+							await HeadlessTrialExtensionRequest.updateTrialExtensionRequest(
+								trialExtend.id,
+								{dueStatus: {key: ExtendRequestStatus.REJECTED}}
+							);
+
+							mutateTrialExtendRequest(
+								ExtendRequestStatus.REJECTED
+							);
+
+							setSubmitting(null);
+
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'trial-extension-rejected-successfully'
+								),
+								title: i18n.translate('success'),
+								type: 'success',
+							});
+						}
+						catch (error) {
+							console.error(error);
+
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'failed-to-reject-trial-extension'
+								),
+								title: i18n.translate('failure'),
+								type: 'danger',
+							});
+						}
+
+						onClose();
+					}}
+				>
+					<div className="align-items-center d-flex">
+						{submitting === 'reject' && (
+							<ClayLoadingIndicator className="mr-3 my-0" />
+						)}
+						{i18n.translate('reject-request')}
+					</div>
+				</ClayButton>
+
+				<ClayButton
+					disabled={!!submitting}
+					onClick={async () => {
+						setSubmitting('approve');
+
+						try {
+							await HeadlessTrialExtensionRequest.updateTrialExtensionRequest(
+								trialExtend.id,
+								{dueStatus: {key: ExtendRequestStatus.APPROVED}}
+							);
+
+							mutateTrialExtendRequest(
+								ExtendRequestStatus.APPROVED
+							);
+
+							await trialOAuth2.extendTrial(trialExtend.id);
+
+							mutatePlacedOrderPage((response: any) => response, {
+								revalidate: true,
+							});
+
+							setSubmitting(null);
+
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'trial-extension-approved-successfully'
+								),
+								title: i18n.translate('success'),
+								type: 'success',
+							});
+						}
+						catch (error) {
+							console.error(error);
+
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'failed-to-approve-trial-extension'
+								),
+								title: i18n.translate('failure'),
+								type: 'danger',
+							});
+						}
+
+						onClose();
+					}}
+				>
+					<div className="align-items-center d-flex">
+						{submitting === 'approve' && (
+							<ClayLoadingIndicator className="mr-3 my-0" />
+						)}
+
+						{i18n.translate('approve-request')}
+					</div>
+				</ClayButton>
+			</div>
+		</>
+	);
+};
+
+export default ExtendRequestModal;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendSSATrialModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ExtendSSATrialModal.tsx
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
+import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {useState} from 'react';
+import {useForm} from 'react-hook-form';
+import {KeyedMutator} from 'swr';
+
+import FormInput from '../../../../components/Input/formInput';
+import {OrderCustomFields} from '../../../../enums/Order';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import zodSchema, {z} from '../../../../schema/zod';
+import trialOAuth2 from '../../../../services/oauth/Trial';
+import HeadlessTrialExtensionRequest from '../../../../services/rest/HeadlessTrialExtensionRequest';
+import {EXTEND_OPTIONS, EXTEND_TYPES} from '../constants';
+import {ExtendRequestStatus} from '../enums/SSATrials';
+
+type ExtendSSATrialModalProps = {
+	accountId: number;
+	firstExtendRequest: boolean;
+	mutatePlacedOrder?: KeyedMutator<any>;
+	onClose: () => void;
+	order: PlacedOrder;
+	orderMutate: KeyedMutator<any>;
+	ssaTrialExtendMutate: KeyedMutator<any>;
+};
+
+const ExtendSSATrialModal: React.FC<ExtendSSATrialModalProps> = ({
+	accountId,
+	firstExtendRequest,
+	mutatePlacedOrder,
+	onClose,
+	order,
+	orderMutate,
+	ssaTrialExtendMutate,
+}) => {
+	const [submitting, setSubmitting] = useState<boolean>(false);
+
+	const {
+		formState: {errors, isLoading},
+		handleSubmit,
+		register,
+	} = useForm({
+		defaultValues: {
+			duration: '' as unknown as number,
+			reason: '',
+		},
+		mode: 'onSubmit',
+		resolver: zodResolver(zodSchema.extendSSATrial),
+	});
+
+	const inputProps = {
+		errors,
+		register,
+		required: true,
+	};
+
+	const extendType = firstExtendRequest
+		? EXTEND_TYPES.AUTO_EXTEND
+		: EXTEND_TYPES.ADMIN_REQUEST;
+
+	const extendOptions = EXTEND_OPTIONS.find(
+		(option) => option.extendType === extendType
+	);
+
+	const onSubmit = async (form: z.infer<typeof zodSchema.extendSSATrial>) => {
+		setSubmitting(true);
+
+		const trialSettings =
+			order.customFields?.[OrderCustomFields.TRIAL_SETTINGS];
+		const projectId = JSON.parse(trialSettings)?.projectId;
+
+		try {
+			const extendTrial = {
+				dueStatus: {
+					key:
+						extendType === EXTEND_TYPES.AUTO_EXTEND
+							? ExtendRequestStatus.AUTO_APPROVED
+							: ExtendRequestStatus.PENDING,
+				},
+				duration: form.duration,
+				projectId,
+				r_accountToTrialExtensionRequest_accountEntryId: accountId,
+				r_orderToTrialExtensionRequest_commerceOrderId: order.id,
+				reason: form.reason,
+			};
+
+			const newExtensionRequest: TrialExtend =
+				await HeadlessTrialExtensionRequest.createTrialExtensionRequest(
+					extendTrial
+				);
+
+			if (extendType === EXTEND_TYPES.AUTO_EXTEND) {
+				await trialOAuth2.extendTrial(newExtensionRequest.id);
+			}
+
+			ssaTrialExtendMutate(
+				(data: any) => {
+					return {
+						...data,
+						items: [newExtensionRequest, ...data.items],
+					};
+				},
+				{revalidate: false}
+			);
+
+			if (extendType === EXTEND_TYPES.AUTO_EXTEND) {
+				if (mutatePlacedOrder) {
+					mutatePlacedOrder((response: any) => response, {
+						revalidate: true,
+					});
+				}
+
+				orderMutate((response: any) => response, {
+					revalidate: true,
+				});
+			}
+
+			Liferay.Util.openToast({
+				message: i18n.translate('trial-extended-successfully'),
+				title: i18n.translate('success'),
+				type: 'success',
+			});
+
+			setSubmitting(false);
+
+			onClose();
+		}
+		catch (error) {
+			console.error(error);
+
+			Liferay.Util.openToast({
+				message: i18n.translate('failed-to-extend-trial'),
+				title: i18n.translate('failure'),
+				type: 'danger',
+			});
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div>
+			<ClayAlert displayType={extendOptions?.alertType}>
+				{extendOptions?.alertText}
+			</ClayAlert>
+
+			<FormInput
+				{...inputProps}
+				boldLabel
+				label="Duration"
+				name="duration"
+				placeholder="Value between 1 and 60"
+				required={true}
+				type="number"
+			/>
+			<FormInput
+				{...inputProps}
+				boldLabel
+				label={i18n.translate('reason')}
+				name="reason"
+				placeholder="Tell why you need to extend the trial"
+				required={true}
+				type="textarea"
+			/>
+			<div className="d-flex justify-content-end">
+				<ClayButton
+					className="mr-4"
+					disabled={!!submitting}
+					displayType="secondary"
+					onClick={onClose}
+				>
+					{i18n.translate('cancel')}
+				</ClayButton>
+				<ClayButton
+					disabled={isLoading || submitting}
+					onClick={handleSubmit(onSubmit)}
+				>
+					<div className="align-items-center d-flex">
+						{submitting && (
+							<ClayLoadingIndicator className="mr-3 my-0" />
+						)}
+						{extendOptions?.actionText}
+					</div>
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default ExtendSSATrialModal;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ManageUserRolesModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/modals/ManageUserRolesModal.tsx
@@ -1,0 +1,182 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useForm} from 'react-hook-form';
+import {KeyedMutator} from 'swr';
+
+import MultiSelect from '../../../../components/MultiSelect/MultiSelect';
+import i18n from '../../../../i18n';
+import {Liferay} from '../../../../liferay/liferay';
+import {z} from '../../../../schema/zod';
+import HeadlessAdminUser from '../../../../services/rest/HeadlessAdminUser';
+import {ssaRoles} from '../constants';
+import {getFilteredItems} from '../utils';
+
+const formSchema = z.object({
+	roles: z.array(z.object({value: z.string()})),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+type ManageUserModalProps = {
+	accountERC: string;
+	mutate: KeyedMutator<any>;
+	onClose: () => void;
+	user: UserAccount;
+};
+
+const ManageUserModal = ({
+	accountERC,
+	mutate,
+	onClose,
+	user,
+}: ManageUserModalProps) => {
+	const ssaAccount = user.accountBriefs.find(
+		(account) => account.externalReferenceCode === accountERC
+	);
+
+	const currentRoles =
+		ssaAccount?.roleBriefs
+			.filter((role) =>
+				ssaRoles.some((ssaRole) => ssaRole.key === role.name)
+			)
+			.map((role) => ({
+				key: role.name,
+				label: role.name,
+				value: role.name,
+			})) || [];
+
+	const {formState, handleSubmit, setValue, watch} = useForm<FormValues>({
+		defaultValues: {roles: currentRoles},
+	});
+
+	const selectedRoles = watch('roles');
+
+	const onSubmit = async (formData: FormValues) => {
+		try {
+			if (!ssaAccount?.id) {
+				return Liferay.Util.openToast({
+					message: i18n.translate('could-not-find-ssa-account'),
+					type: 'danger',
+				});
+			}
+
+			const {items: roles} =
+				await HeadlessAdminUser.getAccountRoles(accountERC);
+
+			const currentRolesSet = new Set(
+				currentRoles.map((role) => role.value)
+			);
+			const newRolesSet = new Set(
+				formData.roles.map((role) => role.value)
+			);
+
+			const rolesToAdd = roles.filter(
+				(role) =>
+					!currentRolesSet.has(role.name) &&
+					newRolesSet.has(role.name)
+			);
+
+			const rolesToRemove = roles.filter(
+				(role) =>
+					currentRolesSet.has(role.name) &&
+					!newRolesSet.has(role.name)
+			);
+
+			await Promise.all([
+				...rolesToRemove.map((role) =>
+					HeadlessAdminUser.deleteRoleAccountUser(
+						ssaAccount?.id,
+						role.id,
+						user.id
+					)
+				),
+				...rolesToAdd.map((role) =>
+					HeadlessAdminUser.sendRoleAccountUser(
+						ssaAccount?.id,
+						role.id,
+						user.id
+					)
+				),
+			]);
+
+			const updatedRoleBriefs = roles.filter((role) =>
+				newRolesSet.has(role.name)
+			);
+
+			mutate(
+				(users?: APIResponse<UserAccount>) => {
+					return {
+						...users,
+						items: users?.items.map((prevUser) => {
+							if (prevUser.id !== user.id) {
+								return prevUser;
+							}
+
+							return {
+								...prevUser,
+								accountBriefs: prevUser.accountBriefs.map(
+									(account) => {
+										if (
+											account.externalReferenceCode !==
+											accountERC
+										) {
+											return account;
+										}
+
+										return {
+											...account,
+											roleBriefs:
+												updatedRoleBriefs.reverse(),
+										};
+									}
+								),
+							};
+						}),
+					};
+				},
+				{revalidate: false}
+			);
+		}
+		catch {
+			return Liferay.Util.openToast({
+				message: i18n.translate('unable-to-assign-roles'),
+				title: i18n.translate('error'),
+				type: 'danger',
+			});
+		}
+
+		Liferay.Util.openToast({
+			message: i18n.translate('user-roles-successfully-updated'),
+			title: i18n.translate('success'),
+		});
+
+		onClose();
+	};
+
+	return (
+		<form id="manage-roles" onSubmit={handleSubmit(onSubmit)}>
+			<p>
+				{i18n.translate(
+					'manage-the-roles-associated-with-this-user-roles-determine-what-features-permissions-and-areas-of-the-platform-the-user-can-access-so-updating-them-allows-you-to-control-their-level-of-access-and-responsibilities'
+				)}
+			</p>
+
+			<MultiSelect
+				disabledClearAll
+				errorMessage={formState.errors.roles?.message}
+				inputName={i18n.translate('roles')}
+				multiselectKey={`roles-${selectedRoles.length}`}
+				onItemsChange={(roles) => {
+					setValue('roles', roles);
+				}}
+				selectedItems={selectedRoles}
+				sourceItems={getFilteredItems(selectedRoles, ssaRoles)}
+			/>
+		</form>
+	);
+};
+
+export default ManageUserModal;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/TrialDetailsBody.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/TrialDetailsBody.tsx
@@ -1,0 +1,249 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import DOMPurify from 'dompurify';
+
+import {DetailedCard} from '../../../../../components/DetailedCard/DetailedCard';
+import ExternalLink from '../../../../../components/ExternalLink';
+import QATable, {Orientation} from '../../../../../components/QATable';
+import {useOneContext} from '../../../../../context/OneContext';
+import MarketplaceDeliveryOrder from '../../../../../entity/MarketplaceDeliveryOrder';
+import {MarketplaceDeliveryProduct} from '../../../../../entity/MarketplaceDeliveryProduct';
+import {OrderWorkflowStatusCode} from '../../../../../enums/Order';
+import i18n from '../../../../../i18n';
+import {formatDate, formatDateTime} from '../../../../../utils/date';
+import {useSSADashboardOutlet} from '../../SSADashboardOutlet';
+import ExtensionStatus from '../../components/ExtensionStatus/ExtensionStatus';
+import TrialStatus from '../../components/TrialStatus/TrialStatus';
+import {EXTEND_TRIAL_STATUS_LABEL} from '../../constants';
+
+type TrialDetailsBodyProps = {
+	marketplaceOrder: MarketplaceDeliveryOrder;
+	marketplaceProduct: MarketplaceDeliveryProduct;
+	placedOrder: PlacedOrder;
+	projectId: string;
+};
+
+const TrialDetailsBody: React.FC<TrialDetailsBodyProps> = ({
+	marketplaceOrder,
+	marketplaceProduct,
+	placedOrder,
+	projectId,
+}) => {
+	const {properties} = useOneContext();
+
+	const ssaProject = `${properties.ssaProjectPrefix}-ext${projectId}`;
+
+	const {ssaTrialExtend} = useSSADashboardOutlet();
+
+	const extensionStatus =
+		placedOrder?.orderStatusInfo?.code === OrderWorkflowStatusCode.COMPLETED
+			? 'extension-expired'
+			: ssaTrialExtend?.items?.find(
+					(trialExtend) => trialExtend.projectId === projectId
+				)?.dueStatus?.key;
+
+	return (
+		<div className="d-flex justify-content-between mt-2 row">
+			<DetailedCard
+				cardIconAltText="Profile Icon"
+				cardTitle={i18n.translate('details')}
+				className="col-6"
+				clayIcon="order-form-tag"
+			>
+				<span>
+					<span className="h4 mt-4 text-black-50">
+						{i18n.translate('general-info')}
+					</span>
+
+					<hr className="my-0" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('account-name'),
+
+								value: (
+									<div className="mb-3">
+										{placedOrder?.account}
+									</div>
+								),
+							},
+							{
+								title: i18n.translate('created-by'),
+								value: (
+									<div className="mb-3">
+										{placedOrder?.author}
+									</div>
+								),
+							},
+							{
+								title: i18n.translate('type'),
+								value: (
+									<div className="mb-3">
+										{placedOrder?.orderType}
+									</div>
+								),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</span>
+
+				<span>
+					<span className="h4 mt-4 text-black-50">
+						{i18n.translate('order-info')}
+					</span>
+					<hr className="my-0" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('order-id'),
+								value: (
+									<div className="mb-3">
+										{placedOrder?.id}
+									</div>
+								),
+							},
+							{
+								title: i18n.translate('order-date'),
+								value: (
+									<div>
+										{placedOrder?.createDate &&
+											formatDate(
+												placedOrder?.createDate as string
+											)}
+									</div>
+								),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</span>
+			</DetailedCard>
+
+			<DetailedCard
+				cardIconAltText="Profile Icon"
+				cardTitle={i18n.translate('ssa-trial-summary')}
+				className="col-6"
+				clayIcon="date-time"
+			>
+				<span>
+					<span className="h4 mt-4 text-black-50">
+						{i18n.translate('trial-info')}
+					</span>
+
+					<hr className="my-0" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('trial-start-date'),
+								value: formatDateTime(
+									marketplaceOrder.customFields
+										.TRIAL_START_DATE
+								),
+								visible: !marketplaceOrder.isCancelled,
+							},
+							{
+								title: i18n.translate('trial-end-date'),
+								value: formatDateTime(
+									marketplaceOrder.customFields.TRIAL_END_DATE
+								),
+								visible: !marketplaceOrder.isCancelled,
+							},
+							{
+								className: 'mb-2',
+								title: i18n.translate('trial-url'),
+								value: (
+									<ExternalLink
+										className="h5 py-1"
+										href={`https://${marketplaceOrder.customFields.TRIAL_VIRTUAL_HOST}`}
+									>
+										{
+											marketplaceOrder.customFields
+												.TRIAL_VIRTUAL_HOST
+										}
+									</ExternalLink>
+								),
+								visible:
+									OrderWorkflowStatusCode.IN_PROGRESS ===
+									placedOrder?.orderStatusInfo?.code,
+							},
+							{
+								title: i18n.translate('cloud-project'),
+								value: (
+									<ExternalLink
+										className="h5"
+										href={`${properties.cloudConsoleURL}/projects/${ssaProject}`}
+									>
+										{ssaProject}
+									</ExternalLink>
+								),
+								visible:
+									OrderWorkflowStatusCode.IN_PROGRESS ===
+									placedOrder?.orderStatusInfo?.code,
+							},
+							{
+								title: i18n.translate('trial-status'),
+								value: (
+									<div className="mb-3">
+										<TrialStatus
+											trialStatus={
+												placedOrder?.orderStatusInfo
+													?.label as string
+											}
+										/>
+									</div>
+								),
+							},
+							{
+								title: i18n.translate('trial-error'),
+								value: (
+									<div className="mb-3">
+										Something went wrong during the Trial
+										Provisioning
+									</div>
+								),
+								visible: marketplaceOrder.isCancelled,
+							},
+							{
+								title: i18n.translate('extension-status'),
+								value: (
+									<ExtensionStatus
+										className="my-3"
+										extensionStatus={
+											extensionStatus as keyof typeof EXTEND_TRIAL_STATUS_LABEL
+										}
+									/>
+								),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</span>
+
+				<span>
+					<span className="h4 mt-4 text-black-50">
+						{i18n.translate('description')}
+					</span>
+					<hr className="my-0" />
+
+					<p
+						className="app-review-section-body-description-paragraph mt-3"
+						dangerouslySetInnerHTML={{
+							__html: DOMPurify.sanitize(
+								marketplaceProduct.description
+							),
+						}}
+					/>
+				</span>
+			</DetailedCard>
+		</div>
+	);
+};
+
+export default TrialDetailsBody;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/index.tsx
@@ -10,13 +10,13 @@ import {useMemo} from 'react';
 import {useParams, useSearchParams} from 'react-router-dom';
 
 import BackLink from '../../../../../components/BackLink';
+import OrderDetailsHeader from '../../../../../components/OrderDetailsHeader';
 import {PageRenderer} from '../../../../../components/Page';
 import MarketplaceDeliveryOrder from '../../../../../entity/MarketplaceDeliveryOrder';
 import {MarketplaceDeliveryProduct} from '../../../../../entity/MarketplaceDeliveryProduct';
 import useGetProductByOrderId from '../../../../../hooks/useGetProductByOrderId';
 import i18n from '../../../../../i18n';
 import {safeJSONParse} from '../../../../../utils/util';
-import OrderDetailsHeader from '../../../../../components/OrderDetailsHeader';
 import useSSAActions from '../../hooks/useSSAActions';
 import TrialDetailsBody from './TrialDetailsBody';
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/pages/TrialDetails/index.tsx
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {ClayDropDownWithItems} from '@clayui/drop-down';
+import ClayIcon from '@clayui/icon';
+import {useMemo} from 'react';
+import {useParams, useSearchParams} from 'react-router-dom';
+
+import BackLink from '../../../../../components/BackLink';
+import {PageRenderer} from '../../../../../components/Page';
+import MarketplaceDeliveryOrder from '../../../../../entity/MarketplaceDeliveryOrder';
+import {MarketplaceDeliveryProduct} from '../../../../../entity/MarketplaceDeliveryProduct';
+import useGetProductByOrderId from '../../../../../hooks/useGetProductByOrderId';
+import i18n from '../../../../../i18n';
+import {safeJSONParse} from '../../../../../utils/util';
+import OrderDetailsHeader from '../../../../../components/OrderDetailsHeader';
+import useSSAActions from '../../hooks/useSSAActions';
+import TrialDetailsBody from './TrialDetailsBody';
+
+type TrialActionsProps = {
+	mutatePlacedOrder: ReturnType<typeof useGetProductByOrderId>['mutate'];
+	placedOrder: PlacedOrder;
+};
+
+function TrialActions({mutatePlacedOrder, placedOrder}: TrialActionsProps) {
+	const actions = useSSAActions();
+
+	return (
+		<ClayDropDownWithItems
+			className="align-items-center cursor-pointer d-flex h-100"
+			items={
+				actions
+					.filter((_, index) => index > 0)
+					.map((action) => {
+						const disabled =
+							typeof action.disabled === 'function'
+								? action.disabled(placedOrder)
+								: action.disabled;
+
+						const hidden =
+							typeof action.hidden === 'function'
+								? action.hidden(placedOrder)
+								: action.hidden;
+
+						return {
+							...action,
+							disabled,
+							hidden,
+							label: action.name,
+							onClick: () =>
+								action?.onClick?.(
+									placedOrder,
+									mutatePlacedOrder
+								),
+						};
+					}) as any[]
+			}
+			trigger={
+				<ClayButton displayType="secondary">
+					{i18n.translate('manage-trial')}
+
+					<ClayIcon className="ml-2" symbol="angle-down-small" />
+				</ClayButton>
+			}
+		/>
+	);
+}
+
+export default function TrialDetails() {
+	const {orderId} = useParams();
+	const {
+		data,
+		error,
+		isLoading,
+		mutate: mutatePlacedOrder,
+	} = useGetProductByOrderId(orderId as string);
+
+	const product = data?.product as DeliveryProduct;
+	const placedOrder = data?.placedOrder as PlacedOrder;
+
+	const [params] = useSearchParams();
+	const parentPath = params.get('from') ?? '/';
+
+	const marketplaceProduct = useMemo(
+		() => new MarketplaceDeliveryProduct(product || {}),
+		[product]
+	);
+
+	const marketplaceOrder = useMemo(
+		() => new MarketplaceDeliveryOrder(placedOrder),
+		[placedOrder]
+	);
+
+	const {projectId} = safeJSONParse(
+		marketplaceOrder.customFields.TRIAL_SETTINGS,
+		{
+			projectId: orderId,
+		}
+	);
+
+	return (
+		<PageRenderer
+			className="app-details-header d-flex flex-column w-100"
+			error={error}
+			isLoading={isLoading || !placedOrder || !marketplaceProduct}
+		>
+			<BackLink path={parentPath}>
+				{i18n.translate('back-to-the-list')}
+			</BackLink>
+
+			<div className="d-flex justify-content-between">
+				<OrderDetailsHeader
+					className="d-flex flex-row justify-content-between pb-3 pt-5"
+					hasOrderDetails
+					image={marketplaceOrder.productThumbnail}
+					name={projectId}
+					productOwner={marketplaceProduct?.catalogName}
+				/>
+
+				<TrialActions
+					mutatePlacedOrder={mutatePlacedOrder}
+					placedOrder={placedOrder}
+				/>
+			</div>
+
+			<TrialDetailsBody
+				marketplaceOrder={marketplaceOrder}
+				marketplaceProduct={marketplaceProduct}
+				placedOrder={placedOrder}
+				projectId={projectId as string}
+			/>
+		</PageRenderer>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/utils/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/utils/index.tsx
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export function getFilteredItems(
+	selectedItems: {[key: string]: string}[] | undefined,
+	defaultItems: {key: string; value: string}[]
+) {
+	return defaultItems?.filter(
+		(defaultItem) =>
+			!selectedItems?.some(
+				(selectedItem) => defaultItem.key === selectedItem.key
+			)
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/adminRoutes.tsx
@@ -29,6 +29,7 @@ const PublisherRequests = lazy(
 );
 const Publishers = lazy(() => import('./Publishers/Publishers'));
 const Solutions = lazy(() => import('./Solutions/Solutions'));
+const TrialDetails = lazy(() => import('./SSADashboard/pages/TrialDetails'));
 const Trials = lazy(() => import('./Trials/Trials'));
 
 export const adminRoutes: AppRoute[] = [
@@ -101,6 +102,10 @@ export const adminRoutes: AppRoute[] = [
 		element: <ManageSsaSaasUsers />,
 		nav: {icon: 'users', label: 'Manage SSA SaaS Users'},
 		path: 'manage-ssa-saas-users',
+	},
+	{
+		element: <TrialDetails />,
+		path: 'details/:orderId',
 	},
 	{
 		element: <MessageQueue />,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -312,6 +312,38 @@ export const filterSchema: FilterSchemas = {
 		],
 		name: 'administratorPublishers',
 	},
+	administratorSSATrials: {
+		fields: [
+			{
+				label: i18n.translate('created-by'),
+				name: 'author',
+				operator: 'contains',
+				type: 'text',
+			},
+			overrides(baseFilters.status, {
+				label: 'Trial Status',
+				name: 'orderStatus',
+				operator: 'lambda',
+				options: [
+					{
+						label: i18n.translate('active'),
+						value: `${OrderWorkflowStatusCode.IN_PROGRESS}`,
+					},
+					{
+						label: i18n.translate('expired'),
+						value: `${OrderWorkflowStatusCode.COMPLETED}`,
+					},
+					{
+						label: i18n.translate('processing'),
+						value: `${OrderWorkflowStatusCode.PROCESSING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'multiselect',
+			}),
+		],
+		name: 'administratorSSATrials',
+	},
 	administratorSolutions: {
 		fields: [
 			baseFilters.dateCreated,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributes.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributes.ts
@@ -3,31 +3,60 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-export const baseAttributes = ['account-id', 'user-id'] as const;
+export const baseAttributes = [
+	'accountExternalReferenceCode',
+	'accountId',
+	'analyticsCloudURL',
+	'cloudConsoleURL',
+	'contactSupportURL',
+	'endUserLicenseAgreement',
+	'eulaBaseURL',
+	'featureFlags',
+	'featurePreview',
+	'lastYearProjectsUsingMarketplaceAppsCount',
+	'marketoFormIdDefault',
+	'marketoFormIdLiferayProduct',
+	'productId',
+	'publisherLicenseAgreement',
+	'ssaProjectPrefix',
+	'trialAccountCheck',
+	'trialSSAHostPrefix',
+	'useSiteTaxonomyVocabularyQuery',
+] as const;
 
-const KPI_DEFAULTS = {
-	kpiConnectorQuartelyRelease: '100',
-	kpiLowCodePublishedApps: '100',
-	kpiPartnershipIntegration: '100',
-	kpiProjectUsingMarketplaceApps: '100',
-	kpiQuartelyReleaseApps: '100',
-} as const;
+const baseKPIAttributes = [
+	'kpiConnectorQuartelyRelease',
+	'kpiLowCodePublishedApps',
+	'kpiPartnershipIntegration',
+	'kpiProjectUsingMarketplaceApps',
+	'kpiQuartelyReleaseApps',
+] as const;
 
-const LAST_YEAR_PROJECTS_USING_MARKETPLACE_APPS_COUNT_DEFAULT = '0';
+function getAttribute<T extends readonly string[]>(
+	element: HTMLElement,
+	attrs: T
+): Record<T[number], string> {
+	return Object.fromEntries(
+		attrs.map((key) => [key, element.getAttribute(key) ?? ''])
+	) as Record<T[number], string>;
+}
 
-export type Properties = {
-	accountId: string | null;
-	kpi: typeof KPI_DEFAULTS;
-	lastYearProjectsUsingMarketplaceAppsCount: string;
-	userId: string | null;
-};
+function parseArray(element: string | null) {
+	return (element ?? '')
+		.split(',')
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
 
-export function getAttributes(element: HTMLElement): Properties {
+export function getAttributes(element: HTMLElement) {
 	return {
-		accountId: element.getAttribute('account-id'),
-		kpi: KPI_DEFAULTS,
-		lastYearProjectsUsingMarketplaceAppsCount:
-			LAST_YEAR_PROJECTS_USING_MARKETPLACE_APPS_COUNT_DEFAULT,
-		userId: element.getAttribute('user-id'),
+		...getAttribute(element, baseAttributes),
+		featureFlags: parseArray(element.getAttribute('featureFlags')),
+		featurePreview: parseArray(element.getAttribute('featurePreview')),
+		kpi: getAttribute(element, baseKPIAttributes),
+		useSiteTaxonomyVocabularyQuery:
+			element.getAttribute('useSiteTaxonomyVocabularyQuery') === 'true',
 	};
 }
+
+export type Properties = ReturnType<typeof getAttributes>;

--- a/workspaces/liferay-one-workspace/yarn.lock
+++ b/workspaces/liferay-one-workspace/yarn.lock
@@ -329,6 +329,15 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
+"@clayui/alert@^3.159.0":
+  version "3.165.0"
+  resolved "https://registry.yarnpkg.com/@clayui/alert/-/alert-3.165.0.tgz#533f5002c5d45120723e447ff4ffba1396cc9c4b"
+  integrity sha512-acFVnRVmCLgWZehx5yYJMgEnLB+50e1FaIOMaoNqwnpJVPOyP2JK3dG/cMEExZX9mBpjj/bk3yDJ+RSiTEGsxw==
+  dependencies:
+    "@clayui/icon" "^3.165.0"
+    "@clayui/layout" "^3.165.0"
+    classnames "2.3.1"
+
 "@clayui/autocomplete@^3.159.0", "@clayui/autocomplete@^3.164.0":
   version "3.164.0"
   resolved "https://registry.yarnpkg.com/@clayui/autocomplete/-/autocomplete-3.164.0.tgz#7d7b293bf3244a499118016c0aaa50fa3caaae11"
@@ -1306,6 +1315,13 @@
   resolved "https://registry.yarnpkg.com/@types/d3-timer/-/d3-timer-3.0.2.tgz#70bbda77dc23aa727413e22e214afa3f0e852f70"
   integrity sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
 
+"@types/dompurify@^3.0.2":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/dompurify/-/dompurify-3.2.0.tgz#56610bf3e4250df57744d61fbd95422e07dfb840"
+  integrity sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==
+  dependencies:
+    dompurify "*"
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz#306e3a3a73828522efa1341159da4846e7573a6c"
@@ -1350,6 +1366,11 @@
   version "7.5.8"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
   integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@typescript-eslint/eslint-plugin@4.30.0":
   version "4.30.0"
@@ -2113,6 +2134,13 @@ dom-helpers@^5.0.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
+
+dompurify@*, dompurify@^3.3.1:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.9.tgz#b036637b2df8997126b58837bc90f85dbcad6b2f"
+  integrity sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dunder-proto@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89753

## What is being fixed

The Admin dashboard's SSA (Self-Service Activation) section in liferay-one-custom-element is still placeholders; the Marketplace SSA dashboard — the trial list, the trial management modals, the My SSA SaaS Demo / SSA SaaS Environments / Manage SSA SaaS Users pages, and the trial detail view — has not been ported into the new workspace.

## How it is being fixed

Ports the Marketplace SSA dashboard from the marketplace workspace into liferay-one as a near-verbatim lift-and-shift, in four parts: (1) shared SSA infrastructure — TrialListView, TrialStatus/ExtensionStatus components, the Create/Expire/Extend/ManageUserRoles modals, hooks and the SSADashboardOutlet; (2) the three SSA dashboard pages (My SSA SaaS Demo, SSA SaaS Environments, Manage SSA SaaS Users) wired into the icon-nav; (3) the administratorSSATrials filter schema; (4) the Trial Details page reached from the trial list, with its supporting OrderStatus/OrderDetailsHeader/ExternalLink components and delivery-order entities (adds dompurify). It builds on the shared ListView, form infrastructure and commerce-delivery services already merged. The trial row link and the kebab "Details" action both navigate to the same absolute /details/:orderId route.

## Why are there no tests?

Mechanical lift-and-shift migration of the Marketplace admin UI into liferay-one. The original marketplace screens ship no automated coverage; this ports them verbatim without altering behavior, and verification is manual.

**pr-check: PASS** — tested on `5a74e3fa84df0ce7f836524f7636a3ac37bb4539`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "5a74e3fa84df0ce7f836524f7636a3ac37bb4539"} -->
