### PR TITLE
LRSD-12360 Hide "Manage Liferay PaaS Users" card for PaaS customers

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/TeamMembers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/TeamMembers.jsx
@@ -85,6 +85,7 @@ const TeamMembers = () => {
 				/>
 
 				<ManageProductUsers
+					hasPaaSExperience={hasPaaSExperience}
 					koroneikiAccount={koroneikiAccount}
 					loading={loading}
 				/>

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
@@ -26,7 +26,7 @@ const getManagedContactURL = (manageContactsURL, activationProductName) => {
 	}
 };
 
-const ManageProductUsers = ({koroneikiAccount, loading}) => {
+const ManageProductUsers = ({hasPaaSExperience, koroneikiAccount, loading}) => {
 	const {
 		data,
 		loading: accountSubscriptionGroupsLoading,
@@ -40,6 +40,20 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 	);
 
 	const accountSubscriptionGroups = data?.c.accountSubscriptionGroups.items;
+
+	const visibleAccountSubscriptionGroups = useMemo(() => {
+		if (!hasPaaSExperience) {
+			return accountSubscriptionGroups;
+		}
+
+		return accountSubscriptionGroups?.filter(
+			({activationProductName}) =>
+				!activationProductName
+					.split(',')
+					.includes(PRODUCT_TYPES.dxpCloud)
+		);
+	}, [accountSubscriptionGroups, hasPaaSExperience]);
+
 	const accountSubscriptionGroupLiferayExperienceCloud = useMemo(
 		() =>
 			accountSubscriptionGroups?.find(
@@ -72,7 +86,7 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 
 		return (
 			<div className="d-flex">
-				{accountSubscriptionGroups?.map(
+				{visibleAccountSubscriptionGroups?.map(
 					({activationProductName, manageContactsURL, name}, index) => {
 						if (activationProductName.split(',')
 								.includes(PRODUCT_TYPES.dxpCloud)) {
@@ -112,7 +126,7 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 	return (
 		(accountSubscriptionGroupsLoading ||
 			Boolean(accountSubscriptionGroupLiferayExperienceCloud) ||
-			Boolean(accountSubscriptionGroups?.length)) && (
+			Boolean(visibleAccountSubscriptionGroups?.length)) && (
 			<div className="bg-brand-primary-lighten-6 cp-manage-product-users mt-4 p-4 rounded-lg">
 				{accountSubscriptionGroupsLoading ? (
 					<Skeleton height={25} width={224} />

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
@@ -49,7 +49,7 @@ const ManageProductUsers = ({hasPaaSExperience, koroneikiAccount, loading}) => {
 		return accountSubscriptionGroups?.filter(
 			({activationProductName}) =>
 				!activationProductName
-					.split(',')
+					?.split(',')
 					.includes(PRODUCT_TYPES.dxpCloud)
 		);
 	}, [accountSubscriptionGroups, hasPaaSExperience]);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12360

## What Is Being Fixed

PaaS Experience customers were shown the "Manage Liferay PaaS Users" card in the project Team Members area. That card maps to a DXP Cloud subscription group, which does not apply to PaaS Experience customers, so it should not be surfaced to them.

## How It Is Being Fixed

`TeamMembers` now passes a `hasPaaSExperience` flag down to `ManageProductUsers`. When that flag is set, `ManageProductUsers` filters out any account subscription group whose `activationProductName` includes the DXP Cloud product type, so the corresponding card is no longer rendered. The `activationProductName` lookup uses optional chaining so a missing or null product name no longer throws and simply leaves the group visible.

## Why Are There No Tests?

This is a frontend-only change to a custom-element client extension (conditional card visibility plus a null guard) with no automated test infrastructure in this module.

## PR Check

**pr-check: PASS** — tested on `b3b29ca40975e13cc412bf8a80dd73dd5c809f5b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "b3b29ca40975e13cc412bf8a80dd73dd5c809f5b"} -->
