### PR TITLE
LPD-89421 Add license key exporter to the liferay-one workspace

### DIFF
--- a/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
+++ b/modules/apps/application-list/application-list-taglib/src/main/resources/META-INF/resources/js/ScopeDropdown.tsx
@@ -51,7 +51,7 @@ export default function ScopeDropdown({
 						<ClayBadge
 							className="c-ml-2 text-uppercase"
 							displayType="warning"
-							label="deprecated"
+							label={Liferay.Language.get('deprecated')}
 							translucent
 						/>
 					)}

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/InstanceDetails.js
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/js/InstanceDetails.js
@@ -98,7 +98,7 @@ function handlePublish({WORKFLOW_ACTION_PUBLISH, namespace}) {
 				workflowActionInput.value = WORKFLOW_ACTION_PUBLISH;
 			}
 
-			submitForm(form);
+			form.requestSubmit();
 		};
 
 		const skuInput = document.getElementById(`${namespace}sku`);

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_date-picker.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_date-picker.scss
@@ -1,6 +1,6 @@
 .datepicker {
 	body {
-		background-color: #fff;
+		background-color: $white;
 	}
 
 	.row {
@@ -42,7 +42,7 @@
 	.day {
 		align-items: center;
 		border-radius: 100%;
-		color: #6b6c7e;
+		color: $gray-600;
 		cursor: pointer;
 		display: flex;
 		height: 31px;
@@ -56,12 +56,12 @@
 	}
 
 	.day.active {
-		background-color: #0b5fff;
-		color: #fff !important;
+		background-color: $primary;
+		color: $white !important;
 	}
 
 	.day.outside {
-		color: #a7a9bc;
+		color: $gray-500;
 	}
 
 	.form-caption,
@@ -89,7 +89,7 @@
 	}
 
 	.week {
-		color: #272833;
+		color: $gray-900;
 		font-weight: 600;
 		text-align: center;
 		width: 32px;
@@ -97,8 +97,8 @@
 
 	.extension-time {
 		align-items: center;
-		background-color: rgba(241, 242, 245, 0.5);
-		color: #6b6c7e;
+		background-color: unquote('hsl(from #{$gray-200} h s l / 0.5)');
+		color: $gray-600;
 		display: flex;
 		padding: 16px 32px;
 	}

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_field-type-checkbox-switch.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_field-type-checkbox-switch.scss
@@ -17,7 +17,7 @@
 }
 
 .ddm-info {
-	color: #6b6c7e;
+	color: $gray-600;
 	display: flex;
 	font-size: 0.875rem;
 	font-weight: 400;
@@ -28,7 +28,7 @@
 	}
 
 	.ddm-tooltip {
-		color: #6b6c7e;
+		color: $gray-600;
 		padding-left: 0;
 	}
 }

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_image_picker.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/_image_picker.scss
@@ -17,10 +17,12 @@
 			border: none;
 
 			> button.close {
-				color: #fff;
+				color: $white;
 
 				&:hover {
-					background-color: rgba(255, 255, 255, 0.1);
+					background-color: unquote(
+						'hsl(from #{$white} h s l / 0.1)'
+					);
 				}
 			}
 		}
@@ -44,7 +46,7 @@
 		top: 0;
 
 		> svg {
-			color: rgba(255, 255, 255, 0.4);
+			color: unquote('hsl(from #{$white} h s l / 0.4)');
 			display: none;
 			height: 40px;
 			left: 48.61%;
@@ -54,7 +56,7 @@
 		}
 
 		&.image-backdor:hover {
-			background-color: rgba(39, 40, 51, 0.5);
+			background-color: unquote('hsl(from #{$gray-900} h s l / 0.5)');
 
 			> svg {
 				display: block;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 @import 'date-picker';
 @import 'field-type-checkbox-switch';
@@ -59,7 +59,7 @@ body .ddm-user-view-content {
 	}
 
 	.multi-step-item.active .multi-step-divider {
-		background-color: #1865fb;
+		background-color: $primary;
 	}
 
 	.multi-step-indicator-label {
@@ -106,14 +106,14 @@ body .ddm-user-view-content {
 		.custom-control-input:checked:disabled
 		~ .custom-control-label::before {
 		background-color: $primary;
-		border-color: #0043c5;
+		border-color: $primary-d1;
 	}
 
 	.custom-checkbox
 		.custom-control-input:checked:disabled
 		~ .custom-control-label::before {
 		background-color: $primary;
-		border-color: #0043c5;
+		border-color: $primary-d1;
 	}
 
 	.form-control:disabled {
@@ -190,7 +190,7 @@ body .ddm-user-view-content {
 	}
 
 	.lfr-ddm-form-field-repeatable-toolbar a {
-		color: #65b6f0;
+		color: $blue-l1;
 		text-decoration: none;
 
 		&:hover {
@@ -300,7 +300,7 @@ body .ddm-user-view-content {
 }
 
 .liferay-ddm-form-field-tip {
-	color: #5b7b86;
+	color: $gray-700;
 	line-height: 16px;
 }
 
@@ -343,10 +343,10 @@ body .ddm-user-view-content {
 
 .multi-step-progress-bar {
 	> .complete {
-		color: #65b6f0;
+		color: $blue-l1;
 
 		.divider {
-			background-color: #65b6f0;
+			background-color: $blue-l1;
 		}
 	}
 }
@@ -369,7 +369,7 @@ body .ddm-user-view-content {
 	position: relative;
 
 	.option-selected-placeholder {
-		color: #6a6c7d;
+		color: $gray-600;
 	}
 
 	.dropdown-menu {
@@ -403,7 +403,7 @@ body .ddm-user-view-content {
 	}
 
 	.search-chosen {
-		border-bottom: 1px solid #e4e9ec;
+		border-bottom: 1px solid $gray-300;
 		position: relative;
 	}
 
@@ -413,12 +413,12 @@ body .ddm-user-view-content {
 		top: 2px;
 
 		a {
-			color: #869cad;
+			color: $gray-500;
 		}
 	}
 
 	&.active .select-field-trigger {
-		border-bottom: 2px solid #65b6f0;
+		border-bottom: 2px solid $blue-l1;
 	}
 
 	.form-control {
@@ -431,7 +431,7 @@ body .ddm-user-view-content {
 	}
 
 	.form-control[disabled]:focus {
-		border-bottom: 2px solid #869cad;
+		border-bottom: 2px solid $gray-500;
 		text-decoration: none;
 	}
 
@@ -543,7 +543,7 @@ body .ddm-user-view-content {
 	}
 
 	fieldset {
-		border: 1px solid rgba(134, 156, 173, 0.4);
+		border: 1px solid unquote('hsl(from #{$gray-500} h s l / 0.4)');
 		border-bottom-width: 0;
 		border-top-width: 0;
 		padding: 10px 10px 0;
@@ -559,7 +559,7 @@ body .ddm-user-view-content {
 
 		legend {
 			border-width: 0;
-			color: #869cad;
+			color: $gray-500;
 			font-size: 12px;
 			font-weight: bold;
 			line-height: 20px;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.scss
@@ -1,9 +1,11 @@
+@import 'atlas-custom-properties/_variables';
+
 .ddm-field-renderer {
 	&--error {
-		background-color: #feefef;
-		border: 2px dashed #f48989;
+		background-color: $danger-l2;
+		border: 2px dashed $danger-l1;
 		border-radius: 4px;
-		color: #da1414;
+		color: $danger;
 		padding: 20px;
 	}
 

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/PageRenderer/WebContentVariant.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .lfr-forms {
 	&__form-view-ddm-target {
 		align-items: center;
@@ -6,7 +8,7 @@
 		width: 100%;
 
 		&.lfr-forms__form-view-ddm-target-over > span {
-			background-color: #0b5fff;
+			background-color: $primary;
 			border-radius: 2px;
 			display: inline-block;
 			height: 2px;
@@ -22,7 +24,7 @@
 		&:focus-within,
 		&:hover {
 			&::after {
-				border: 0.125rem solid #0b5fff;
+				border: 0.125rem solid $primary;
 				border-radius: 0 4px 4px;
 				bottom: -4px;
 				content: '';
@@ -50,10 +52,10 @@
 	}
 
 	&__form-view-field-dragging {
-		background-color: #fff;
-		border: 2px dashed #a7a9bc;
+		background-color: $white;
+		border: 2px dashed $gray-500;
 		border-radius: 4px;
-		box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.2);
+		box-shadow: 0 0 3px 0 unquote('hsl(from #{$black} h s l / 0.2)');
 		opacity: 0.7;
 		padding: 2px 6px 6px !important;
 		z-index: 10;
@@ -61,10 +63,10 @@
 
 	&__form-view-field-topbar {
 		align-items: center;
-		background-color: #0b5fff;
+		background-color: $primary;
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
-		color: #fff;
+		color: $white;
 		display: none;
 		font-size: 12px;
 		font-weight: 600;

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/components/sidebar/Sidebar.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 $c: '.lfr-de__form-report-sidebar';
 
 #{$c} {
@@ -15,7 +17,7 @@ $c: '.lfr-de__form-report-sidebar';
 	}
 
 	.list-group-item:hover {
-		background-color: #f0f5ff;
+		background-color: $blue-l5;
 	}
 
 	.navbar-collapse {
@@ -35,6 +37,6 @@ $c: '.lfr-de__form-report-sidebar';
 	}
 
 	.sidebar-light {
-		background-color: #fff;
+		background-color: $white;
 	}
 }

--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/index.scss
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/custom/form-report/index.scss
@@ -1,4 +1,4 @@
-@import 'atlas-variables';
+@import 'atlas-custom-properties/_variables';
 
 %entries-list {
 	font-size: 14px;
@@ -97,7 +97,7 @@
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent .menubar-toggler {
-		color: #272833;
+		color: $gray-900;
 		font-size: 0.875rem;
 		font-weight: var(--font-weight-semi-bold, 600);
 		text-decoration: none;
@@ -105,14 +105,14 @@
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent .menubar-collapse {
-		background-color: #fff;
-		border-color: #e7e7ed;
+		background-color: $white;
+		border-color: $gray-300;
 		border-radius: 0.25rem;
-		box-shadow: 0 1px 5px -1px rgb(0 0 0 / 30%);
+		box-shadow: 0 1px 5px -1px unquote('hsl(from #{$black} h s l / 0.3)');
 	}
 
 	.menubar-vertical-expand-lg.menubar-transparent {
-		background-color: #fff;
+		background-color: $white;
 		z-index: 1;
 	}
 
@@ -176,12 +176,12 @@
 }
 
 .document-title-link {
-	color: #272833;
+	color: $gray-900;
 	font-size: 0.875rem;
 	font-weight: 600;
 
 	&:hover {
-		color: #272833;
+		color: $gray-900;
 	}
 }
 
@@ -361,7 +361,7 @@
 		.custom-tooltip {
 			background: $secondary-d1;
 			border-radius: 4px;
-			box-shadow: 0 2px 4px rgba(39, 40, 51, 0.2);
+			box-shadow: 0 2px 4px unquote('hsl(from #{$gray-900} h s l / 0.2)');
 			color: $white;
 			display: flex;
 			flex-direction: column;
@@ -394,7 +394,7 @@
 			}
 
 			.header {
-				border-bottom: 1px solid #ccc;
+				border-bottom: 1px solid $gray-400;
 				font-size: 13px;
 				font-weight: 600;
 				font-weight: 600;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_ddm_form_builder.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_ddm_form_builder.scss
@@ -37,7 +37,7 @@
 
 		.ddm-drag {
 			&.dragging {
-				background-color: #fff;
+				background-color: $white;
 				padding: 2px 6px 6px !important;
 			}
 		}
@@ -74,7 +74,7 @@
 
 			&.targetOver:after,
 			&.target-over:after {
-				background-color: #0b5fff;
+				background-color: $primary;
 				border-radius: 2px;
 				bottom: 0;
 				content: '';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_modal_editor.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_modal_editor.scss
@@ -14,6 +14,6 @@
 	}
 
 	.modal-body:nth-child(3) {
-		background-color: #f1f2f5;
+		background-color: $gray-200;
 	}
 }

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_rule_item.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/components/_rule_item.scss
@@ -18,7 +18,7 @@
 
 		.panel-unstyled {
 			border-bottom-width: 1px;
-			border-color: #e7e7ed;
+			border-color: $gray-300;
 			margin-bottom: 0;
 
 			.panel-header {
@@ -38,12 +38,12 @@
 		}
 
 		.panel-unstyled:hover {
-			background-color: #f0f5ff;
+			background-color: $blue-l5;
 		}
 	}
 
 	hr {
-		border: 0.5px solid #e7e7ed;
+		border: 0.5px solid $gray-300;
 		margin-bottom: 0;
 		margin-top: 0;
 		width: 100%;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/css/main.scss
@@ -1,3 +1,6 @@
+@import 'atlas-custom-properties/_variables';
+@import 'atlas-variables';
+
 @import 'variables';
 
 @import 'components/ddm_form_builder';

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetModal.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-sets/FieldSetModal.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 @import '../../../css/variables';
 
 .fieldset-modal {
@@ -33,8 +35,8 @@
 	}
 
 	.lfr-ddm-form-container:not(.ddm-user-view-content) {
-		background-color: white;
-		border: 1px solid #e7e7ed;
+		background-color: $white;
+		border: 1px solid $gray-300;
 		border-radius: 0.25rem;
 		margin: 1.5rem auto;
 		padding: 0 1.5rem;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
@@ -1,7 +1,9 @@
+@import 'atlas-custom-properties/_variables';
+
 @import '../../../css/variables';
 
-$fieldTypeFieldGroup: #0b5fff;
-$fieldTypeFieldSet: #5aca75;
+$fieldTypeFieldGroup: $primary;
+$fieldTypeFieldSet: $success;
 
 .field-type {
 	border: 2px solid transparent;
@@ -17,8 +19,8 @@ $fieldTypeFieldSet: #5aca75;
 
 	&:focus,
 	&:hover:not(.disabled) {
-		border-color: #80acff;
-		box-shadow: 0 2px 4px rgba(39, 40, 51, 0.12);
+		border-color: $blue-l2;
+		box-shadow: 0 2px 4px unquote('hsl(from #{$gray-900} h s l / 0.12)');
 		outline: none;
 	}
 
@@ -27,13 +29,13 @@ $fieldTypeFieldSet: #5aca75;
 	}
 
 	&.dragging {
-		background-color: #e7e7ed;
+		background-color: $gray-300;
 		opacity: 0.5;
 	}
 
 	.sticker {
-		background-color: #f7f8f9;
-		color: #6b6c7e;
+		background-color: $gray-100;
+		color: $gray-600;
 	}
 
 	.list-group-subtitle {
@@ -55,9 +57,9 @@ $fieldTypeFieldSet: #5aca75;
 	max-width: 280px;
 
 	.field-type {
-		background-color: #fff;
-		border-color: #80acff;
-		box-shadow: 0 8px 16px rgba(39, 40, 51, 0.16);
+		background-color: $white;
+		border-color: $blue-l2;
+		box-shadow: 0 8px 16px unquote('hsl(from #{$gray-900} h s l / 0.16)');
 		cursor: grabbing;
 	}
 }
@@ -66,11 +68,11 @@ $fieldTypeFieldSet: #5aca75;
 	.field-type-fieldgroup {
 		.field-type-header {
 			&:hover {
-				background-color: rgba($fieldTypeFieldGroup, 0.05) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)') !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: rgba($fieldTypeFieldGroup, 0.1) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)') !important;
 
 				.sticker-overlay {
 					svg {
@@ -81,18 +83,18 @@ $fieldTypeFieldSet: #5aca75;
 		}
 
 		.field-type-item:before {
-			border-color: rgba($fieldTypeFieldGroup, 0.2);
+			border-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)');
 		}
 	}
 
 	.field-type-fieldset {
 		.field-type-header {
 			&:hover {
-				background-color: rgba($fieldTypeFieldSet, 0.1) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.1)') !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: rgba($fieldTypeFieldSet, 0.2) !important;
+				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)') !important;
 
 				.sticker-overlay {
 					svg {
@@ -103,7 +105,7 @@ $fieldTypeFieldSet: #5aca75;
 		}
 
 		.field-type-item:before {
-			border-color: rgba($fieldTypeFieldSet, 0.2);
+			border-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)');
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/field-types/FieldType.scss
@@ -68,11 +68,15 @@ $fieldTypeFieldSet: $success;
 	.field-type-fieldgroup {
 		.field-type-header {
 			&:hover {
-				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldGroup} h s l / 0.05)'
+				) !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldGroup} h s l / 0.1)'
+				) !important;
 
 				.sticker-overlay {
 					svg {
@@ -83,18 +87,24 @@ $fieldTypeFieldSet: $success;
 		}
 
 		.field-type-item:before {
-			border-color: unquote('hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)');
+			border-color: unquote(
+				'hsl(from #{$fieldTypeFieldGroup} h s l / 0.2)'
+			);
 		}
 	}
 
 	.field-type-fieldset {
 		.field-type-header {
 			&:hover {
-				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.1)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldSet} h s l / 0.1)'
+				) !important;
 			}
 
 			.data-layout-builder-field-sticker {
-				background-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)') !important;
+				background-color: unquote(
+					'hsl(from #{$fieldTypeFieldSet} h s l / 0.2)'
+				) !important;
 
 				.sticker-overlay {
 					svg {
@@ -105,7 +115,9 @@ $fieldTypeFieldSet: $success;
 		}
 
 		.field-type-item:before {
-			border-color: unquote('hsl(from #{$fieldTypeFieldSet} h s l / 0.2)');
+			border-color: unquote(
+				'hsl(from #{$fieldTypeFieldSet} h s l / 0.2)'
+			);
 		}
 	}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Calculator.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Calculator.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	.liferay-ddm-form-builder-calculator {
 		align-content: center;
@@ -7,7 +9,7 @@
 	}
 
 	.calculate-container {
-		background-color: #f8f8f8;
+		background-color: $gray-100;
 		display: flex;
 		flex-wrap: wrap;
 		margin-top: 15px;
@@ -18,10 +20,10 @@
 		padding: 8px 25px 25px;
 
 		textarea {
-			background-color: #f5f5f5;
-			border: 1px solid #ccc;
+			background-color: $gray-200;
+			border: 1px solid $gray-400;
 			border-radius: 2px;
-			color: #333;
+			color: $gray-900;
 			font-family: Menlo;
 			font-size: 13px;
 			min-height: 200px;
@@ -97,9 +99,9 @@
 				}
 
 				.calculator-add-operator-button-area {
-					background-color: #fff;
-					border: solid 1px #cdced9;
-					color: #6b6c7e;
+					background-color: $white;
+					border: solid 1px $gray-400;
+					color: $gray-600;
 
 					.calculator-add-operator-button {
 						height: 50px;
@@ -117,7 +119,7 @@
 						}
 
 						.drop-chosen {
-							border: solid 1px #dde1e3;
+							border: solid 1px $gray-300;
 							border-radius: 4px;
 							left: -17px;
 							padding: 5px 0;

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Editor.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Editor.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	// Autofill
 
@@ -15,8 +17,8 @@
 		}
 
 		.data-provider-parameter-container {
-			background-color: #f8f8f8;
-			border-top: 1px solid #dce0e3;
+			background-color: $gray-100;
+			border-top: 1px solid $gray-300;
 			margin-top: 15px;
 			padding: 20px 55px;
 		}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/rules/editor/Timeline.scss
@@ -1,3 +1,5 @@
+@import 'atlas-custom-properties/_variables';
+
 .form-rule-builder-timeline {
 	margin: 0;
 
@@ -8,7 +10,7 @@
 	}
 
 	.timeline-item {
-		color: #869cad;
+		color: $gray-500;
 		position: relative;
 
 		&:hover > .container-trash {
@@ -16,11 +18,11 @@
 		}
 
 		&:not(:nth-of-type(1)) .timeline-icon {
-			background-color: #6b6c7e;
+			background-color: $gray-600;
 		}
 
 		.timeline-icon {
-			border: 2px solid #6b6c7e;
+			border: 2px solid $gray-600;
 			margin-right: 2px;
 		}
 
@@ -33,7 +35,7 @@
 			top: 13px;
 
 			&:hover {
-				color: #65b6f0;
+				color: $blue-l1;
 			}
 		}
 

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
@@ -137,7 +137,9 @@ $zIndexPanel: 1;
 				&:active,
 				&:focus,
 				&:hover {
-					background-color: unquote('hsl(from #{$white} h s l / 0.06)');
+					background-color: unquote(
+						'hsl(from #{$white} h s l / 0.06)'
+					);
 					color: $white;
 				}
 			}

--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/js/components/sidebar/MultiPanelSidebar.scss
@@ -1,5 +1,7 @@
-@import '../../../css/variables';
+@import 'atlas-custom-properties/_variables';
 @import 'atlas-variables';
+
+@import '../../../css/variables';
 
 $defaultTransitionDuration: 0.5s;
 $toolbarDesktopHeight: 64px;
@@ -73,7 +75,7 @@ $zIndexPanel: 1;
 				box-shadow:
 					0 0 0 0.125rem $white,
 					0 0 0 0.25rem $primary-l1,
-					inset 0 0 fade-out($black, 1);
+					inset 0 0 unquote('hsl(from #{$black} h s l / 0)');
 				outline: none;
 			}
 		}
@@ -135,7 +137,7 @@ $zIndexPanel: 1;
 				&:active,
 				&:focus,
 				&:hover {
-					background-color: fade-out($white, 0.94);
+					background-color: unquote('hsl(from #{$white} h s l / 0.06)');
 					color: $white;
 				}
 			}

--- a/modules/apps/depot/depot-service/bnd.bnd
+++ b/modules/apps/depot/depot-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Depot Service
 Bundle-SymbolicName: com.liferay.depot.service
 Bundle-Version: 3.0.87
-Liferay-Require-SchemaVersion: 2.3.0
+Liferay-Require-SchemaVersion: 2.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
@@ -7,11 +7,15 @@ package com.liferay.depot.internal.upgrade.registry;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.internal.upgrade.v2_2_0.util.DepotEntryPinTable;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -56,6 +60,22 @@ public class DepotServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.runSQL(
 				"update DepotEntryGroupRel set type_ = " +
 					DepotConstants.TYPE_ASSET_LIBRARY));
+
+		registry.register(
+			"2.3.0", "2.4.0",
+			new com.liferay.depot.internal.upgrade.v2_4_0.
+				TrashEntriesMaxAgeUpgradeProcess(
+					_companyLocalService, _depotEntryLocalService,
+					_groupLocalService));
 	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/registry/DepotServiceUpgradeStepRegistrator.java
@@ -7,15 +7,11 @@ package com.liferay.depot.internal.upgrade.registry;
 
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.internal.upgrade.v2_2_0.util.DepotEntryPinTable;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Alejandro Tardín
@@ -64,18 +60,7 @@ public class DepotServiceUpgradeStepRegistrator
 		registry.register(
 			"2.3.0", "2.4.0",
 			new com.liferay.depot.internal.upgrade.v2_4_0.
-				TrashEntriesMaxAgeUpgradeProcess(
-					_companyLocalService, _depotEntryLocalService,
-					_groupLocalService));
+				TrashEntriesMaxAgeUpgradeProcess());
 	}
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private DepotEntryLocalService _depotEntryLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -45,15 +45,15 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 			long companyId, int trashEntriesMaxAge)
 		throws Exception {
 
-		String selectSQL = StringBundler.concat(
-			"select Group_.ctCollectionId, Group_.groupId, ",
-			"Group_.typeSettings from DepotEntry inner join Group_ on ",
-			"DepotEntry.groupId = Group_.groupId and ",
-			"DepotEntry.ctCollectionId = Group_.ctCollectionId where ",
-			"DepotEntry.companyId = ? and DepotEntry.type_ = ?");
-
 		try (PreparedStatement selectPreparedStatement =
-				connection.prepareStatement(selectSQL);
+				connection.prepareStatement(
+					StringBundler.concat(
+						"select Group_.ctCollectionId, Group_.groupId, ",
+						"Group_.typeSettings from DepotEntry inner join ",
+						"Group_ on DepotEntry.groupId = Group_.groupId and ",
+						"DepotEntry.ctCollectionId = Group_.ctCollectionId ",
+						"where DepotEntry.companyId = ? and DepotEntry.type_ ",
+						"= ?"));
 			PreparedStatement updatePreparedStatement =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0;
+
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+
+/**
+ * @author Alicia García
+ */
+public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
+
+	public TrashEntriesMaxAgeUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		DepotEntryLocalService depotEntryLocalService,
+		GroupLocalService groupLocalService) {
+
+		_companyLocalService = companyLocalService;
+		_depotEntryLocalService = depotEntryLocalService;
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				int trashEntriesMaxAgeCompany = PrefsPropsUtil.getInteger(
+					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE);
+
+				if (trashEntriesMaxAgeCompany <= 0) {
+					return;
+				}
+
+				List<DepotEntry> depotEntries =
+					_depotEntryLocalService.getDepotEntries(
+						companyId, DepotConstants.TYPE_SPACE);
+
+				for (DepotEntry depotEntry : depotEntries) {
+					Group group = _groupLocalService.fetchGroup(
+						depotEntry.getGroupId());
+
+					if (group == null) {
+						continue;
+					}
+
+					_updateTrashEntriesMaxAge(group, trashEntriesMaxAgeCompany);
+				}
+			});
+	}
+
+	private void _updateTrashEntriesMaxAge(
+			Group group, int trashEntriesMaxAgeCompany)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		String trashEntriesMaxAgeGroup =
+			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+
+		if (Validator.isNotNull(trashEntriesMaxAgeGroup) &&
+			(GetterUtil.getInteger(trashEntriesMaxAgeGroup) > 0)) {
+
+			return;
+		}
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAgeCompany));
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Set trash entries max age for group ID " + group.getGroupId());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		TrashEntriesMaxAgeUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final DepotEntryLocalService _depotEntryLocalService;
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -6,42 +6,28 @@
 package com.liferay.depot.internal.upgrade.v2_4_0;
 
 import com.liferay.depot.constants.DepotConstants;
-import com.liferay.depot.model.DepotEntry;
-import com.liferay.depot.service.DepotEntryLocalService;
-import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.Property;
-import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 
 /**
  * @author Alicia García
  */
 public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 
-	public TrashEntriesMaxAgeUpgradeProcess(
-		CompanyLocalService companyLocalService,
-		DepotEntryLocalService depotEntryLocalService,
-		GroupLocalService groupLocalService) {
-
-		_companyLocalService = companyLocalService;
-		_depotEntryLocalService = depotEntryLocalService;
-		_groupLocalService = groupLocalService;
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
-		_companyLocalService.forEachCompanyId(
+		CompanyLocalServiceUtil.forEachCompanyId(
 			companyId -> {
 				int trashEntriesMaxAge = PrefsPropsUtil.getInteger(
 					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
@@ -51,62 +37,66 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 					return;
 				}
 
-				ActionableDynamicQuery actionableDynamicQuery =
-					_depotEntryLocalService.getActionableDynamicQuery();
-
-				Property property = PropertyFactoryUtil.forName("type");
-
-				actionableDynamicQuery.setAddCriteriaMethod(
-					dynamicQuery -> dynamicQuery.add(
-						property.eq(DepotConstants.TYPE_SPACE)));
-
-				actionableDynamicQuery.setCompanyId(companyId);
-				actionableDynamicQuery.setPerformActionMethod(
-					(DepotEntry depotEntry) -> {
-						Group group = _groupLocalService.fetchGroup(
-							depotEntry.getGroupId());
-
-						if (group == null) {
-							return;
-						}
-
-						_updateTrashEntriesMaxAge(group, trashEntriesMaxAge);
-					});
-
-				actionableDynamicQuery.performActions();
+				_updateTrashEntriesMaxAge(companyId, trashEntriesMaxAge);
 			});
 	}
 
-	private void _updateTrashEntriesMaxAge(Group group, int trashEntriesMaxAge)
-		throws PortalException {
+	private void _updateTrashEntriesMaxAge(
+			long companyId, int trashEntriesMaxAge)
+		throws Exception {
 
-		UnicodeProperties typeSettingsUnicodeProperties =
-			group.getTypeSettingsProperties();
+		String selectSQL = StringBundler.concat(
+			"select Group_.ctCollectionId, Group_.groupId, ",
+			"Group_.typeSettings from DepotEntry inner join Group_ on ",
+			"DepotEntry.groupId = Group_.groupId and ",
+			"DepotEntry.ctCollectionId = Group_.ctCollectionId where ",
+			"DepotEntry.companyId = ? and DepotEntry.type_ = ?");
 
-		int currentTrashEntriesMaxAge = GetterUtil.getInteger(
-			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge"));
+		try (PreparedStatement selectPreparedStatement =
+				connection.prepareStatement(selectSQL);
+			PreparedStatement updatePreparedStatement =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update Group_ set typeSettings = ? where ctCollectionId " +
+						"= ? and groupId = ?")) {
 
-		if (currentTrashEntriesMaxAge > 0) {
-			return;
-		}
+			selectPreparedStatement.setLong(1, companyId);
+			selectPreparedStatement.setInt(2, DepotConstants.TYPE_SPACE);
 
-		typeSettingsUnicodeProperties.setProperty(
-			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAge));
+			try (ResultSet resultSet = selectPreparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					UnicodeProperties typeSettingsUnicodeProperties =
+						UnicodePropertiesBuilder.create(
+							true
+						).fastLoad(
+							resultSet.getString("typeSettings")
+						).build();
 
-		_groupLocalService.updateGroup(
-			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+					int currentTrashEntriesMaxAge = GetterUtil.getInteger(
+						typeSettingsUnicodeProperties.getProperty(
+							"trashEntriesMaxAge"));
 
-		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Update trash entries max age for group " + group.getGroupId());
+					if (currentTrashEntriesMaxAge > 0) {
+						continue;
+					}
+
+					typeSettingsUnicodeProperties.setProperty(
+						"trashEntriesMaxAge",
+						String.valueOf(trashEntriesMaxAge));
+
+					updatePreparedStatement.setString(
+						1, typeSettingsUnicodeProperties.toString());
+					updatePreparedStatement.setLong(
+						2, resultSet.getLong("ctCollectionId"));
+					updatePreparedStatement.setLong(
+						3, resultSet.getLong("groupId"));
+
+					updatePreparedStatement.addBatch();
+				}
+
+				updatePreparedStatement.executeBatch();
+			}
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		TrashEntriesMaxAgeUpgradeProcess.class);
-
-	private final CompanyLocalService _companyLocalService;
-	private final DepotEntryLocalService _depotEntryLocalService;
-	private final GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -98,7 +98,7 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
-				"Set trash entries max age for group ID " + group.getGroupId());
+				"Update trash entries max age for group " + group.getGroupId());
 		}
 	}
 

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -8,6 +8,9 @@ package com.liferay.depot.internal.upgrade.v2_4_0;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -19,9 +22,6 @@ import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.UnicodeProperties;
-import com.liferay.portal.kernel.util.Validator;
-
-import java.util.List;
 
 /**
  * @author Alicia García
@@ -42,49 +42,56 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		_companyLocalService.forEachCompanyId(
 			companyId -> {
-				int trashEntriesMaxAgeCompany = PrefsPropsUtil.getInteger(
+				int trashEntriesMaxAge = PrefsPropsUtil.getInteger(
 					companyId, PropsKeys.TRASH_ENTRIES_MAX_AGE,
 					PropsValues.TRASH_ENTRIES_MAX_AGE);
 
-				if (trashEntriesMaxAgeCompany <= 0) {
+				if (trashEntriesMaxAge <= 0) {
 					return;
 				}
 
-				List<DepotEntry> depotEntries =
-					_depotEntryLocalService.getDepotEntries(
-						companyId, DepotConstants.TYPE_SPACE);
+				ActionableDynamicQuery actionableDynamicQuery =
+					_depotEntryLocalService.getActionableDynamicQuery();
 
-				for (DepotEntry depotEntry : depotEntries) {
-					Group group = _groupLocalService.fetchGroup(
-						depotEntry.getGroupId());
+				actionableDynamicQuery.setAddCriteriaMethod(
+					dynamicQuery -> dynamicQuery.add(
+						PropertyFactoryUtil.forName(
+							"type"
+						).eq(
+							DepotConstants.TYPE_SPACE
+						)));
+				actionableDynamicQuery.setCompanyId(companyId);
+				actionableDynamicQuery.setPerformActionMethod(
+					(DepotEntry depotEntry) -> {
+						Group group = _groupLocalService.fetchGroup(
+							depotEntry.getGroupId());
 
-					if (group == null) {
-						continue;
-					}
+						if (group == null) {
+							return;
+						}
 
-					_updateTrashEntriesMaxAge(group, trashEntriesMaxAgeCompany);
-				}
+						_updateTrashEntriesMaxAge(group, trashEntriesMaxAge);
+					});
+
+				actionableDynamicQuery.performActions();
 			});
 	}
 
-	private void _updateTrashEntriesMaxAge(
-			Group group, int trashEntriesMaxAgeCompany)
-		throws Exception {
+	private void _updateTrashEntriesMaxAge(Group group, int trashEntriesMaxAge)
+		throws PortalException {
 
 		UnicodeProperties typeSettingsUnicodeProperties =
 			group.getTypeSettingsProperties();
 
-		String trashEntriesMaxAgeGroup =
-			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+		int currentTrashEntriesMaxAge = GetterUtil.getInteger(
+			typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge"));
 
-		if (Validator.isNotNull(trashEntriesMaxAgeGroup) &&
-			(GetterUtil.getInteger(trashEntriesMaxAgeGroup) > 0)) {
-
+		if (currentTrashEntriesMaxAge > 0) {
 			return;
 		}
 
 		typeSettingsUnicodeProperties.setProperty(
-			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAgeCompany));
+			"trashEntriesMaxAge", String.valueOf(trashEntriesMaxAge));
 
 		_groupLocalService.updateGroup(
 			group.getGroupId(), typeSettingsUnicodeProperties.toString());

--- a/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
+++ b/modules/apps/depot/depot-service/src/main/java/com/liferay/depot/internal/upgrade/v2_4_0/TrashEntriesMaxAgeUpgradeProcess.java
@@ -9,6 +9,7 @@ import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.model.DepotEntry;
 import com.liferay.depot.service.DepotEntryLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -53,13 +54,12 @@ public class TrashEntriesMaxAgeUpgradeProcess extends UpgradeProcess {
 				ActionableDynamicQuery actionableDynamicQuery =
 					_depotEntryLocalService.getActionableDynamicQuery();
 
+				Property property = PropertyFactoryUtil.forName("type");
+
 				actionableDynamicQuery.setAddCriteriaMethod(
 					dynamicQuery -> dynamicQuery.add(
-						PropertyFactoryUtil.forName(
-							"type"
-						).eq(
-							DepotConstants.TYPE_SPACE
-						)));
+						property.eq(DepotConstants.TYPE_SPACE)));
+
 				actionableDynamicQuery.setCompanyId(companyId);
 				actionableDynamicQuery.setPerformActionMethod(
 					(DepotEntry depotEntry) -> {

--- a/modules/apps/depot/depot-test/build.gradle
+++ b/modules/apps/depot/depot-test/build.gradle
@@ -22,8 +22,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-search:portal-search-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-web-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:site:site-memberships-api")
 	testIntegrationImplementation project(":apps:staging:staging-api")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -92,19 +92,6 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		return typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
 	}
 
-	private void _upgrade() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME, LoggerTestUtil.OFF)) {
-
-			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-				_upgradeStepRegistrator, _CLASS_NAME);
-
-			upgradeProcess.upgrade();
-
-			_multiVMPool.clear();
-		}
-	}
-
 	private void _setGroupTrashEntriesMaxAge(
 			DepotEntry depotEntry, String trashEntriesMaxAge)
 		throws Exception {
@@ -162,6 +149,19 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		Assert.assertEquals(
 			String.valueOf(_getTrashEntriesMaxAgeCompany()),
 			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _upgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
 	}
 
 	private static final String _CLASS_NAME =

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -92,7 +92,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		return typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
 	}
 
-	private void _runUpgradeProcess() throws Exception {
+	private void _upgrade() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_CLASS_NAME, LoggerTestUtil.OFF)) {
 
@@ -127,7 +127,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 
 		_setGroupTrashEntriesMaxAge(depotEntry, "0");
 
-		_runUpgradeProcess();
+		_upgrade();
 
 		Assert.assertEquals("0", _getTrashEntriesMaxAgeGroup(depotEntry));
 	}
@@ -137,7 +137,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 
 		_setGroupTrashEntriesMaxAge(depotEntry, "1440");
 
-		_runUpgradeProcess();
+		_upgrade();
 
 		Assert.assertEquals("1440", _getTrashEntriesMaxAgeGroup(depotEntry));
 	}
@@ -145,7 +145,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 	private void _testUpgradeWithMissingTrashEntriesMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
-		_runUpgradeProcess();
+		_upgrade();
 
 		Assert.assertEquals(
 			String.valueOf(_getTrashEntriesMaxAgeCompany()),
@@ -157,7 +157,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 
 		_setGroupTrashEntriesMaxAge(depotEntry, "0");
 
-		_runUpgradeProcess();
+		_upgrade();
 
 		Assert.assertEquals(
 			String.valueOf(_getTrashEntriesMaxAgeCompany()),

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -59,9 +59,9 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 	@TestInfo("LPD-91035")
 	public void testUpgrade() throws Exception {
 		_testUpgradeWithAssetLibraryDepotEntry();
-		_testUpgradeWithCustomMaxAge();
-		_testUpgradeWithMissingMaxAge();
-		_testUpgradeWithZeroMaxAge();
+		_testUpgradeWithCustomTrashEntriesMaxAge();
+		_testUpgradeWithMissingTrashEntriesMaxAge();
+		_testUpgradeWithZeroTrashEntriesMaxAge();
 	}
 
 	private DepotEntry _addDepotEntry(int type) throws Exception {
@@ -132,7 +132,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		Assert.assertEquals("0", _getTrashEntriesMaxAgeGroup(depotEntry));
 	}
 
-	private void _testUpgradeWithCustomMaxAge() throws Exception {
+	private void _testUpgradeWithCustomTrashEntriesMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
 		_setGroupTrashEntriesMaxAge(depotEntry, "1440");
@@ -142,7 +142,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		Assert.assertEquals("1440", _getTrashEntriesMaxAgeGroup(depotEntry));
 	}
 
-	private void _testUpgradeWithMissingMaxAge() throws Exception {
+	private void _testUpgradeWithMissingTrashEntriesMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
 		_runUpgradeProcess();
@@ -152,7 +152,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 			_getTrashEntriesMaxAgeGroup(depotEntry));
 	}
 
-	private void _testUpgradeWithZeroMaxAge() throws Exception {
+	private void _testUpgradeWithZeroTrashEntriesMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
 		_setGroupTrashEntriesMaxAge(depotEntry, "0");

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -105,7 +105,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		}
 	}
 
-	private void _setTrashEntriesMaxAgeGroup(
+	private void _setGroupTrashEntriesMaxAge(
 			DepotEntry depotEntry, String trashEntriesMaxAge)
 		throws Exception {
 
@@ -125,7 +125,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 		DepotEntry depotEntry = _addDepotEntry(
 			DepotConstants.TYPE_ASSET_LIBRARY);
 
-		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+		_setGroupTrashEntriesMaxAge(depotEntry, "0");
 
 		_runUpgradeProcess();
 
@@ -135,7 +135,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 	private void _testUpgradeWithCustomMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
-		_setTrashEntriesMaxAgeGroup(depotEntry, "1440");
+		_setGroupTrashEntriesMaxAge(depotEntry, "1440");
 
 		_runUpgradeProcess();
 
@@ -155,7 +155,7 @@ public class TrashEntriesMaxAgeUpgradeProcessTest {
 	private void _testUpgradeWithZeroMaxAge() throws Exception {
 		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
 
-		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+		_setGroupTrashEntriesMaxAge(depotEntry, "0");
 
 		_runUpgradeProcess();
 

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/upgrade/v2_4_0/test/TrashEntriesMaxAgeUpgradeProcessTest.java
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.upgrade.v2_4_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class TrashEntriesMaxAgeUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91035")
+	public void testUpgrade() throws Exception {
+		_testUpgradeWithAssetLibraryDepotEntry();
+		_testUpgradeWithCustomMaxAge();
+		_testUpgradeWithMissingMaxAge();
+		_testUpgradeWithZeroMaxAge();
+	}
+
+	private DepotEntry _addDepotEntry(int type) throws Exception {
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			Collections.singletonMap(
+				LocaleUtil.US, RandomTestUtil.randomString()),
+			type, ServiceContextTestUtil.getServiceContext());
+
+		_depotEntries.add(depotEntry);
+
+		return depotEntry;
+	}
+
+	private int _getTrashEntriesMaxAgeCompany() throws Exception {
+		return PrefsPropsUtil.getInteger(
+			TestPropsValues.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE,
+			PropsValues.TRASH_ENTRIES_MAX_AGE);
+	}
+
+	private String _getTrashEntriesMaxAgeGroup(DepotEntry depotEntry) {
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		return typeSettingsUnicodeProperties.getProperty("trashEntriesMaxAge");
+	}
+
+	private void _runUpgradeProcess() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private void _setTrashEntriesMaxAgeGroup(
+			DepotEntry depotEntry, String trashEntriesMaxAge)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroup(depotEntry.getGroupId());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			group.getTypeSettingsProperties();
+
+		typeSettingsUnicodeProperties.setProperty(
+			"trashEntriesMaxAge", trashEntriesMaxAge);
+
+		_groupLocalService.updateGroup(
+			group.getGroupId(), typeSettingsUnicodeProperties.toString());
+	}
+
+	private void _testUpgradeWithAssetLibraryDepotEntry() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(
+			DepotConstants.TYPE_ASSET_LIBRARY);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("0", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithCustomMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "1440");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals("1440", _getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithMissingMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private void _testUpgradeWithZeroMaxAge() throws Exception {
+		DepotEntry depotEntry = _addDepotEntry(DepotConstants.TYPE_SPACE);
+
+		_setTrashEntriesMaxAgeGroup(depotEntry, "0");
+
+		_runUpgradeProcess();
+
+		Assert.assertEquals(
+			String.valueOf(_getTrashEntriesMaxAgeCompany()),
+			_getTrashEntriesMaxAgeGroup(depotEntry));
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.depot.internal.upgrade.v2_4_0." +
+			"TrashEntriesMaxAgeUpgradeProcess";
+
+	@DeleteAfterTestRun
+	private final List<DepotEntry> _depotEntries = new ArrayList<>();
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "component.name=com.liferay.depot.internal.upgrade.registry.DepotServiceUpgradeStepRegistrator"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}

--- a/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-impl/src/main/java/com/liferay/frontend/data/set/internal/serializer/BaseFDSSerializer.java
@@ -116,7 +116,8 @@ public abstract class BaseFDSSerializer {
 					"items", _toJSONArray(ownedObjectEntries)
 				).put(
 					"label",
-					language.get(httpServletRequest.getLocale(), "owned")
+					language.get(
+						PortalUtil.getLocale(httpServletRequest), "owned")
 				));
 
 			if (!sharedObjectEntries.isEmpty()) {
@@ -128,7 +129,8 @@ public abstract class BaseFDSSerializer {
 					).put(
 						"label",
 						language.get(
-							httpServletRequest.getLocale(), "shared-with-me")
+							PortalUtil.getLocale(httpServletRequest),
+							"shared-with-me")
 					));
 			}
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/renderers/ActionLinkRenderer.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/renderers/ActionLinkRenderer.tsx
@@ -84,6 +84,8 @@ function ActionLinkRenderer({
 		currentAction.href &&
 		formatActionURL(currentAction.href, itemData, currentAction.target);
 
+	const showValue = hasValue(value);
+
 	function handleClickOnLink(event: React.MouseEvent) {
 		const doAction = () => {
 			if (currentAction?.target === 'modal') {
@@ -166,6 +168,11 @@ function ActionLinkRenderer({
 			className={classNames({'table-list-title': !options?.displayType})}
 		>
 			<ClayLink
+				aria-label={
+					showValue
+						? undefined
+						: currentAction.accessibleName || currentAction.label
+				}
 				data-senna-off
 				decoration={options?.decoration}
 				displayType={options?.displayType}
@@ -195,7 +202,7 @@ function ActionLinkRenderer({
 							}
 				}
 			>
-				{hasValue(value)
+				{showValue
 					? value
 					: currentAction.icon && (
 							<ClayIcon symbol={currentAction.icon} />

--- a/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_multi-step-nav.scss
+++ b/modules/apps/frontend-js/frontend-js-clay-web/clay/clay-css/src/scss/atlas-custom-properties/variables/_multi-step-nav.scss
@@ -84,7 +84,7 @@ $data-multi-step-icon-before-content: unquote(
 
 $multi-step-divider-bg: var(--multi-step-divider-bg, $gray-200) !default;
 $multi-step-divider-height: var(--multi-step-divider-height, 4px) !default;
-$multi-step-divider-spacer-x: var(--multi-step-divider-spacer-x, 0) !default;
+$multi-step-divider-spacer-x: var(--multi-step-divider-spacer-x, 0px) !default;
 $multi-step-divider-top: var(
 	--multi-step-divider-top,
 	calc(#{$multi-step-divider-height} * 0.5 + #{$multi-step-icon-size} * 0.5)

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/CreationMenu.js
@@ -29,6 +29,7 @@ const Item = ({item, onClick}) => {
 					{unescapeHTML(item.label)}
 
 					<ClayBadge
+						className="text-uppercase"
 						displayType="warning"
 						label={Liferay.Language.get('deprecated')}
 						translucent

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/CountryResourceTest.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/CountryResourceTest.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -36,6 +37,8 @@ import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.rule.Inject;
 
 import jakarta.ws.rs.core.Response;
+
+import java.text.DateFormat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,6 +88,8 @@ public class CountryResourceTest extends BaseCountryResourceTestCase {
 		assertContains(country1, (List<Country>)page.getItems());
 		assertContains(country2, (List<Country>)page.getItems());
 		assertValid(page);
+
+		_testGetCountriesPageWithFilter();
 	}
 
 	@Override
@@ -280,6 +285,11 @@ public class CountryResourceTest extends BaseCountryResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"a2", "a3", "name", "number"};
+	}
+
+	@Override
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[] {"dateCreated", "dateModified"};
 	}
 
 	@Override
@@ -483,6 +493,77 @@ public class CountryResourceTest extends BaseCountryResourceTestCase {
 		return randomValue ->
 			StringUtil.isLowerCase(randomValue) &&
 			!existingValues.contains(randomValue);
+	}
+
+	private void _testGetCountriesPageWithFilter() throws Exception {
+		Country country1 = randomCountry();
+
+		String keywords = RandomTestUtil.randomString();
+
+		country1.setName(keywords + country1.getName());
+
+		// Sleep for 1 second to ensure that country 1 and existing
+		// countries are created 1 second apart
+
+		Thread.sleep(1000);
+
+		country1 = testGetCountriesPage_addCountry(country1);
+
+		// Sleep for 1 second to ensure that country 1 and country 2 are created
+		// 1 second apart
+
+		Thread.sleep(1000);
+
+		Country country2 = randomCountry();
+
+		country2.setName(keywords + country2.getName());
+
+		country2 = testGetCountriesPage_addCountry(country2);
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Page<Country> page = countryResource.getCountriesPage(
+			null, keywords,
+			"dateCreated lt " + dateFormat.format(country1.getDateCreated()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		page = countryResource.getCountriesPage(
+			null, keywords,
+			"dateCreated ge " + dateFormat.format(country1.getDateCreated()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		// Sleep for 1 second to ensure that country 1 and country 2 are
+		// modified 1 second apart
+
+		Thread.sleep(1000);
+
+		country1.setName(
+			keywords + StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		country1 = countryResource.patchCountry(country1.getId(), country1);
+
+		page = countryResource.getCountriesPage(
+			null, keywords,
+			"dateModified ge " + dateFormat.format(country1.getDateModified()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(country1, (List<Country>)page.getItems());
+
+		page = countryResource.getCountriesPage(
+			null, keywords,
+			"dateModified lt " + dateFormat.format(country1.getDateModified()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(country2, (List<Country>)page.getItems());
 	}
 
 	private void _testGetCountryWithNestedFields() throws Exception {

--- a/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/RegionResourceTest.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-test/src/testIntegration/java/com/liferay/headless/admin/address/resource/v1_0/test/RegionResourceTest.java
@@ -25,9 +25,11 @@ import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -35,6 +37,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 
 import jakarta.ws.rs.core.Response;
+
+import java.text.DateFormat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -96,6 +100,8 @@ public class RegionResourceTest extends BaseRegionResourceTestCase {
 		assertContains(region1, (List<Region>)page.getItems());
 		assertContains(region2, (List<Region>)page.getItems());
 		assertValid(page);
+
+		_testGetRegionsPageWithFilter();
 	}
 
 	@Override
@@ -223,6 +229,11 @@ public class RegionResourceTest extends BaseRegionResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"name", "position", "regionCode"};
+	}
+
+	@Override
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[] {"dateCreated", "dateModified"};
 	}
 
 	@Override
@@ -441,6 +452,69 @@ public class RegionResourceTest extends BaseRegionResourceTestCase {
 					exceptionClass.getSimpleName(), jsonObject.get("type"));
 			}
 		}
+	}
+
+	private void _testGetRegionsPageWithFilter() throws Exception {
+		String keywords = RandomTestUtil.randomString();
+
+		// Sleep for 1 second to ensure that region 1 and existing
+		// regions are created 1 second apart
+
+		Thread.sleep(1000);
+
+		Region region1 = _addRegion(keywords);
+
+		// Sleep for 1 second to ensure that region 1 and region 2 are created
+		// 1 second apart
+
+		Thread.sleep(1000);
+
+		Region region2 = _addRegion(keywords);
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Page<Region> page = regionResource.getRegionsPage(
+			null, keywords,
+			"dateCreated lt " + dateFormat.format(region1.getDateCreated()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(0, page.getTotalCount());
+
+		page = regionResource.getRegionsPage(
+			null, keywords,
+			"dateCreated ge " + dateFormat.format(region1.getDateCreated()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(2, page.getTotalCount());
+
+		// Sleep for 1 second to ensure that region 1 and region 2 are modified
+		// 1 second apart
+
+		Thread.sleep(1000);
+
+		region1.setName(
+			keywords + StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		region1 = regionResource.patchRegion(region1.getId(), region1);
+
+		page = regionResource.getRegionsPage(
+			null, keywords,
+			"dateModified ge " + dateFormat.format(region1.getDateModified()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(region1, (List<Region>)page.getItems());
+
+		page = regionResource.getRegionsPage(
+			null, keywords,
+			"dateModified lt " + dateFormat.format(region1.getDateModified()),
+			Pagination.of(1, 2), null);
+
+		Assert.assertEquals(1, page.getTotalCount());
+
+		assertContains(region2, (List<Region>)page.getItems());
 	}
 
 	private void _testGetRegionWithNestedFields() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-impl/src/main/java/com/liferay/headless/asset/library/internal/dto/v1_0/converter/AssetLibraryDTOConverter.java
@@ -26,6 +26,9 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
@@ -224,8 +227,20 @@ public class AssetLibraryDTOConverter
 					() -> GetterUtil.getBoolean(
 						unicodeProperties.get("trashEnabled"), true));
 				setTrashEntriesMaxAge(
-					() -> GetterUtil.getInteger(
-						unicodeProperties.getProperty("trashEntriesMaxAge")));
+					() -> {
+						int trashEntriesMaxAge = GetterUtil.getInteger(
+							unicodeProperties.getProperty(
+								"trashEntriesMaxAge"));
+
+						if (trashEntriesMaxAge > 0) {
+							return trashEntriesMaxAge;
+						}
+
+						return PrefsPropsUtil.getInteger(
+							group.getCompanyId(),
+							PropsKeys.TRASH_ENTRIES_MAX_AGE,
+							PropsValues.TRASH_ENTRIES_MAX_AGE);
+					});
 				setUseCustomLanguages(
 					() -> !GetterUtil.getBoolean(
 						unicodeProperties.get("inheritLocales")));

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -36,6 +36,9 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.odata.entity.EntityField;
@@ -191,6 +194,7 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		_testPostAssetLibrary(new MimeTypeLimit[0]);
 		_testPostAssetLibraryWithDuplicateExternalReferenceCode();
 		_testPostAssetLibraryWithExternalReferenceCode();
+		_testPostAssetLibraryWithMissingTrashEntriesMaxAge();
 		_testPostAssetLibraryWithNoSettings();
 
 		AssetLibrary randomAssetLibrary = randomAssetLibrary();
@@ -796,6 +800,28 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		Assert.assertNotNull(
 			_groupLocalService.fetchGroupByExternalReferenceCode(
 				externalReferenceCode, testCompany.getCompanyId()));
+	}
+
+	private void _testPostAssetLibraryWithMissingTrashEntriesMaxAge()
+		throws Exception {
+
+		AssetLibrary randomAssetLibrary = randomAssetLibrary();
+
+		randomAssetLibrary.setSettings(new Settings());
+		randomAssetLibrary.setType(AssetLibrary.Type.SPACE);
+
+		AssetLibrary postedAssetLibrary = assetLibraryResource.postAssetLibrary(
+			randomAssetLibrary);
+
+		Settings settings = postedAssetLibrary.getSettings();
+
+		Assert.assertEquals(
+			Integer.valueOf(
+				PrefsPropsUtil.getInteger(
+					TestPropsValues.getCompanyId(),
+					PropsKeys.TRASH_ENTRIES_MAX_AGE,
+					PropsValues.TRASH_ENTRIES_MAX_AGE)),
+			settings.getTrashEntriesMaxAge());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
+++ b/modules/apps/headless/headless-asset-library/headless-asset-library-test/src/testIntegration/java/com/liferay/headless/asset/library/resource/v1_0/test/AssetLibraryResourceTest.java
@@ -816,12 +816,10 @@ public class AssetLibraryResourceTest extends BaseAssetLibraryResourceTestCase {
 		Settings settings = postedAssetLibrary.getSettings();
 
 		Assert.assertEquals(
-			Integer.valueOf(
-				PrefsPropsUtil.getInteger(
-					TestPropsValues.getCompanyId(),
-					PropsKeys.TRASH_ENTRIES_MAX_AGE,
-					PropsValues.TRASH_ENTRIES_MAX_AGE)),
-			settings.getTrashEntriesMaxAge());
+			PrefsPropsUtil.getInteger(
+				TestPropsValues.getCompanyId(), PropsKeys.TRASH_ENTRIES_MAX_AGE,
+				PropsValues.TRASH_ENTRIES_MAX_AGE),
+			(int)settings.getTrashEntriesMaxAge());
 	}
 
 	private void _testPostAssetLibraryWithNoSettings() throws Exception {

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/bnd.bnd
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless DSR API
 Bundle-SymbolicName: com.liferay.headless.dsr.api
-Bundle-Version: 1.1.1
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.headless.dsr.dto.v1_0,\
 	com.liferay.headless.dsr.resource.v1_0

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/dto/v1_0/Room.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/dto/v1_0/Room.java
@@ -1,0 +1,456 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+@GraphQLName("Room")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Room")
+public class Room implements Serializable {
+
+	public static Room toDTO(String json) {
+		return ObjectMapperUtil.readValue(Room.class, json);
+	}
+
+	public static Room unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Room.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long[] getFileEntryIds() {
+		if (_fileEntryIdsSupplier != null) {
+			fileEntryIds = _fileEntryIdsSupplier.get();
+
+			_fileEntryIdsSupplier = null;
+		}
+
+		return fileEntryIds;
+	}
+
+	public void setFileEntryIds(Long[] fileEntryIds) {
+		this.fileEntryIds = fileEntryIds;
+
+		_fileEntryIdsSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFileEntryIds(
+		UnsafeSupplier<Long[], Exception> fileEntryIdsUnsafeSupplier) {
+
+		_fileEntryIdsSupplier = () -> {
+			try {
+				return fileEntryIdsUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long[] fileEntryIds;
+
+	@JsonIgnore
+	private Supplier<Long[]> _fileEntryIdsSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getFriendlyURL() {
+		if (_friendlyURLSupplier != null) {
+			friendlyURL = _friendlyURLSupplier.get();
+
+			_friendlyURLSupplier = null;
+		}
+
+		return friendlyURL;
+	}
+
+	public void setFriendlyURL(String friendlyURL) {
+		this.friendlyURL = friendlyURL;
+
+		_friendlyURLSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setFriendlyURL(
+		UnsafeSupplier<String, Exception> friendlyURLUnsafeSupplier) {
+
+		_friendlyURLSupplier = () -> {
+			try {
+				return friendlyURLUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String friendlyURL;
+
+	@JsonIgnore
+	private Supplier<String> _friendlyURLSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getGroupId() {
+		if (_groupIdSupplier != null) {
+			groupId = _groupIdSupplier.get();
+
+			_groupIdSupplier = null;
+		}
+
+		return groupId;
+	}
+
+	public void setGroupId(Long groupId) {
+		this.groupId = groupId;
+
+		_groupIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setGroupId(
+		UnsafeSupplier<Long, Exception> groupIdUnsafeSupplier) {
+
+		_groupIdSupplier = () -> {
+			try {
+				return groupIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long groupId;
+
+	@JsonIgnore
+	private Supplier<Long> _groupIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getId() {
+		if (_idSupplier != null) {
+			id = _idSupplier.get();
+
+			_idSupplier = null;
+		}
+
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+
+		_idSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		_idSupplier = () -> {
+			try {
+				return idUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@JsonIgnore
+	private Supplier<Long> _idSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Room)) {
+			return false;
+		}
+
+		Room room = (Room)object;
+
+		return Objects.equals(toString(), room.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long[] fileEntryIds = getFileEntryIds();
+
+		if (fileEntryIds != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileEntryIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < fileEntryIds.length; i++) {
+				sb.append(fileEntryIds[i]);
+
+				if ((i + 1) < fileEntryIds.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		String friendlyURL = getFriendlyURL();
+
+		if (friendlyURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(friendlyURL));
+
+			sb.append("\"");
+		}
+
+		Long groupId = getGroupId();
+
+		if (groupId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupId\": ");
+
+			sb.append(groupId);
+		}
+
+		Long id = getId();
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.dsr.dto.v1_0.Room",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:393804324

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/resource/v1_0/RoomResource.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/java/com/liferay/headless/dsr/resource/v1_0/RoomResource.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/headless-dsr/v1.0
+ *
+ * @author Stefano Motta
+ * @generated
+ */
+@CTAware
+@Generated("")
+@ProviderType
+public interface RoomResource {
+
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public RoomResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:457732909

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-dsr/headless-dsr-api/src/main/resources/com/liferay/headless/dsr/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/dto/v1_0/Room.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/dto/v1_0/Room.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.dto.v1_0;
+
+import com.liferay.headless.dsr.client.function.UnsafeSupplier;
+import com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public class Room implements Cloneable, Serializable {
+
+	public static Room toDTO(String json) {
+		return RoomSerDes.toDTO(json);
+	}
+
+	public Long[] getFileEntryIds() {
+		return fileEntryIds;
+	}
+
+	public void setFileEntryIds(Long[] fileEntryIds) {
+		this.fileEntryIds = fileEntryIds;
+	}
+
+	public void setFileEntryIds(
+		UnsafeSupplier<Long[], Exception> fileEntryIdsUnsafeSupplier) {
+
+		try {
+			fileEntryIds = fileEntryIdsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long[] fileEntryIds;
+
+	public String getFriendlyURL() {
+		return friendlyURL;
+	}
+
+	public void setFriendlyURL(String friendlyURL) {
+		this.friendlyURL = friendlyURL;
+	}
+
+	public void setFriendlyURL(
+		UnsafeSupplier<String, Exception> friendlyURLUnsafeSupplier) {
+
+		try {
+			friendlyURL = friendlyURLUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String friendlyURL;
+
+	public Long getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(Long groupId) {
+		this.groupId = groupId;
+	}
+
+	public void setGroupId(
+		UnsafeSupplier<Long, Exception> groupIdUnsafeSupplier) {
+
+		try {
+			groupId = groupIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long groupId;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	@Override
+	public Room clone() throws CloneNotSupportedException {
+		return (Room)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Room)) {
+			return false;
+		}
+
+		Room room = (Room)object;
+
+		return Objects.equals(toString(), room.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return RoomSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:145553694

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/resource/v1_0/RoomResource.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/resource/v1_0/RoomResource.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.resource.v1_0;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.http.HttpInvoker;
+import com.liferay.headless.dsr.client.problem.Problem;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public interface RoomResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception;
+
+	public HttpInvoker.HttpResponse postRoomDuplicateHttpResponse(
+			Long roomId, Room room)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public RoomResource build() {
+			return new RoomResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class RoomResourceImpl implements RoomResource {
+
+		public Room postRoomDuplicate(Long roomId, Room room) throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				postRoomDuplicateHttpResponse(roomId, room);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes.
+					toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postRoomDuplicateHttpResponse(
+				Long roomId, Room room)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(room.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-dsr/v1.0/rooms/{roomId}/duplicate");
+
+			httpInvoker.path("roomId", roomId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private RoomResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			RoomResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-899476169

--- a/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/serdes/v1_0/RoomSerDes.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-client/src/main/java/com/liferay/headless/dsr/client/serdes/v1_0/RoomSerDes.java
@@ -1,0 +1,316 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.client.serdes.v1_0;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public class RoomSerDes {
+
+	public static Room toDTO(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToDTO(json);
+	}
+
+	public static Room[] toDTOs(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Room room) {
+		if (room == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (room.getFileEntryIds() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"fileEntryIds\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < room.getFileEntryIds().length; i++) {
+				sb.append(room.getFileEntryIds()[i]);
+
+				if ((i + 1) < room.getFileEntryIds().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (room.getFriendlyURL() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(room.getFriendlyURL()));
+
+			sb.append("\"");
+		}
+
+		if (room.getGroupId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"groupId\": ");
+
+			sb.append(room.getGroupId());
+		}
+
+		if (room.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(room.getId());
+		}
+
+		if (room.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(room.getName()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		RoomJSONParser roomJSONParser = new RoomJSONParser();
+
+		return roomJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Room room) {
+		if (room == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (room.getFileEntryIds() == null) {
+			map.put("fileEntryIds", null);
+		}
+		else {
+			map.put("fileEntryIds", String.valueOf(room.getFileEntryIds()));
+		}
+
+		if (room.getFriendlyURL() == null) {
+			map.put("friendlyURL", null);
+		}
+		else {
+			map.put("friendlyURL", String.valueOf(room.getFriendlyURL()));
+		}
+
+		if (room.getGroupId() == null) {
+			map.put("groupId", null);
+		}
+		else {
+			map.put("groupId", String.valueOf(room.getGroupId()));
+		}
+
+		if (room.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(room.getId()));
+		}
+
+		if (room.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(room.getName()));
+		}
+
+		return map;
+	}
+
+	public static class RoomJSONParser extends BaseJSONParser<Room> {
+
+		@Override
+		protected Room createDTO() {
+			return new Room();
+		}
+
+		@Override
+		protected Room[] createDTOArray(int size) {
+			return new Room[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "fileEntryIds")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "friendlyURL")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "groupId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			Room room, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "fileEntryIds")) {
+				if (jsonParserFieldValue != null) {
+					room.setFileEntryIds(
+						toLongs((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "friendlyURL")) {
+				if (jsonParserFieldValue != null) {
+					room.setFriendlyURL((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "groupId")) {
+				if (jsonParserFieldValue != null) {
+					room.setGroupId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					room.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					room.setName((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:712251575

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/rest-openapi.yaml
@@ -15,6 +15,26 @@ components:
                     type: integer
                 roleKey:
                     type: string
+        Room:
+            properties:
+                fileEntryIds:
+                    items:
+                        format: int64
+                        type: integer
+                    type: array
+                friendlyURL:
+                    readOnly: true
+                    type: string
+                groupId:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                id:
+                    format: int64
+                    readOnly: true
+                    type: integer
+                name:
+                    type: string
         UserAccount:
             properties:
                 alternateName:
@@ -42,6 +62,34 @@ info:
     version: v1.0
 openapi: 3.0.1
 paths:
+    "/rooms/{roomId}/duplicate":
+        post:
+            operationId: postRoomDuplicate
+            parameters:
+                -   in: path
+                    name: roomId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/Room"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/Room"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Room"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Room"
+            tags: ["Room"]
     "/rooms/{roomId}/invited-members":
         get:
             operationId: getRoomInvitedMembersPage

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/BaseRoomResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/BaseRoomResourceImpl.java
@@ -1,0 +1,521 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseRoomResourceImpl implements RoomResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-dsr/v1.0/rooms/{roomId}/duplicate' -d $'{"fileEntryIds": ___, "name": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "roomId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Room")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/rooms/{roomId}/duplicate")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Room postRoomDuplicate(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("roomId")
+			Long roomId,
+			Room room)
+		throws Exception {
+
+		return new Room();
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "headless-dsr";
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseRoomResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:113858518

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -87,6 +87,8 @@ public class OpenAPIResourceImpl {
 		{
 			add(InvitedMemberResourceImpl.class);
 
+			add(RoomResourceImpl.class);
+
 			add(UserAccountResourceImpl.class);
 
 			add(OpenAPIResourceImpl.class);
@@ -94,4 +96,4 @@ public class OpenAPIResourceImpl {
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1468967523
+// LIFERAY-REST-BUILDER-HASH:1610006332

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/RoomResourceImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/RoomResourceImpl.java
@@ -1,0 +1,153 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0;
+
+import com.liferay.headless.dsr.dto.v1_0.Room;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.object.constants.ObjectActionKeys;
+import com.liferay.object.definition.security.permission.resource.ObjectDefinitionPortletResourcePermissionRegistryUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.site.dsr.site.initializer.thread.local.DSRRoomThreadLocal;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Stefano Motta
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/room.properties",
+	scope = ServiceScope.PROTOTYPE, service = RoomResource.class
+)
+public class RoomResourceImpl extends BaseRoomResourceImpl {
+
+	@Override
+	public Room postRoomDuplicate(Long roomId, Room room) throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-66359")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		ObjectEntry objectEntry = _objectEntryService.getObjectEntry(roomId);
+
+		_checkPermission(objectEntry);
+
+		DSRRoomThreadLocal.setFileEntryIds(
+			GetterUtil.getLongValues(room.getFileEntryIds()));
+		DSRRoomThreadLocal.setObjectEntryId(objectEntry.getObjectEntryId());
+
+		try {
+			ServiceContext serviceContext = new ServiceContext();
+
+			serviceContext.setCompanyId(contextCompany.getCompanyId());
+			serviceContext.setUserId(contextUser.getUserId());
+
+			return _toRoom(
+				_objectEntryLocalService.addObjectEntry(
+					0, contextUser.getUserId(),
+					objectEntry.getObjectDefinitionId(), 0, null,
+					HashMapBuilder.<String, Serializable>put(
+						"description",
+						MapUtil.getString(
+							objectEntry.getValues(), "description")
+					).put(
+						"name",
+						GetterUtil.getString(
+							room.getName(),
+							MapUtil.getString(objectEntry.getValues(), "name"))
+					).put(
+						"r_accountToDSRRooms_accountEntryId",
+						MapUtil.getLong(
+							objectEntry.getValues(),
+							"r_accountToDSRRooms_accountEntryId")
+					).build(),
+					serviceContext));
+		}
+		finally {
+			DSRRoomThreadLocal.setFileEntryIds(new long[0]);
+			DSRRoomThreadLocal.setObjectEntryId(0);
+		}
+	}
+
+	private void _checkPermission(ObjectEntry objectEntry) throws Exception {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker.isCompanyAdmin()) {
+			return;
+		}
+
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		PortletResourcePermission portletResourcePermission =
+			ObjectDefinitionPortletResourcePermissionRegistryUtil.getService(
+				objectDefinition.getResourceName());
+
+		if ((objectEntry.getUserId() == permissionChecker.getUserId()) &&
+			portletResourcePermission.contains(
+				permissionChecker, objectEntry.getGroupId(),
+				ObjectActionKeys.ADD_OBJECT_ENTRY)) {
+
+			return;
+		}
+
+		throw new PrincipalException.MustHavePermission(
+			permissionChecker, objectDefinition.getResourceName(),
+			objectEntry.getGroupId(), ObjectActionKeys.ADD_OBJECT_ENTRY);
+	}
+
+	private Room _toRoom(ObjectEntry objectEntry) throws Exception {
+		ObjectDefinition objectDefinition = objectEntry.getObjectDefinition();
+
+		Group group = _groupLocalService.fetchGroup(
+			objectEntry.getCompanyId(),
+			_classNameLocalService.getClassNameId(
+				objectDefinition.getClassName()),
+			objectEntry.getObjectEntryId());
+
+		return new Room() {
+			{
+				setFriendlyURL(group::getFriendlyURL);
+				setGroupId(group::getGroupId);
+				setId(objectEntry::getObjectEntryId);
+				setName(
+					() -> MapUtil.getString(objectEntry.getValues(), "name"));
+			}
+		};
+	}
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
+
+}

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/factory/RoomResourceFactoryImpl.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/java/com/liferay/headless/dsr/internal/resource/v1_0/factory/RoomResourceFactoryImpl.java
@@ -1,0 +1,326 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.internal.resource.v1_0.factory;
+
+import com.liferay.headless.dsr.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.headless.dsr.resource.v1_0.RoomResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/headless-dsr/v1.0/Room",
+	service = RoomResource.Factory.class
+)
+@Generated("")
+public class RoomResourceFactoryImpl implements RoomResource.Factory {
+
+	@Override
+	public RoomResource.Builder create() {
+		return new RoomResource.Builder() {
+
+			@Override
+			public RoomResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, RoomResource>
+					roomResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_roomResourceProxyProviderFunction;
+
+				return roomResourceProxyProviderFunction.apply(
+					(proxy, method, arguments) -> _invoke(
+						method, arguments, _checkPermissions,
+						_httpServletRequest, _httpServletResponse,
+						_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public RoomResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder httpServletRequest(
+				HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder httpServletResponse(
+				HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder uriInfo(UriInfo uriInfo) {
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public RoomResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function<InvocationHandler, RoomResource>
+		_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			RoomResource.class.getClassLoader(), RoomResource.class);
+
+		try {
+			Constructor<RoomResource> constructor =
+				(Constructor<RoomResource>)proxyClass.getConstructor(
+					InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		RoomResource roomResource = _componentServiceObjects.getService();
+
+		roomResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		roomResource.setContextCompany(company);
+
+		roomResource.setContextHttpServletRequest(httpServletRequest);
+		roomResource.setContextHttpServletResponse(httpServletResponse);
+		roomResource.setContextUriInfo(uriInfo);
+		roomResource.setContextUser(user);
+		roomResource.setExpressionConvert(_expressionConvert);
+		roomResource.setFilterParserProvider(_filterParserProvider);
+		roomResource.setGroupLocalService(_groupLocalService);
+		roomResource.setResourceActionLocalService(_resourceActionLocalService);
+		roomResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		roomResource.setRoleLocalService(_roleLocalService);
+		roomResource.setSortParserProvider(_sortParserProvider);
+
+		try {
+			return method.invoke(roomResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(roomResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<RoomResource> _componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function<InvocationHandler, RoomResource>
+			_roomResourceProxyProviderFunction = _getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:228301270

--- a/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/room.properties
+++ b/modules/apps/headless/headless-dsr/headless-dsr-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/room.properties
@@ -1,0 +1,8 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+entity.class.name=com.liferay.headless.dsr.dto.v1_0.Room
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.DSR)
+osgi.jaxrs.resource=true

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/build.gradle
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation project(":apps:account:account-api")
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
+	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:fragment:fragment-api")
 	testIntegrationImplementation project(":apps:headless:headless-dsr:headless-dsr-api")
 	testIntegrationImplementation project(":apps:headless:headless-dsr:headless-dsr-client")

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/BaseRoomResourceTestCase.java
@@ -1,0 +1,950 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.http.HttpInvoker;
+import com.liferay.headless.dsr.client.pagination.Page;
+import com.liferay.headless.dsr.client.resource.v1_0.RoomResource;
+import com.liferay.headless.dsr.client.serdes.v1_0.RoomSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Stefano Motta
+ * @generated
+ */
+@Generated("")
+public abstract class BaseRoomResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_roomResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		roomResource = RoomResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Room room1 = randomRoom();
+
+		String json = objectMapper.writeValueAsString(room1);
+
+		Room room2 = RoomSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(room1, room2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		Room room = randomRoom();
+
+		String json1 = objectMapper.writeValueAsString(room);
+		String json2 = RoomSerDes.toJSON(room);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		Room room = randomRoom();
+
+		room.setFriendlyURL(regex);
+		room.setName(regex);
+
+		String json = RoomSerDes.toJSON(room);
+
+		Assert.assertFalse(json.contains(regex));
+
+		room = RoomSerDes.toDTO(json);
+
+		Assert.assertEquals(regex, room.getFriendlyURL());
+		Assert.assertEquals(regex, room.getName());
+	}
+
+	@Test
+	public void testPostRoomDuplicate() throws Exception {
+		Room randomRoom = randomRoom();
+
+		Room postRoom = testPostRoomDuplicate_addRoom(randomRoom);
+
+		assertEquals(randomRoom, postRoom);
+		assertValid(postRoom);
+	}
+
+	protected Room testPostRoomDuplicate_addRoom(Room room) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void assertContains(Room room, List<Room> rooms) {
+		boolean contains = false;
+
+		for (Room item : rooms) {
+			if (equals(room, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(rooms + " does not contain " + room, contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(Room room1, Room room2) {
+		Assert.assertTrue(
+			room1 + " does not equal " + room2, equals(room1, room2));
+	}
+
+	protected void assertEquals(List<Room> rooms1, List<Room> rooms2) {
+		Assert.assertEquals(rooms1.size(), rooms2.size());
+
+		for (int i = 0; i < rooms1.size(); i++) {
+			Room room1 = rooms1.get(i);
+			Room room2 = rooms2.get(i);
+
+			assertEquals(room1, room2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<Room> rooms1, List<Room> rooms2) {
+
+		Assert.assertEquals(rooms1.size(), rooms2.size());
+
+		for (Room room1 : rooms1) {
+			boolean contains = false;
+
+			for (Room room2 : rooms2) {
+				if (equals(room1, room2)) {
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(rooms2 + " does not contain " + room1, contains);
+		}
+	}
+
+	protected void assertValid(Room room) throws Exception {
+		boolean valid = true;
+
+		if (room.getId() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("fileEntryIds", additionalAssertFieldName)) {
+				if (room.getFileEntryIds() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("friendlyURL", additionalAssertFieldName)) {
+				if (room.getFriendlyURL() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("groupId", additionalAssertFieldName)) {
+				if (room.getGroupId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (room.getName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<Room> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<Room> page, Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<Room> rooms = page.getItems();
+
+		int size = rooms.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("id"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.headless.dsr.dto.v1_0.Room.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(Room room1, Room room2) {
+		if (room1 == room2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("fileEntryIds", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getFileEntryIds(), room2.getFileEntryIds())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("friendlyURL", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getFriendlyURL(), room2.getFriendlyURL())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("groupId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						room1.getGroupId(), room2.getGroupId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("id", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(room1.getId(), room2.getId())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("name", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(room1.getName(), room2.getName())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_roomResource instanceof EntityModelResource)) {
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_roomResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator, Room room) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("fileEntryIds")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("friendlyURL")) {
+			Object object = room.getFriendlyURL();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("groupId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("id")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("name")) {
+			Object object = room.getName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected Room randomRoom() throws Exception {
+		return new Room() {
+			{
+				friendlyURL = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				groupId = RandomTestUtil.randomLong();
+				id = RandomTestUtil.randomLong();
+				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected Room randomIrrelevantRoom() throws Exception {
+		Room randomIrrelevantRoom = randomRoom();
+
+		return randomIrrelevantRoom;
+	}
+
+	protected Room randomPatchRoom() throws Exception {
+		return randomRoom();
+	}
+
+	protected RoomResource roomResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseRoomResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.headless.dsr.resource.v1_0.RoomResource _roomResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:381240240

--- a/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/RoomResourceTest.java
+++ b/modules/apps/headless/headless-dsr/headless-dsr-test/src/testIntegration/java/com/liferay/headless/dsr/resource/v1_0/test/RoomResourceTest.java
@@ -1,0 +1,263 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.dsr.resource.v1_0.test;
+
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.headless.dsr.client.dto.v1_0.Room;
+import com.liferay.headless.dsr.client.problem.Problem;
+import com.liferay.headless.dsr.client.resource.v1_0.RoomResource;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.site.dsr.site.initializer.constants.DSRFolderConstants;
+import com.liferay.site.dsr.site.initializer.constants.DSRRoleConstants;
+import com.liferay.site.dsr.site.initializer.test.util.DSRTestUtil;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Stefano Motta
+ */
+@FeatureFlag("LPD-66359")
+@RunWith(Arquillian.class)
+public class RoomResourceTest extends BaseRoomResourceTestCase {
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		DSRTestUtil.getOrAddGroup(RoomResourceTest.class);
+
+		_accountEntry = _accountEntryLocalService.addAccountEntry(
+			StringPool.BLANK, TestPropsValues.getUserId(), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			"business", 1, ServiceContextTestUtil.getServiceContext());
+		_objectDefinition =
+			_objectDefinitionLocalService.
+				getObjectDefinitionByExternalReferenceCode(
+					"L_DSR_ROOM", TestPropsValues.getCompanyId());
+	}
+
+	@Override
+	@Test
+	public void testPostRoomDuplicate() throws Exception {
+		ObjectEntry objectEntry1 = _objectEntryLocalService.addObjectEntry(
+			0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(), 0, null,
+			HashMapBuilder.<String, Serializable>put(
+				"name",
+				StringUtil.toLowerCase("A" + RandomTestUtil.randomString())
+			).put(
+				"r_accountToDSRRooms_accountEntryId",
+				_accountEntry.getAccountEntryId()
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group1 = _groupLocalService.fetchGroup(
+			TestPropsValues.getCompanyId(),
+			_classNameLocalService.getClassNameId(
+				_objectDefinition.getClassName()),
+			objectEntry1.getObjectEntryId());
+
+		DLFolder dlFolder1 =
+			_dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				DSRFolderConstants.EXTERNAL_REFERENCE_CODE_DSR_DOCUMENTS,
+				group1.getGroupId());
+
+		DLFileEntry dlFileEntry1 = _addFileEntry(
+			dlFolder1.getFolderId(), group1);
+
+		Room room = roomResource.postRoomDuplicate(
+			objectEntry1.getObjectEntryId(),
+			new Room() {
+				{
+					setFileEntryIds(new Long[] {dlFileEntry1.getFileEntryId()});
+					setName(
+						StringUtil.toLowerCase(
+							"A" + RandomTestUtil.randomString()));
+				}
+			});
+
+		Assert.assertTrue(room.getGroupId() > 0);
+		Assert.assertTrue(room.getId() != objectEntry1.getObjectEntryId());
+
+		DLFolder dlFolder2 =
+			_dlFolderLocalService.getDLFolderByExternalReferenceCode(
+				DSRFolderConstants.EXTERNAL_REFERENCE_CODE_DSR_DOCUMENTS,
+				room.getGroupId());
+
+		Assert.assertTrue(
+			ListUtil.exists(
+				_dlFileEntryLocalService.getFileEntries(
+					room.getGroupId(), dlFolder2.getFolderId()),
+				dlFileEntry2 -> Objects.equals(
+					dlFileEntry2.getTitle(), dlFileEntry1.getTitle())));
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password, RandomTestUtil.randomString() + "@liferay.com",
+			RandomTestUtil.randomString(), LocaleUtil.getDefault(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			new long[0], ServiceContextTestUtil.getServiceContext());
+
+		objectEntry1 = _objectEntryLocalService.getObjectEntry(
+			objectEntry1.getObjectEntryId());
+
+		objectEntry1.setUserId(user.getUserId());
+
+		objectEntry1 = _objectEntryLocalService.updateObjectEntry(objectEntry1);
+
+		RoomResource roomResource = RoomResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+
+		try {
+			roomResource.postRoomDuplicate(
+				objectEntry1.getObjectEntryId(),
+				new Room() {
+					{
+						setName(
+							StringUtil.toLowerCase(
+								"A" + RandomTestUtil.randomString()));
+					}
+				});
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			String message = problemException.getMessage();
+
+			Assert.assertTrue(message, message.contains("Forbidden"));
+		}
+
+		Role role = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), DSRRoleConstants.NAME_DSR_SELLER);
+
+		_userLocalService.addRoleUsers(
+			role.getRoleId(), new long[] {user.getUserId()});
+
+		room = roomResource.postRoomDuplicate(
+			objectEntry1.getObjectEntryId(),
+			new Room() {
+				{
+					setName(
+						StringUtil.toLowerCase(
+							"A" + RandomTestUtil.randomString()));
+				}
+			});
+
+		Assert.assertTrue(room.getGroupId() > 0);
+		Assert.assertTrue(room.getId() != objectEntry1.getObjectEntryId());
+	}
+
+	private DLFileEntry _addFileEntry(long folderId, Group group)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			return _dlFileEntryLocalService.addFileEntry(
+				null, TestPropsValues.getUserId(), group.getGroupId(),
+				group.getGroupId(), folderId, RandomTestUtil.randomString(),
+				null, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), null, null,
+				DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT,
+				null, null,
+				new ByteArrayInputStream(TestDataConstants.TEST_BYTE_ARRAY),
+				TestDataConstants.TEST_BYTE_ARRAY.length, null, null, null,
+				serviceContext);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
+	private AccountEntry _accountEntry;
+
+	@Inject
+	private AccountEntryLocalService _accountEntryLocalService;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1593,8 +1593,9 @@ public class LayoutsAdminDisplayContext {
 					verticalNavItem.setLabel(name);
 				}
 			).add(
-				() -> FeatureFlagManagerUtil.isEnabled(
-					themeDisplay.getCompanyId(), "LPD-76864"),
+				() ->
+					selectLayoutPageTemplateEntryDisplayContext.
+						isShowGlobalTemplates(),
 				verticalNavItem -> {
 					verticalNavItem.setActive(
 						selectLayoutPageTemplateEntryDisplayContext.

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java
@@ -278,6 +278,12 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		_selectedTab = ParamUtil.getString(
 			_httpServletRequest, "selectedTab", "basic-templates");
 
+		if (Objects.equals(_selectedTab, "global-templates") &&
+			!isShowGlobalTemplates()) {
+
+			_selectedTab = "basic-templates";
+		}
+
 		return _selectedTab;
 	}
 
@@ -362,6 +368,16 @@ public class SelectLayoutPageTemplateEntryDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isShowGlobalTemplates() {
+		if (_isWidgetPageFeatureFlagEnabled() &&
+			(getGlobalLayoutPageTemplateEntriesCount() > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _getLayoutPageTemplateEntryAddLayoutURL(

--- a/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-admin-web/src/test/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContextTest.java
@@ -218,7 +218,7 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.anyLong(), Mockito.anyLong(),
 							Mockito.anyInt())
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
 			layoutPageTemplateEntryServiceUtilMockedStatic.when(
@@ -230,39 +230,17 @@ public class LayoutsAdminDisplayContextTest {
 							Mockito.eq(
 								LayoutPageTemplateEntryTypeConstants.BASIC))
 			).thenReturn(
-				1
+				RandomTestUtil.randomInt()
 			);
 
-			for (boolean featureFlagEnabled : new boolean[] {false, true}) {
-				try (MockedStatic<FeatureFlagManagerUtil>
-						featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
-							FeatureFlagManagerUtil.class)) {
-
-					featureFlagManagerUtilMockedStatic.when(
-						() -> FeatureFlagManagerUtil.isEnabled(
-							Mockito.anyLong(), Mockito.eq("LPD-76864"))
-					).thenReturn(
-						featureFlagEnabled
-					);
-
-					VerticalNavItemList verticalNavItemList =
-						layoutsAdminDisplayContext.getVerticalNavItemList(
-							Mockito.mock(
-								SelectLayoutPageTemplateEntryDisplayContext.
-									class));
-
-					if (featureFlagEnabled) {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 4,
-							verticalNavItemList.size());
-					}
-					else {
-						Assert.assertEquals(
-							verticalNavItemList.toString(), 2,
-							verticalNavItemList.size());
-					}
-				}
-			}
+			_testGetVerticalNavItemList(
+				2, false, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				3, false, layoutsAdminDisplayContext, true);
+			_testGetVerticalNavItemList(
+				3, true, layoutsAdminDisplayContext, false);
+			_testGetVerticalNavItemList(
+				4, true, layoutsAdminDisplayContext, true);
 		}
 	}
 
@@ -455,6 +433,42 @@ public class LayoutsAdminDisplayContextTest {
 		);
 
 		portalUtil.setPortal(_portal);
+	}
+
+	private void _testGetVerticalNavItemList(
+		int expectedVerticalNavItemsCount, boolean featureFlagEnabled,
+		LayoutsAdminDisplayContext layoutsAdminDisplayContext,
+		boolean showGlobalTemplates) {
+
+		SelectLayoutPageTemplateEntryDisplayContext
+			selectLayoutPageTemplateEntryDisplayContext = Mockito.mock(
+				SelectLayoutPageTemplateEntryDisplayContext.class);
+
+		Mockito.when(
+			selectLayoutPageTemplateEntryDisplayContext.isShowGlobalTemplates()
+		).thenReturn(
+			showGlobalTemplates
+		);
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			VerticalNavItemList verticalNavItemList =
+				layoutsAdminDisplayContext.getVerticalNavItemList(
+					selectLayoutPageTemplateEntryDisplayContext);
+
+			Assert.assertEquals(
+				verticalNavItemList.toString(), expectedVerticalNavItemsCount,
+				verticalNavItemList.size());
+		}
 	}
 
 	private static final Group _group = Mockito.mock(Group.class);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContext.java
@@ -8,6 +8,9 @@ package com.liferay.layout.page.template.admin.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
@@ -121,6 +124,25 @@ public class LayoutPageTemplatesAdminDisplayContext {
 			_liferayPortletRequest, "tabs1", "master-layouts");
 
 		return _tabs1;
+	}
+
+	public boolean isShowPageTemplates() {
+		int layoutPageTemplateEntriesCountByType =
+			LayoutPageTemplateEntryServiceUtil.
+				getLayoutPageTemplateEntriesCountByType(
+					_themeDisplay.getScopeGroupId(),
+					LayoutPageTemplateConstants.
+						PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT,
+					LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE);
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				_themeDisplay.getCompanyId(), "LPD-76864") ||
+			(layoutPageTemplateEntriesCountByType > 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,7 +18,7 @@ Group scopeGroup = themeDisplay.getScopeGroup();
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "master-layouts") %>'>
 		<liferay-util:include page="/view_master_layouts.jsp" servletContext="<%= application %>" />
 	</c:when>
-	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() %>'>
+	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && scopeGroup.isCompany() && layoutPageTemplatesAdminDisplayContext.isShowPageTemplates() %>'>
 		<liferay-util:include page="/view_layout_prototypes.jsp" servletContext="<%= application %>" />
 	</c:when>
 	<c:when test='<%= Objects.equals(layoutPageTemplatesAdminDisplayContext.getTabs1(), "page-templates") && !scopeGroup.isCompany() %>'>

--- a/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/test/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplatesAdminDisplayContextTest.java
@@ -6,6 +6,10 @@
 package com.liferay.layout.page.template.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -13,6 +17,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletURL;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -139,6 +144,13 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 			navigationItems.toString(), 0, navigationItems.size());
 	}
 
+	@Test
+	public void testIsShowPageTemplates() {
+		_testIsShowPageTemplates(false, 0, false);
+		_testIsShowPageTemplates(false, RandomTestUtil.randomInt(), true);
+		_testIsShowPageTemplates(true, RandomTestUtil.randomInt(), true);
+	}
+
 	private void _setUpGroup(boolean company) {
 		Mockito.when(
 			_group.isCompany()
@@ -230,6 +242,51 @@ public class LayoutPageTemplatesAdminDisplayContextTest {
 		).thenReturn(
 			_group
 		);
+	}
+
+	private void _testIsShowPageTemplates(
+		boolean featureFlagEnabled, int layoutPageTemplateEntriesCountByType,
+		boolean showPageTemplates) {
+
+		try (MockedStatic<FeatureFlagManagerUtil>
+				featureFlagManagerUtilMockedStatic = Mockito.mockStatic(
+					FeatureFlagManagerUtil.class);
+			MockedStatic<LayoutPageTemplateEntryServiceUtil>
+				layoutPageTemplateEntryServiceUtilMockedStatic =
+					Mockito.mockStatic(
+						LayoutPageTemplateEntryServiceUtil.class)) {
+
+			featureFlagManagerUtilMockedStatic.when(
+				() -> FeatureFlagManagerUtil.isEnabled(
+					Mockito.anyLong(), Mockito.eq("LPD-76864"))
+			).thenReturn(
+				featureFlagEnabled
+			);
+
+			layoutPageTemplateEntryServiceUtilMockedStatic.when(
+				() ->
+					LayoutPageTemplateEntryServiceUtil.
+						getLayoutPageTemplateEntriesCountByType(
+							Mockito.anyLong(),
+							Mockito.eq(
+								LayoutPageTemplateConstants.
+									PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT),
+							Mockito.eq(
+								LayoutPageTemplateEntryTypeConstants.
+									WIDGET_PAGE))
+			).thenReturn(
+				layoutPageTemplateEntriesCountByType
+			);
+
+			LayoutPageTemplatesAdminDisplayContext
+				layoutPageTemplatesAdminDisplayContext =
+					new LayoutPageTemplatesAdminDisplayContext(
+						_liferayPortletRequest, _liferayPortletResponse);
+
+			Assert.assertEquals(
+				showPageTemplates,
+				layoutPageTemplatesAdminDisplayContext.isShowPageTemplates());
+		}
 	}
 
 	private final Group _group = Mockito.mock(Group.class);

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,12 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
-                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
-                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
-                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
-                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
-                    \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -174,6 +174,13 @@ paths:
                             description:
                                 Input map matching the tool's `inputSchema`.
                             type: object
+                description:
+                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for
+                    this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a
+                    `body` property, it holds the request payload and must stay nested under `body` here rather than be
+                    flattened into this map; pass any path or query parameters as siblings of `body`. For example, a
+                    tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...},
+                    \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
+++ b/modules/apps/mcp/mcp-server-rest-impl/rest-openapi.yaml
@@ -175,7 +175,7 @@ paths:
                                 Input map matching the tool's `inputSchema`.
                             type: object
                 description:
-                    "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
+                    "The complete input map for the target tool, matching the `inputSchema` that `getToolSetToolSetNameTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`."
                 required: false
             responses:
                 200:

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -92,7 +92,8 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
-		operationId = "postToolSetToolSetNameToolInvoke"
+		operationId = "postToolSetToolSetNameToolInvoke",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -578,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:1426896571
+// LIFERAY-REST-BUILDER-HASH:-1744722583

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/resource/v1_0/BaseToolResourceImpl.java
@@ -93,7 +93,7 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Invokes a tool. ALWAYS call `getToolSetToolSetNameTool` first to fetch the tool's `inputSchema`, then build the request `body` to match it exactly. Skipping `getToolSetToolSetNameTool` leads to malformed input and avoidable failures. Returns the tool's response body unchanged.",
 		operationId = "postToolSetToolSetNameToolInvoke",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Object.class)), description = "The complete input map for the target tool, matching the `inputSchema` that `getToolSetToolSetNameTool` returns for this `toolName`. Use that schema's properties exactly as named: when the `inputSchema` declares a `body` property, it holds the request payload and must stay nested under `body` here rather than be flattened into this map; pass any path or query parameters as siblings of `body`. For example, a tool whose `inputSchema` has `body` and `itemId` properties is invoked with `{\"body\": {...}, \"itemId\": \"123\"}`.")
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -579,4 +579,4 @@ public abstract class BaseToolResourceImpl implements ToolResource {
 		LogFactoryUtil.getLog(BaseToolResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1744722583
+// LIFERAY-REST-BUILDER-HASH:-1516858284

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -894,18 +894,19 @@ public class OpenAPIUtil {
 					"into the input map."));
 		}
 
-		Object bodyValue = inputJSONObject.get("body");
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 
 		String body = StringPool.BLANK;
 
-		if (bodyValue instanceof JSONObject) {
-			body = bodyValue.toString();
+		Object bodyObject = inputJSONObject.get("body");
+
+		if (bodyObject instanceof JSONObject) {
+			body = bodyObject.toString();
 		}
-		else if (bodyValue != null) {
-			body = String.valueOf(bodyValue);
+		else if (bodyObject != null) {
+			body = String.valueOf(bodyObject);
 		}
 
-		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
 		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -7,12 +7,14 @@ package com.liferay.mcp.server.rest.internal.util;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -110,14 +112,17 @@ public class OpenAPIUtil {
 					continue;
 				}
 
-				ToolSummary toolSummary = new ToolSummary();
-
-				toolSummary.setDescription(
-					() -> _getDescription(method, operationJSONObject, path));
-				toolSummary.setName(
-					() -> operationJSONObject.getString("operationId"));
-
-				toolSummaries.add(toolSummary);
+				toolSummaries.add(
+					new ToolSummary() {
+						{
+							setDescription(
+								() -> _getDescription(
+									method, operationJSONObject, path));
+							setName(
+								() -> operationJSONObject.getString(
+									"operationId"));
+						}
+					});
 			}
 		}
 
@@ -126,76 +131,71 @@ public class OpenAPIUtil {
 
 	private static void _addMultipartParts(
 		JSONObject operationJSONObject, Map<String, Object> properties,
-		List<Object> required, JSONObject openAPIJSONObject) {
+		List<String> requiredPropertyNames, JSONObject openAPIJSONObject) {
 
-		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
-			openAPIJSONObject, _getBodySchemaJSONObject(operationJSONObject),
-			new HashSet<>());
+		Map<String, Object> bodySchemaMap =
+			(Map<String, Object>)_getSchemaObject(
+				openAPIJSONObject,
+				_getBodySchemaJSONObject(operationJSONObject), new HashSet<>());
 
-		Map<String, Object> partProperties =
+		Map<String, Object> bodyProperties =
 			(Map<String, Object>)bodySchemaMap.get("properties");
 
-		if (partProperties == null) {
+		if (bodyProperties == null) {
 			return;
 		}
 
-		for (Map.Entry<String, Object> entry : partProperties.entrySet()) {
-			String partName = entry.getKey();
-			Map<String, Object> partSchema =
+		for (Map.Entry<String, Object> entry : bodyProperties.entrySet()) {
+			Map<String, Object> propertySchemaMap =
 				(Map<String, Object>)entry.getValue();
 
-			if (_isBinaryPartSchema(partSchema)) {
-				properties.put(partName, _buildBinaryPartEnvelope(partSchema));
-			}
-			else {
-				properties.put(partName, partSchema);
-			}
+			properties.put(
+				entry.getKey(),
+				_isBinary(propertySchemaMap) ?
+					_getBinarySchemaMap(propertySchemaMap) : propertySchemaMap);
 		}
 
-		List<Object> bodySchemaRequired = (List<Object>)bodySchemaMap.get(
-			"required");
-
-		if (bodySchemaRequired != null) {
-			required.addAll(bodySchemaRequired);
-		}
+		requiredPropertyNames.addAll(
+			TransformUtil.transform(
+				(List<Object>)bodySchemaMap.get("required"), String::valueOf));
 	}
 
 	private static void _addParameter(
-		JSONObject parameterJSONObject, Set<String> processedParameterNames,
-		Map<String, Object> properties, List<Object> required) {
+		JSONObject parameterJSONObject, Map<String, Object> properties,
+		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
 
 		String name = parameterJSONObject.getString("name");
 
 		if (_vulcanFieldSelectionParameterNames.contains(name) ||
-			!processedParameterNames.add(name)) {
+			!visitedParameterNames.add(name)) {
 
 			return;
 		}
 
-		Map<String, Object> property = new LinkedHashMap<>();
+		Map<String, Object> parameterProperties = new LinkedHashMap<>();
 
 		JSONObject parameterSchemaJSONObject =
 			parameterJSONObject.getJSONObject("schema");
 
 		for (String key : parameterSchemaJSONObject.keySet()) {
-			property.put(key, parameterSchemaJSONObject.get(key));
+			parameterProperties.put(key, parameterSchemaJSONObject.get(key));
 		}
 
 		if (parameterJSONObject.has("description")) {
-			property.put(
+			parameterProperties.put(
 				"description", parameterJSONObject.getString("description"));
 		}
 
-		properties.put(name, property);
+		properties.put(name, parameterProperties);
 
 		if (Objects.equals(parameterJSONObject.getString("in"), "path")) {
-			required.add(name);
+			requiredPropertyNames.add(name);
 		}
 	}
 
 	private static void _addParameters(
-		JSONArray parametersJSONArray, Set<String> processedParameterNames,
-		Map<String, Object> properties, List<Object> required) {
+		JSONArray parametersJSONArray, Map<String, Object> properties,
+		List<String> requiredPropertyNames, Set<String> visitedParameterNames) {
 
 		if (parametersJSONArray == null) {
 			return;
@@ -203,13 +203,13 @@ public class OpenAPIUtil {
 
 		for (int i = 0; i < parametersJSONArray.length(); i++) {
 			_addParameter(
-				parametersJSONArray.getJSONObject(i), processedParameterNames,
-				properties, required);
+				parametersJSONArray.getJSONObject(i), properties,
+				requiredPropertyNames, visitedParameterNames);
 		}
 	}
 
 	private static void _appendQueryParameter(
-		String name, StringBundler queryStringSB, Object value) {
+		String name, StringBundler sb, Object value) {
 
 		if (value == null) {
 			return;
@@ -221,30 +221,106 @@ public class OpenAPIUtil {
 			return;
 		}
 
-		if (queryStringSB.length() > 0) {
-			queryStringSB.append(CharPool.AMPERSAND);
+		if (sb.length() > 0) {
+			sb.append(CharPool.AMPERSAND);
 		}
 
-		queryStringSB.append(URLCodec.encodeURL(name));
-		queryStringSB.append(CharPool.EQUAL);
-		queryStringSB.append(URLCodec.encodeURL(stringValue));
+		sb.append(URLCodec.encodeURL(name));
+		sb.append(CharPool.EQUAL);
+		sb.append(URLCodec.encodeURL(stringValue));
 	}
 
-	private static Map<String, Object> _buildBinaryPartEnvelope(
-		Map<String, Object> partSchema) {
+	private static Map<String, Object> _getAllOfSchemaMap(
+		JSONObject jsonObject, JSONObject openAPIJSONObject,
+		Set<String> visitedRefs) {
 
-		String description = (String)partSchema.get("description");
+		Map<String, Object> allOfSchemaMap = new LinkedHashMap<>();
+		Map<String, Object> properties = new LinkedHashMap<>();
+		Set<String> requiredPropertyNames = new HashSet<>();
 
-		String envelopeDescription =
-			"Provide as an object with `data` (base64-encoded bytes), and " +
-				"optional `filename` and `contentType`.";
+		for (String key : jsonObject.keySet()) {
+			if (key.equals("allOf") || _excludedSchemaKeys.contains(key) ||
+				key.startsWith("x-")) {
 
-		if (Validator.isNotNull(description)) {
-			envelopeDescription = description + ". " + envelopeDescription;
+				continue;
+			}
+
+			allOfSchemaMap.put(
+				key,
+				_getSchemaObject(
+					openAPIJSONObject, jsonObject.get(key), visitedRefs));
 		}
 
+		JSONArray allOfJSONArray = jsonObject.getJSONArray("allOf");
+
+		for (int i = 0; i < allOfJSONArray.length(); i++) {
+			Object schemaObject = _getSchemaObject(
+				openAPIJSONObject, allOfJSONArray.getJSONObject(i),
+				visitedRefs);
+
+			if (!(schemaObject instanceof Map)) {
+				continue;
+			}
+
+			Map<String, Object> schemaMap = (Map<String, Object>)schemaObject;
+
+			Map<String, Object> schemaProperties =
+				(Map<String, Object>)schemaMap.get("properties");
+
+			if (schemaProperties != null) {
+				properties.putAll(schemaProperties);
+			}
+
+			requiredPropertyNames.addAll(
+				TransformUtil.transform(
+					(List<Object>)schemaMap.get("required"), String::valueOf));
+
+			for (Map.Entry<String, Object> entry : schemaMap.entrySet()) {
+				String key = entry.getKey();
+
+				if (allOfSchemaMap.containsKey(key) ||
+					key.equals("properties") || key.equals("required")) {
+
+					continue;
+				}
+
+				allOfSchemaMap.put(key, entry.getValue());
+			}
+		}
+
+		if (!properties.isEmpty()) {
+			allOfSchemaMap.put("properties", properties);
+		}
+
+		if (!requiredPropertyNames.isEmpty()) {
+			allOfSchemaMap.put("required", List.copyOf(requiredPropertyNames));
+		}
+
+		if (!allOfSchemaMap.containsKey("type")) {
+			allOfSchemaMap.put("type", "object");
+		}
+
+		return allOfSchemaMap;
+	}
+
+	private static Map<String, Object> _getBinarySchemaMap(
+		Map<String, Object> schemaMap) {
+
 		return HashMapBuilder.<String, Object>put(
-			"description", envelopeDescription
+			"description",
+			() -> {
+				String extraDescription =
+					"Provide as an object with `data` (base64-encoded bytes)" +
+						", and optional `filename` and `contentType`.";
+
+				String description = (String)schemaMap.get("description");
+
+				if (Validator.isNotNull(description)) {
+					return description + ". " + extraDescription;
+				}
+
+				return extraDescription;
+			}
 		).put(
 			"properties",
 			HashMapBuilder.<String, Object>put(
@@ -273,136 +349,6 @@ public class OpenAPIUtil {
 			"required", Arrays.asList("data")
 		).put(
 			"type", "object"
-		).build();
-	}
-
-	private static Map<String, Object> _collectMatchingParameters(
-		JSONObject inputJSONObject, Operation operation, String filterIn) {
-
-		Map<String, Object> matchingParameters = new LinkedHashMap<>();
-
-		for (JSONArray parametersJSONArray :
-				Arrays.asList(
-					operation._operationJSONObject.getJSONArray("parameters"),
-					operation._pathParametersJSONArray)) {
-
-			if (parametersJSONArray == null) {
-				continue;
-			}
-
-			for (int i = 0; i < parametersJSONArray.length(); i++) {
-				JSONObject parameterJSONObject =
-					parametersJSONArray.getJSONObject(i);
-
-				if (!Objects.equals(
-						parameterJSONObject.getString("in"), filterIn)) {
-
-					continue;
-				}
-
-				String name = parameterJSONObject.getString("name");
-
-				if (matchingParameters.containsKey(name) ||
-					!inputJSONObject.has(name)) {
-
-					continue;
-				}
-
-				Object value = inputJSONObject.get(name);
-
-				if (value == null) {
-					continue;
-				}
-
-				matchingParameters.put(name, value);
-			}
-		}
-
-		return matchingParameters;
-	}
-
-	private static Map<String, Object> _expandDiscriminator(
-		JSONObject baseJSONObject, String baseRef, JSONObject openAPIJSONObject,
-		Set<String> visitedRefs) {
-
-		List<Object> oneOfList = new ArrayList<>();
-
-		JSONObject componentsJSONObject = openAPIJSONObject.getJSONObject(
-			"components");
-
-		JSONObject schemasJSONObject = (componentsJSONObject != null) ?
-			componentsJSONObject.getJSONObject("schemas") : null;
-
-		if (schemasJSONObject != null) {
-			for (String schemaName : schemasJSONObject.keySet()) {
-				JSONObject candidateJSONObject =
-					schemasJSONObject.getJSONObject(schemaName);
-
-				JSONArray allOfJSONArray = candidateJSONObject.getJSONArray(
-					"allOf");
-
-				if (allOfJSONArray == null) {
-					continue;
-				}
-
-				boolean extendsBase = false;
-
-				for (int i = 0; i < allOfJSONArray.length(); i++) {
-					JSONObject memberJSONObject = allOfJSONArray.getJSONObject(
-						i);
-
-					if (memberJSONObject == null) {
-						continue;
-					}
-
-					if (baseRef.equals(memberJSONObject.getString("$ref"))) {
-						extendsBase = true;
-
-						break;
-					}
-				}
-
-				if (!extendsBase) {
-					continue;
-				}
-
-				String subtypeRef = "#/components/schemas/" + schemaName;
-
-				if (visitedRefs.contains(subtypeRef)) {
-					continue;
-				}
-
-				Set<String> subtypeVisitedRefs = new HashSet<>(visitedRefs);
-
-				subtypeVisitedRefs.add(subtypeRef);
-
-				oneOfList.add(
-					_resolveRefs(
-						openAPIJSONObject, candidateJSONObject,
-						subtypeVisitedRefs));
-			}
-		}
-
-		if (oneOfList.isEmpty()) {
-			Map<String, Object> resolvedMap = new LinkedHashMap<>();
-
-			for (String key : baseJSONObject.keySet()) {
-				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
-					continue;
-				}
-
-				resolvedMap.put(
-					key,
-					_resolveRefs(
-						openAPIJSONObject, baseJSONObject.get(key),
-						visitedRefs));
-			}
-
-			return resolvedMap;
-		}
-
-		return LinkedHashMapBuilder.<String, Object>put(
-			"oneOf", oneOfList
 		).build();
 	}
 
@@ -474,41 +420,41 @@ public class OpenAPIUtil {
 	private static Http.FilePart _getFilePart(String name, Object value) {
 		String fileName = name;
 		String contentType = ContentTypes.APPLICATION_OCTET_STREAM;
-		String base64Data;
+		String data;
 
-		JSONObject envelopeJSONObject = null;
+		JSONObject jsonObject = null;
 
 		if (value instanceof JSONObject) {
-			envelopeJSONObject = (JSONObject)value;
+			jsonObject = (JSONObject)value;
 		}
 		else if (value instanceof Map) {
-			envelopeJSONObject = JSONFactoryUtil.createJSONObject(
+			jsonObject = JSONFactoryUtil.createJSONObject(
 				(Map<String, ?>)value);
 		}
 
-		if (envelopeJSONObject != null) {
-			if (envelopeJSONObject.has("filename")) {
-				fileName = envelopeJSONObject.getString("filename");
+		if (jsonObject != null) {
+			if (jsonObject.has("filename")) {
+				fileName = jsonObject.getString("filename");
 			}
 
-			if (envelopeJSONObject.has("contentType")) {
-				contentType = envelopeJSONObject.getString("contentType");
+			if (jsonObject.has("contentType")) {
+				contentType = jsonObject.getString("contentType");
 			}
 
-			base64Data = envelopeJSONObject.getString("data");
+			data = jsonObject.getString("data");
 		}
 		else {
-			base64Data = String.valueOf(value);
+			data = String.valueOf(value);
 		}
 
-		if (Validator.isNull(base64Data)) {
+		if (Validator.isNull(data)) {
 			throw new IllegalArgumentException(
 				"Multipart part \"" + name + "\" has no \"data\"");
 		}
 
 		Base64.Decoder decoder = Base64.getDecoder();
 
-		byte[] bytes = decoder.decode(base64Data);
+		byte[] bytes = decoder.decode(data);
 
 		return new Http.FilePart(
 			name, fileName, bytes, contentType, StringPool.UTF8);
@@ -519,12 +465,12 @@ public class OpenAPIUtil {
 		JSONArray pathParametersJSONArray) {
 
 		Map<String, Object> properties = new LinkedHashMap<>();
-		List<Object> required = new ArrayList<>();
+		List<String> requiredPropertyNames = new ArrayList<>();
 
 		if (operationJSONObject.has("requestBody")) {
 			if (_isMultipartRequest(operationJSONObject)) {
 				_addMultipartParts(
-					operationJSONObject, properties, required,
+					operationJSONObject, properties, requiredPropertyNames,
 					openAPIJSONObject);
 			}
 			else {
@@ -534,13 +480,13 @@ public class OpenAPIUtil {
 				Map<String, Object> bodySchemaMap = null;
 
 				if (requestBodyJSONObject.getJSONObject("content") != null) {
-					Object resolvedObject = _resolveRefs(
+					Object bodySchemaObject = _getSchemaObject(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
 						new HashSet<>());
 
-					if (resolvedObject instanceof Map) {
-						bodySchemaMap = (Map<String, Object>)resolvedObject;
+					if (bodySchemaObject instanceof Map) {
+						bodySchemaMap = (Map<String, Object>)bodySchemaObject;
 					}
 				}
 
@@ -554,46 +500,125 @@ public class OpenAPIUtil {
 					"description");
 
 				if (Validator.isNotNull(requestBodyDescription)) {
-					Object bodySchemaDescription = bodySchemaMap.get(
-						"description");
+					Object bodyDescription = bodySchemaMap.get("description");
 
-					if (Validator.isNull(bodySchemaDescription)) {
+					if (Validator.isNull(bodyDescription)) {
 						bodySchemaMap.put(
 							"description", requestBodyDescription);
 					}
 					else if (!Objects.equals(
-								bodySchemaDescription,
-								requestBodyDescription)) {
+								bodyDescription, requestBodyDescription)) {
 
 						bodySchemaMap.put(
 							"description",
 							StringBundler.concat(
 								requestBodyDescription, StringPool.SPACE,
-								bodySchemaDescription));
+								bodyDescription));
 					}
 				}
 
 				properties.put("body", bodySchemaMap);
 
-				required.add("body");
+				requiredPropertyNames.add("body");
 			}
 		}
 
-		Set<String> processedParameterNames = new HashSet<>();
+		Set<String> visitedParameterNames = new HashSet<>();
 
 		_addParameters(
-			operationJSONObject.getJSONArray("parameters"),
-			processedParameterNames, properties, required);
+			operationJSONObject.getJSONArray("parameters"), properties,
+			requiredPropertyNames, visitedParameterNames);
 		_addParameters(
-			pathParametersJSONArray, processedParameterNames, properties,
-			required);
+			pathParametersJSONArray, properties, requiredPropertyNames,
+			visitedParameterNames);
 
 		return LinkedHashMapBuilder.<String, Object>put(
 			"properties", properties
 		).put(
-			"required", required
+			"required", requiredPropertyNames
 		).put(
 			"type", "object"
+		).build();
+	}
+
+	private static Map<String, Object> _getOneOfSchemaMap(
+		JSONObject jsonObject, JSONObject openAPIJSONObject, String ref,
+		Set<String> visitedRefs) {
+
+		List<Object> oneOfSchemaObjects = new ArrayList<>();
+
+		JSONObject schemasJSONObject = JSONUtil.getValueAsJSONObject(
+			openAPIJSONObject, "JSONObject/components", "JSONObject/schemas");
+
+		if (schemasJSONObject != null) {
+			for (String schemaName : schemasJSONObject.keySet()) {
+				JSONObject schemaJSONObject = schemasJSONObject.getJSONObject(
+					schemaName);
+
+				JSONArray allOfJSONArray = schemaJSONObject.getJSONArray(
+					"allOf");
+
+				if (allOfJSONArray == null) {
+					continue;
+				}
+
+				boolean extendsBase = false;
+
+				for (int i = 0; i < allOfJSONArray.length(); i++) {
+					JSONObject memberJSONObject = allOfJSONArray.getJSONObject(
+						i);
+
+					if (memberJSONObject == null) {
+						continue;
+					}
+
+					if (ref.equals(memberJSONObject.getString("$ref"))) {
+						extendsBase = true;
+
+						break;
+					}
+				}
+
+				if (!extendsBase) {
+					continue;
+				}
+
+				String subtypeRef = "#/components/schemas/" + schemaName;
+
+				if (visitedRefs.contains(subtypeRef)) {
+					continue;
+				}
+
+				Set<String> subtypeVisitedRefs = new HashSet<>(visitedRefs);
+
+				subtypeVisitedRefs.add(subtypeRef);
+
+				oneOfSchemaObjects.add(
+					_getSchemaObject(
+						openAPIJSONObject, schemaJSONObject,
+						subtypeVisitedRefs));
+			}
+		}
+
+		if (oneOfSchemaObjects.isEmpty()) {
+			Map<String, Object> schemaMap = new LinkedHashMap<>();
+
+			for (String key : jsonObject.keySet()) {
+				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
+					continue;
+				}
+
+				schemaMap.put(
+					key,
+					_getSchemaObject(
+						openAPIJSONObject, jsonObject.get(key), visitedRefs));
+			}
+
+			return schemaMap;
+		}
+
+		return LinkedHashMapBuilder.<String, Object>put(
+			"oneOf", oneOfSchemaObjects
 		).build();
 	}
 
@@ -608,11 +633,11 @@ public class OpenAPIUtil {
 		}
 
 		for (String path : pathsJSONObject.keySet()) {
-			JSONObject pathItemJSONObject = pathsJSONObject.getJSONObject(path);
+			JSONObject pathJSONObject = pathsJSONObject.getJSONObject(path);
 
 			for (String method : _METHODS) {
-				JSONObject operationJSONObject =
-					pathItemJSONObject.getJSONObject(method);
+				JSONObject operationJSONObject = pathJSONObject.getJSONObject(
+					method);
 
 				if ((operationJSONObject == null) ||
 					!toolName.equals(
@@ -623,12 +648,55 @@ public class OpenAPIUtil {
 
 				return new Operation(
 					method, operationJSONObject, path,
-					pathItemJSONObject.getJSONArray("parameters"));
+					pathJSONObject.getJSONArray("parameters"));
 			}
 		}
 
 		throw new IllegalArgumentException(
 			"OpenAPI document has no tool with name \"" + toolName + "\"");
+	}
+
+	private static Map<String, Object> _getParameterSchemaObjects(
+		String in, JSONObject inputJSONObject, Operation operation) {
+
+		Map<String, Object> parameterSchemaObjects = new LinkedHashMap<>();
+
+		for (JSONArray parametersJSONArray :
+				Arrays.asList(
+					operation._operationJSONObject.getJSONArray("parameters"),
+					operation._pathParametersJSONArray)) {
+
+			if (parametersJSONArray == null) {
+				continue;
+			}
+
+			for (int i = 0; i < parametersJSONArray.length(); i++) {
+				JSONObject parameterJSONObject =
+					parametersJSONArray.getJSONObject(i);
+
+				if (!Objects.equals(parameterJSONObject.getString("in"), in)) {
+					continue;
+				}
+
+				String name = parameterJSONObject.getString("name");
+
+				if (parameterSchemaObjects.containsKey(name) ||
+					!inputJSONObject.has(name)) {
+
+					continue;
+				}
+
+				Object value = inputJSONObject.get(name);
+
+				if (value == null) {
+					continue;
+				}
+
+				parameterSchemaObjects.put(name, value);
+			}
+		}
+
+		return parameterSchemaObjects;
 	}
 
 	private static String _getPart(Object value) {
@@ -654,12 +722,14 @@ public class OpenAPIUtil {
 	private static String _getPath(
 		JSONObject inputJSONObject, Operation operation) {
 
-		Map<String, Object> pathParameters = _collectMatchingParameters(
-			inputJSONObject, operation, "path");
+		Map<String, Object> parameterSchemaObjects = _getParameterSchemaObjects(
+			"path", inputJSONObject, operation);
 
 		String path = operation._path;
 
-		for (Map.Entry<String, Object> entry : pathParameters.entrySet()) {
+		for (Map.Entry<String, Object> entry :
+				parameterSchemaObjects.entrySet()) {
+
 			path = StringUtil.replace(
 				path, "{" + entry.getKey() + "}",
 				URLCodec.encodeURL(String.valueOf(entry.getValue())));
@@ -673,10 +743,12 @@ public class OpenAPIUtil {
 
 		StringBundler sb = new StringBundler();
 
-		Map<String, Object> queryParameters = _collectMatchingParameters(
-			inputJSONObject, operation, "query");
+		Map<String, Object> parameterSchemaObjects = _getParameterSchemaObjects(
+			"query", inputJSONObject, operation);
 
-		for (Map.Entry<String, Object> entry : queryParameters.entrySet()) {
+		for (Map.Entry<String, Object> entry :
+				parameterSchemaObjects.entrySet()) {
+
 			String name = entry.getKey();
 
 			if (_vulcanFieldSelectionParameterNames.contains(name)) {
@@ -693,128 +765,19 @@ public class OpenAPIUtil {
 		return sb.toString();
 	}
 
-	private static boolean _isBinaryPartSchema(Map<String, Object> partSchema) {
-		if (partSchema == null) {
-			return false;
-		}
-
-		return Objects.equals(partSchema.get("format"), "binary");
-	}
-
-	private static boolean _isMultipartRequest(JSONObject operationJSONObject) {
-		JSONObject requestBodyJSONObject = operationJSONObject.getJSONObject(
-			"requestBody");
-
-		if (requestBodyJSONObject == null) {
-			return false;
-		}
-
-		JSONObject contentJSONObject = requestBodyJSONObject.getJSONObject(
-			"content");
-
-		if ((contentJSONObject == null) ||
-			contentJSONObject.has("application/json")) {
-
-			return false;
-		}
-
-		return contentJSONObject.has("multipart/form-data");
-	}
-
-	private static Map<String, Object> _mergeAllOf(
-		JSONObject jsonObject, JSONObject openAPIJSONObject,
-		Set<String> visitedRefs) {
-
-		Map<String, Object> mergedMap = new LinkedHashMap<>();
-		Map<String, Object> mergedProperties = new LinkedHashMap<>();
-		List<Object> mergedRequired = new ArrayList<>();
-		Set<String> mergedRequiredSet = new HashSet<>();
-
-		for (String key : jsonObject.keySet()) {
-			if (key.equals("allOf") || _excludedSchemaKeys.contains(key) ||
-				key.startsWith("x-")) {
-
-				continue;
-			}
-
-			mergedMap.put(
-				key,
-				_resolveRefs(
-					openAPIJSONObject, jsonObject.get(key), visitedRefs));
-		}
-
-		JSONArray allOfJSONArray = jsonObject.getJSONArray("allOf");
-
-		for (int i = 0; i < allOfJSONArray.length(); i++) {
-			Object resolvedObject = _resolveRefs(
-				openAPIJSONObject, allOfJSONArray.getJSONObject(i),
-				visitedRefs);
-
-			if (!(resolvedObject instanceof Map)) {
-				continue;
-			}
-
-			Map<String, Object> memberMap = (Map<String, Object>)resolvedObject;
-
-			Map<String, Object> memberProperties =
-				(Map<String, Object>)memberMap.get("properties");
-
-			if (memberProperties != null) {
-				mergedProperties.putAll(memberProperties);
-			}
-
-			List<Object> memberRequired = (List<Object>)memberMap.get(
-				"required");
-
-			if (memberRequired != null) {
-				for (Object name : memberRequired) {
-					if (mergedRequiredSet.add(String.valueOf(name))) {
-						mergedRequired.add(name);
-					}
-				}
-			}
-
-			for (Map.Entry<String, Object> entry : memberMap.entrySet()) {
-				String key = entry.getKey();
-
-				if (mergedMap.containsKey(key) || key.equals("properties") ||
-					key.equals("required")) {
-
-					continue;
-				}
-
-				mergedMap.put(key, entry.getValue());
-			}
-		}
-
-		if (!mergedProperties.isEmpty()) {
-			mergedMap.put("properties", mergedProperties);
-		}
-
-		if (!mergedRequired.isEmpty()) {
-			mergedMap.put("required", mergedRequired);
-		}
-
-		if (!mergedMap.containsKey("type")) {
-			mergedMap.put("type", "object");
-		}
-
-		return mergedMap;
-	}
-
-	private static JSONObject _resolveRef(
+	private static JSONObject _getRefJSONObject(
 		String ref, JSONObject openAPIJSONObject) {
 
-		JSONObject currentJSONObject = openAPIJSONObject;
+		JSONObject refJSONObject = openAPIJSONObject;
 
 		for (String part : StringUtil.split(ref.substring(2), CharPool.SLASH)) {
-			currentJSONObject = currentJSONObject.getJSONObject(part);
+			refJSONObject = refJSONObject.getJSONObject(part);
 		}
 
-		return currentJSONObject;
+		return refJSONObject;
 	}
 
-	private static Object _resolveRefs(
+	private static Object _getSchemaObject(
 		JSONObject openAPIJSONObject, Object value, Set<String> visitedRefs) {
 
 		if (value instanceof JSONObject) {
@@ -829,59 +792,74 @@ public class OpenAPIUtil {
 					).build();
 				}
 
-				JSONObject referencedJSONObject = _resolveRef(
+				JSONObject refJSONObject = _getRefJSONObject(
 					ref, openAPIJSONObject);
 
 				Set<String> currentVisitedRefs = new HashSet<>(visitedRefs);
 
 				currentVisitedRefs.add(ref);
 
-				if (referencedJSONObject.has("discriminator")) {
-					return _expandDiscriminator(
-						referencedJSONObject, ref, openAPIJSONObject,
+				if (refJSONObject.has("discriminator")) {
+					return _getOneOfSchemaMap(
+						refJSONObject, openAPIJSONObject, ref,
 						currentVisitedRefs);
 				}
 
-				return _resolveRefs(
-					openAPIJSONObject, referencedJSONObject,
-					currentVisitedRefs);
+				return _getSchemaObject(
+					openAPIJSONObject, refJSONObject, currentVisitedRefs);
 			}
 
 			if (jsonObject.has("allOf")) {
-				return _mergeAllOf(jsonObject, openAPIJSONObject, visitedRefs);
+				return _getAllOfSchemaMap(
+					jsonObject, openAPIJSONObject, visitedRefs);
 			}
 
-			Map<String, Object> resolvedMap = new LinkedHashMap<>();
+			Map<String, Object> schemaMap = new LinkedHashMap<>();
 
 			for (String key : jsonObject.keySet()) {
 				if (_excludedSchemaKeys.contains(key) || key.startsWith("x-")) {
 					continue;
 				}
 
-				resolvedMap.put(
+				schemaMap.put(
 					key,
-					_resolveRefs(
+					_getSchemaObject(
 						openAPIJSONObject, jsonObject.get(key), visitedRefs));
 			}
 
-			return resolvedMap;
+			return schemaMap;
 		}
 
-		if (value instanceof JSONArray) {
-			JSONArray jsonArray = (JSONArray)value;
-
-			List<Object> resolvedList = new ArrayList<>();
-
-			for (int i = 0; i < jsonArray.length(); i++) {
-				resolvedList.add(
-					_resolveRefs(
-						openAPIJSONObject, jsonArray.get(i), visitedRefs));
-			}
-
-			return resolvedList;
+		if (value instanceof JSONArray jsonArray) {
+			return TransformUtil.transform(
+				JSONUtil.toObjectList(jsonArray),
+				object -> _getSchemaObject(
+					openAPIJSONObject, object, visitedRefs));
 		}
 
 		return value;
+	}
+
+	private static boolean _isBinary(Map<String, Object> schemaMap) {
+		if (schemaMap == null) {
+			return false;
+		}
+
+		return Objects.equals(schemaMap.get("format"), "binary");
+	}
+
+	private static boolean _isMultipartRequest(JSONObject operationJSONObject) {
+		JSONObject contentJSONObject = JSONUtil.getValueAsJSONObject(
+			operationJSONObject, "JSONObject/requestBody",
+			"JSONObject/content");
+
+		if ((contentJSONObject == null) ||
+			contentJSONObject.has("application/json")) {
+
+			return false;
+		}
+
+		return contentJSONObject.has("multipart/form-data");
 	}
 
 	private static void _setBody(
@@ -917,10 +895,11 @@ public class OpenAPIUtil {
 		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
 		Operation operation, Http.Options options) {
 
-		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
-			openAPIJSONObject,
-			_getBodySchemaJSONObject(operation._operationJSONObject),
-			new HashSet<>());
+		Map<String, Object> bodySchemaMap =
+			(Map<String, Object>)_getSchemaObject(
+				openAPIJSONObject,
+				_getBodySchemaJSONObject(operation._operationJSONObject),
+				new HashSet<>());
 
 		Map<String, Object> partProperties =
 			(Map<String, Object>)bodySchemaMap.get("properties");

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -61,24 +61,8 @@ public class OpenAPIUtil {
 			_setMultipartBody(
 				inputJSONObject, openAPIJSONObject, operation, options);
 		}
-		else if (inputJSONObject.has("body")) {
-			Object bodyValue = inputJSONObject.get("body");
-
-			String body = null;
-
-			if (bodyValue instanceof JSONObject) {
-				body = bodyValue.toString();
-			}
-			else if (bodyValue != null) {
-				body = String.valueOf(bodyValue);
-			}
-
-			if (Validator.isNotNull(body)) {
-				options.setBody(
-					body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-				options.addHeader(
-					"Content-Type", ContentTypes.APPLICATION_JSON);
-			}
+		else if (operation._operationJSONObject.has("requestBody")) {
+			_setBody(inputJSONObject, options, toolName);
 		}
 
 		return options;
@@ -895,6 +879,34 @@ public class OpenAPIUtil {
 		}
 
 		return value;
+	}
+
+	private static void _setBody(
+		JSONObject inputJSONObject, Http.Options options, String toolName) {
+
+		if (!inputJSONObject.has("body")) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"The \"", toolName,
+					"\" tool requires the request payload nested under a ",
+					"\"body\" property. Pass any path or query parameters as ",
+					"siblings of \"body\" rather than flattening the payload ",
+					"into the input map."));
+		}
+
+		Object bodyValue = inputJSONObject.get("body");
+
+		String body = StringPool.BLANK;
+
+		if (bodyValue instanceof JSONObject) {
+			body = bodyValue.toString();
+		}
+		else if (bodyValue != null) {
+			body = String.valueOf(bodyValue);
+		}
+
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setBody(body, ContentTypes.APPLICATION_JSON, StringPool.UTF8);
 	}
 
 	private static void _setMultipartBody(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -128,12 +128,12 @@ public class OpenAPIUtil {
 		JSONObject operationJSONObject, Map<String, Object> properties,
 		List<Object> required, JSONObject openAPIJSONObject) {
 
-		Map<String, Object> resolvedSchema = (Map<String, Object>)_resolveRefs(
+		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
 			openAPIJSONObject, _getBodySchemaJSONObject(operationJSONObject),
 			new HashSet<>());
 
 		Map<String, Object> partProperties =
-			(Map<String, Object>)resolvedSchema.get("properties");
+			(Map<String, Object>)bodySchemaMap.get("properties");
 
 		if (partProperties == null) {
 			return;
@@ -152,11 +152,11 @@ public class OpenAPIUtil {
 			}
 		}
 
-		List<Object> schemaRequired = (List<Object>)resolvedSchema.get(
+		List<Object> bodySchemaRequired = (List<Object>)bodySchemaMap.get(
 			"required");
 
-		if (schemaRequired != null) {
-			required.addAll(schemaRequired);
+		if (bodySchemaRequired != null) {
+			required.addAll(bodySchemaRequired);
 		}
 	}
 
@@ -174,11 +174,11 @@ public class OpenAPIUtil {
 
 		Map<String, Object> property = new LinkedHashMap<>();
 
-		JSONObject schemaJSONObject = parameterJSONObject.getJSONObject(
-			"schema");
+		JSONObject parameterSchemaJSONObject =
+			parameterJSONObject.getJSONObject("schema");
 
-		for (String key : schemaJSONObject.keySet()) {
-			property.put(key, schemaJSONObject.get(key));
+		for (String key : parameterSchemaJSONObject.keySet()) {
+			property.put(key, parameterSchemaJSONObject.get(key));
 		}
 
 		if (parameterJSONObject.has("description")) {
@@ -438,15 +438,15 @@ public class OpenAPIUtil {
 			throw new IllegalArgumentException("Request body has no content");
 		}
 
-		JSONObject schemaJSONObject = mediaTypeJSONObject.getJSONObject(
+		JSONObject bodySchemaJSONObject = mediaTypeJSONObject.getJSONObject(
 			"schema");
 
-		if (schemaJSONObject == null) {
+		if (bodySchemaJSONObject == null) {
 			throw new IllegalArgumentException(
 				"Request body content has no \"schema\"");
 		}
 
-		return schemaJSONObject;
+		return bodySchemaJSONObject;
 	}
 
 	private static String _getDescription(
@@ -531,17 +531,21 @@ public class OpenAPIUtil {
 				JSONObject requestBodyJSONObject =
 					operationJSONObject.getJSONObject("requestBody");
 
-				Object bodySchema = null;
+				Map<String, Object> bodySchemaMap = null;
 
 				if (requestBodyJSONObject.getJSONObject("content") != null) {
-					bodySchema = _resolveRefs(
+					Object resolvedObject = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
 						new HashSet<>());
+
+					if (resolvedObject instanceof Map) {
+						bodySchemaMap = (Map<String, Object>)resolvedObject;
+					}
 				}
 
-				if (!(bodySchema instanceof Map)) {
-					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+				if (bodySchemaMap == null) {
+					bodySchemaMap = LinkedHashMapBuilder.<String, Object>put(
 						"type", "object"
 					).build();
 				}
@@ -550,27 +554,26 @@ public class OpenAPIUtil {
 					"description");
 
 				if (Validator.isNotNull(requestBodyDescription)) {
-					Map<String, Object> bodySchemaMap =
-						(Map<String, Object>)bodySchema;
+					Object bodySchemaDescription = bodySchemaMap.get(
+						"description");
 
-					Object schemaDescription = bodySchemaMap.get("description");
-
-					if (Validator.isNull(schemaDescription)) {
+					if (Validator.isNull(bodySchemaDescription)) {
 						bodySchemaMap.put(
 							"description", requestBodyDescription);
 					}
 					else if (!Objects.equals(
-								schemaDescription, requestBodyDescription)) {
+								bodySchemaDescription,
+								requestBodyDescription)) {
 
 						bodySchemaMap.put(
 							"description",
 							StringBundler.concat(
 								requestBodyDescription, StringPool.SPACE,
-								schemaDescription));
+								bodySchemaDescription));
 					}
 				}
 
-				properties.put("body", bodySchema);
+				properties.put("body", bodySchemaMap);
 
 				required.add("body");
 			}
@@ -914,13 +917,13 @@ public class OpenAPIUtil {
 		JSONObject inputJSONObject, JSONObject openAPIJSONObject,
 		Operation operation, Http.Options options) {
 
-		Map<String, Object> bodySchema = (Map<String, Object>)_resolveRefs(
+		Map<String, Object> bodySchemaMap = (Map<String, Object>)_resolveRefs(
 			openAPIJSONObject,
 			_getBodySchemaJSONObject(operation._operationJSONObject),
 			new HashSet<>());
 
 		Map<String, Object> partProperties =
-			(Map<String, Object>)bodySchema.get("properties");
+			(Map<String, Object>)bodySchemaMap.get("properties");
 
 		if (partProperties == null) {
 			return;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtil.java
@@ -544,12 +544,49 @@ public class OpenAPIUtil {
 					openAPIJSONObject);
 			}
 			else {
-				properties.put(
-					"body",
-					_resolveRefs(
+				JSONObject requestBodyJSONObject =
+					operationJSONObject.getJSONObject("requestBody");
+
+				Object bodySchema = null;
+
+				if (requestBodyJSONObject.getJSONObject("content") != null) {
+					bodySchema = _resolveRefs(
 						openAPIJSONObject,
 						_getBodySchemaJSONObject(operationJSONObject),
-						new HashSet<>()));
+						new HashSet<>());
+				}
+
+				if (!(bodySchema instanceof Map)) {
+					bodySchema = LinkedHashMapBuilder.<String, Object>put(
+						"type", "object"
+					).build();
+				}
+
+				String requestBodyDescription = requestBodyJSONObject.getString(
+					"description");
+
+				if (Validator.isNotNull(requestBodyDescription)) {
+					Map<String, Object> bodySchemaMap =
+						(Map<String, Object>)bodySchema;
+
+					Object schemaDescription = bodySchemaMap.get("description");
+
+					if (Validator.isNull(schemaDescription)) {
+						bodySchemaMap.put(
+							"description", requestBodyDescription);
+					}
+					else if (!Objects.equals(
+								schemaDescription, requestBodyDescription)) {
+
+						bodySchemaMap.put(
+							"description",
+							StringBundler.concat(
+								requestBodyDescription, StringPool.SPACE,
+								schemaDescription));
+					}
+				}
+
+				properties.put("body", bodySchema);
 
 				required.add("body");
 			}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.dto.v1_0.ToolSummary;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -93,6 +94,11 @@ public class OpenAPIUtilTest {
 				"itemId", "123"
 			),
 			"patchItem");
+		_testGetOptions(
+			"{}", "application/json", Http.Method.POST,
+			"http://localhost/test/v1.0/items",
+			JSONUtil.put("body", JSONFactoryUtil.createJSONObject()),
+			"postItem");
 
 		String fileContent = RandomTestUtil.randomString();
 		String fileName = RandomTestUtil.randomString();
@@ -165,6 +171,20 @@ public class OpenAPIUtilTest {
 		Assert.assertEquals("true", parts.get("boolean"));
 		Assert.assertEquals("1", parts.get("integer"));
 		Assert.assertEquals(fileContent, parts.get("string"));
+
+		AssertUtils.assertFailure(
+			IllegalArgumentException.class,
+			StringBundler.concat(
+				"The \"postItem\" tool requires the request payload nested ",
+				"under a \"body\" property. Pass any path or query parameters ",
+				"as siblings of \"body\" rather than flattening the payload ",
+				"into the input map."),
+			() -> OpenAPIUtil.getOptions(
+				"http://localhost/test",
+				JSONUtil.put(
+					RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				_openAPIJSONObject, "postItem"));
 	}
 
 	@Test
@@ -213,31 +233,21 @@ public class OpenAPIUtilTest {
 
 	@Test
 	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
+					"application/json",
 					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
+						"schema",
 						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema",
-									JSONUtil.put(
-										"description", "A Thing resource."
-									).put(
-										"type", "object"
-									)))
+							"description", _SCHEMA_DESCRIPTION
 						).put(
-							"description", "The thing to create."
-						)
-					))));
+							"type", "object"
+						)))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -248,32 +258,21 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create. A Thing resource.",
+			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
 			bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
 			JSONUtil.put(
-				"/things",
+				"content",
 				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put(
-							"content",
-							JSONUtil.put(
-								"application/json",
-								JSONUtil.put(
-									"schema", JSONUtil.put("type", "object")))
-						).put(
-							"description", "The thing to create."
-						)
-					))));
+					"application/json",
+					JSONUtil.put("schema", JSONUtil.put("type", "object")))
+			).put(
+				"description", _REQUEST_BODY_DESCRIPTION
+			));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -284,23 +283,13 @@ public class OpenAPIUtilTest {
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
 	}
 
 	@Test
 	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody",
-						JSONUtil.put("description", "The thing to create.")
-					))));
+		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
+			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
 
 		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
 
@@ -310,9 +299,9 @@ public class OpenAPIUtilTest {
 
 		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
 
-		Assert.assertEquals("object", bodySchema.get("type"));
 		Assert.assertEquals(
-			"The thing to create.", bodySchema.get("description"));
+			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
+		Assert.assertEquals("object", bodySchema.get("type"));
 	}
 
 	@Test
@@ -322,31 +311,31 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(toolSummaries.toString(), 12, toolSummaries.size());
 		_assertToolSummary(
-			toolSummaries.get(0), "This is the description", "getItem");
+			"This is the description", "getItem", toolSummaries.get(0));
 		_assertToolSummary(
-			toolSummaries.get(1), "PATCH /v1.0/items/{itemId}", "patchItem");
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(1));
 		_assertToolSummary(
-			toolSummaries.get(2), "PUT /v1.0/items/{itemId}", "putItem");
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(2));
 		_assertToolSummary(
-			toolSummaries.get(3), "POST /v1.0/binaries", "postBinary");
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(3));
 		_assertToolSummary(
-			toolSummaries.get(4), "POST /v1.0/empty-content",
-			"postEmptyContent");
+			"POST /v1.0/empty-content", "postEmptyContent",
+			toolSummaries.get(4));
 		_assertToolSummary(
-			toolSummaries.get(5), "POST /v1.0/no-content", "postNoContent");
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(5));
 		_assertToolSummary(
-			toolSummaries.get(6), "POST /v1.0/parents", "postParent");
+			"POST /v1.0/parents", "postParent", toolSummaries.get(6));
 		_assertToolSummary(
-			toolSummaries.get(7), "POST /v1.0/uploads", "postUpload");
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(7));
 		_assertToolSummary(
-			toolSummaries.get(8),
-			"This is the summary. This is the description", "getItems");
+			"This is the summary. This is the description", "getItems",
+			toolSummaries.get(8));
 		_assertToolSummary(
-			toolSummaries.get(9), "POST /v1.0/items", "postItem");
+			"POST /v1.0/items", "postItem", toolSummaries.get(9));
 		_assertToolSummary(
-			toolSummaries.get(10), "POST /v1.0/no-schema", "postNoSchema");
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(10));
 		_assertToolSummary(
-			toolSummaries.get(11), "This is the summary", "getItemsPage");
+			"This is the summary", "getItemsPage", toolSummaries.get(11));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
@@ -365,11 +354,27 @@ public class OpenAPIUtilTest {
 	}
 
 	private void _assertToolSummary(
-		ToolSummary toolSummary, String expectedDescription,
-		String expectedName) {
+		String expectedDescription, String expectedName,
+		ToolSummary toolSummary) {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
+	}
+
+	private JSONObject _createOpenAPIJSONObject(
+		JSONObject requestBodyJSONObject) {
+
+		return JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody", requestBodyJSONObject
+					))));
 	}
 
 	private Map<String, ?> _getInputSchema(
@@ -402,6 +407,8 @@ public class OpenAPIUtilTest {
 		else {
 			Assert.assertEquals(expectedBody, body.getContent());
 			Assert.assertEquals(expectedContentType, body.getContentType());
+			Assert.assertEquals(
+				expectedContentType, options.getHeader("Content-Type"));
 		}
 
 		Assert.assertNull(options.getFileParts());
@@ -428,6 +435,11 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
+
+	private static final String _REQUEST_BODY_DESCRIPTION =
+		"The thing to create.";
+
+	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -221,9 +221,18 @@ public class OpenAPIUtilTest {
 			"POST /v1.0/binaries", "post_test_v1.0_binaries.json",
 			"postBinary");
 		_testGetTool(
+			"POST /v1.0/described", "post_test_v1.0_described.json",
+			"postDescribed");
+		_testGetTool(
 			"POST /v1.0/items", "post_test_v1.0_items.json", "postItem");
 		_testGetTool(
+			"POST /v1.0/no-content", "post_test_v1.0_no-content.json",
+			"postNoContent");
+		_testGetTool(
 			"POST /v1.0/parents", "post_test_v1.0_parents.json", "postParent");
+		_testGetTool(
+			"POST /v1.0/undescribed", "post_test_v1.0_undescribed.json",
+			"postUndescribed");
 		_testGetTool(
 			"POST /v1.0/uploads", "post_test_v1.0_uploads.json", "postUpload");
 		_testGetTool(
@@ -232,110 +241,41 @@ public class OpenAPIUtilTest {
 	}
 
 	@Test
-	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put(
-				"content",
-				JSONUtil.put(
-					"application/json",
-					JSONUtil.put(
-						"schema",
-						JSONUtil.put(
-							"description", _SCHEMA_DESCRIPTION
-						).put(
-							"type", "object"
-						)))
-			).put(
-				"description", _REQUEST_BODY_DESCRIPTION
-			));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION + " " + _SCHEMA_DESCRIPTION,
-			bodySchema.get("description"));
-	}
-
-	@Test
-	public void testGetToolRequestBodyDescriptionIsSurfaced() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put(
-				"content",
-				JSONUtil.put(
-					"application/json",
-					JSONUtil.put("schema", JSONUtil.put("type", "object")))
-			).put(
-				"description", _REQUEST_BODY_DESCRIPTION
-			));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
-	}
-
-	@Test
-	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
-		JSONObject openAPIJSONObject = _createOpenAPIJSONObject(
-			JSONUtil.put("description", _REQUEST_BODY_DESCRIPTION));
-
-		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
-
-		Map<String, ?> inputSchema = tool.getInputSchema();
-
-		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
-
-		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
-
-		Assert.assertEquals(
-			_REQUEST_BODY_DESCRIPTION, bodySchema.get("description"));
-		Assert.assertEquals("object", bodySchema.get("type"));
-	}
-
-	@Test
 	public void testGetToolSummaries() {
 		List<ToolSummary> toolSummaries = OpenAPIUtil.getToolSummaries(
 			_openAPIJSONObject);
 
-		Assert.assertEquals(toolSummaries.toString(), 12, toolSummaries.size());
+		Assert.assertEquals(toolSummaries.toString(), 14, toolSummaries.size());
 		_assertToolSummary(
-			"This is the description", "getItem", toolSummaries.get(0));
+			"POST /v1.0/described", "postDescribed", toolSummaries.get(0));
 		_assertToolSummary(
-			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(1));
+			"POST /v1.0/undescribed", "postUndescribed", toolSummaries.get(1));
 		_assertToolSummary(
-			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(2));
+			"This is the description", "getItem", toolSummaries.get(2));
 		_assertToolSummary(
-			"POST /v1.0/binaries", "postBinary", toolSummaries.get(3));
+			"PATCH /v1.0/items/{itemId}", "patchItem", toolSummaries.get(3));
+		_assertToolSummary(
+			"PUT /v1.0/items/{itemId}", "putItem", toolSummaries.get(4));
+		_assertToolSummary(
+			"POST /v1.0/binaries", "postBinary", toolSummaries.get(5));
 		_assertToolSummary(
 			"POST /v1.0/empty-content", "postEmptyContent",
-			toolSummaries.get(4));
+			toolSummaries.get(6));
 		_assertToolSummary(
-			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(5));
+			"POST /v1.0/no-content", "postNoContent", toolSummaries.get(7));
 		_assertToolSummary(
-			"POST /v1.0/parents", "postParent", toolSummaries.get(6));
+			"POST /v1.0/parents", "postParent", toolSummaries.get(8));
 		_assertToolSummary(
-			"POST /v1.0/uploads", "postUpload", toolSummaries.get(7));
+			"POST /v1.0/uploads", "postUpload", toolSummaries.get(9));
 		_assertToolSummary(
 			"This is the summary. This is the description", "getItems",
-			toolSummaries.get(8));
+			toolSummaries.get(10));
 		_assertToolSummary(
-			"POST /v1.0/items", "postItem", toolSummaries.get(9));
+			"POST /v1.0/items", "postItem", toolSummaries.get(11));
 		_assertToolSummary(
-			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(10));
+			"POST /v1.0/no-schema", "postNoSchema", toolSummaries.get(12));
 		_assertToolSummary(
-			"This is the summary", "getItemsPage", toolSummaries.get(11));
+			"This is the summary", "getItemsPage", toolSummaries.get(13));
 
 		AssertUtils.assertFailure(
 			IllegalArgumentException.class,
@@ -359,22 +299,6 @@ public class OpenAPIUtilTest {
 
 		Assert.assertEquals(expectedDescription, toolSummary.getDescription());
 		Assert.assertEquals(expectedName, toolSummary.getName());
-	}
-
-	private JSONObject _createOpenAPIJSONObject(
-		JSONObject requestBodyJSONObject) {
-
-		return JSONUtil.put(
-			"paths",
-			JSONUtil.put(
-				"/things",
-				JSONUtil.put(
-					"post",
-					JSONUtil.put(
-						"operationId", "postThing"
-					).put(
-						"requestBody", requestBodyJSONObject
-					))));
 	}
 
 	private Map<String, ?> _getInputSchema(
@@ -435,11 +359,6 @@ public class OpenAPIUtilTest {
 			),
 			true);
 	}
-
-	private static final String _REQUEST_BODY_DESCRIPTION =
-		"The thing to create.";
-
-	private static final String _SCHEMA_DESCRIPTION = "A Thing resource.";
 
 	private JSONObject _openAPIJSONObject;
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/java/com/liferay/mcp/server/rest/internal/util/OpenAPIUtilTest.java
@@ -180,9 +180,6 @@ public class OpenAPIUtilTest {
 				JSONFactoryUtil.createJSONObject(),
 				RandomTestUtil.randomString()));
 		AssertUtils.assertFailure(
-			IllegalArgumentException.class, "Request body has no \"content\"",
-			() -> _getInputSchema(_openAPIJSONObject, "postNoContent"));
-		AssertUtils.assertFailure(
 			IllegalArgumentException.class, "Request body has no content",
 			() -> _getInputSchema(_openAPIJSONObject, "postEmptyContent"));
 		AssertUtils.assertFailure(
@@ -212,6 +209,110 @@ public class OpenAPIUtilTest {
 		_testGetTool(
 			"PUT /v1.0/items/{itemId}", "put_test_v1.0_items_itemId.json",
 			"putItem");
+	}
+
+	@Test
+	public void testGetToolMergesRequestBodyAndSchemaDescriptions() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema",
+									JSONUtil.put(
+										"description", "A Thing resource."
+									).put(
+										"type", "object"
+									)))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create. A Thing resource.",
+			bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyDescriptionIsSurfaced() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put(
+							"content",
+							JSONUtil.put(
+								"application/json",
+								JSONUtil.put(
+									"schema", JSONUtil.put("type", "object")))
+						).put(
+							"description", "The thing to create."
+						)
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
+	}
+
+	@Test
+	public void testGetToolRequestBodyWithoutContentDoesNotFail() {
+		JSONObject openAPIJSONObject = JSONUtil.put(
+			"paths",
+			JSONUtil.put(
+				"/things",
+				JSONUtil.put(
+					"post",
+					JSONUtil.put(
+						"operationId", "postThing"
+					).put(
+						"requestBody",
+						JSONUtil.put("description", "The thing to create.")
+					))));
+
+		Tool tool = OpenAPIUtil.getTool(openAPIJSONObject, "postThing");
+
+		Map<String, ?> inputSchema = tool.getInputSchema();
+
+		Map<?, ?> properties = (Map<?, ?>)inputSchema.get("properties");
+
+		Map<?, ?> bodySchema = (Map<?, ?>)properties.get("body");
+
+		Assert.assertEquals("object", bodySchema.get("type"));
+		Assert.assertEquals(
+			"The thing to create.", bodySchema.get("description"));
 	}
 
 	@Test

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/openapi.json
@@ -130,6 +130,22 @@
 				}
 			}
 		},
+		"/v1.0/described": {
+			"post": {
+				"operationId": "postDescribed",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"description": "This is the schema description",
+								"type": "object"
+							}
+						}
+					},
+					"description": "This is the request body description"
+				}
+			}
+		},
 		"/v1.0/empty-content": {
 			"post": {
 				"operationId": "postEmptyContent",
@@ -282,6 +298,7 @@
 			"post": {
 				"operationId": "postNoContent",
 				"requestBody": {
+					"description": "This is the request body description"
 				}
 			}
 		},
@@ -307,6 +324,21 @@
 							}
 						}
 					}
+				}
+			}
+		},
+		"/v1.0/undescribed": {
+			"post": {
+				"operationId": "postUndescribed",
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object"
+							}
+						}
+					},
+					"description": "This is the request body description"
 				}
 			}
 		},

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_described.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_described.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description This is the schema description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_no-content.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_no-content.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_undescribed.json
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/test/resources/com/liferay/mcp/server/rest/internal/util/dependencies/post_test_v1.0_undescribed.json
@@ -1,0 +1,12 @@
+{
+	"properties": {
+		"body": {
+			"description": "This is the request body description",
+			"type": "object"
+		}
+	},
+	"required": [
+		"body"
+	],
+	"type": "object"
+}

--- a/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
+++ b/modules/apps/object/object-rest-test/src/testIntegration/java/com/liferay/object/rest/internal/manager/v1_0/test/DefaultObjectEntryManagerImplTest.java
@@ -5282,8 +5282,7 @@ public class DefaultObjectEntryManagerImplTest
 			});
 
 		// Sleep for 1 second to ensure that child object entry 1 and child
-		// object entry 2 are created 1 second apart to ensure that the
-		// tests with buildRangeExpression work
+		// object entry 2 are created 1 second apart
 
 		Thread.sleep(1000);
 

--- a/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-kaleo-test/src/testIntegration/java/com/liferay/portal/workflow/kaleo/internal/runtime/integration/test/WorkflowTaskManagerImplTest.java
@@ -1490,6 +1490,9 @@ public class WorkflowTaskManagerImplTest extends BaseWorkflowManagerTestCase {
 	public void testSearchWorkflowTasksWhenThereIsAnUnregisteredHandler()
 		throws Exception {
 
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
 		try (ServiceRegistrationHolder serviceRegistrationHolder =
 				registryWorkflowHandler()) {
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
@@ -21,7 +21,8 @@ html#{$cadmin-selector} {
 				.sidebar-body__add-panel__tab-item-add {
 					position: absolute;
 					right: 4px;
-					top: 0;
+					top: 50%;
+					transform: translateY(-50%);
 				}
 			}
 
@@ -128,6 +129,8 @@ html#{$cadmin-selector} {
 
 				.sidebar-body__add-panel__tab-item-add {
 					right: 0;
+					top: 0;
+					transform: none;
 				}
 			}
 		}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/css/_TabItem.scss
@@ -82,11 +82,11 @@ html#{$cadmin-selector} {
 				.title {
 					font-size: 12px;
 					font-weight: 600;
+					min-width: 0;
 				}
 
 				.subtitle {
 					color: $cadmin-gray-600;
-					flex-basis: 100%;
 					font-size: 12px;
 				}
 			}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
@@ -64,17 +64,19 @@ const TabItem = ({item}) => {
 					<ClayIcon symbol={item.icon} />
 				</div>
 
-				<div className="align-items-center d-flex text">
-					<div className="mr-1 text-truncate title">{item.label}</div>
+				<div className="text">
+					<div className="align-items-center d-flex">
+						<div className="text-truncate title">{item.label}</div>
 
-					{item.data.deprecated && (
-						<div className="flex-shrink-0 ml-1">
-							<FeatureIndicator type="deprecated" />
-						</div>
-					)}
+						{item.data.deprecated && (
+							<div className="flex-shrink-0 ml-1">
+								<FeatureIndicator type="deprecated" />
+							</div>
+						)}
+					</div>
 
 					{isContent && (
-						<div className="subtitle text-break">
+						<div className="subtitle text-truncate">
 							{item.category}
 						</div>
 					)}

--- a/modules/apps/product-navigation/product-navigation-taglib/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Product Navigation Taglib
 Bundle-SymbolicName: com.liferay.product.navigation.taglib
-Bundle-Version: 7.0.18
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.product.navigation.taglib.display.context,\
 	com.liferay.product.navigation.taglib.servlet.taglib

--- a/modules/apps/product-navigation/product-navigation-taglib/package.json
+++ b/modules/apps/product-navigation/product-navigation-taglib/package.json
@@ -16,5 +16,5 @@
 		"checkFormat": "node-scripts format --check",
 		"format": "node-scripts format"
 	},
-	"version": "7.0.18"
+	"version": "7.1.0"
 }

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/common/components/forms/validations.ts
@@ -41,6 +41,24 @@ const maxLength =
 		}
 	};
 
+const minValue =
+	(min: number): ValidationFunction =>
+	(value) => {
+		if (
+			value !== '' &&
+			value !== undefined &&
+			value !== null &&
+			Number(value) < min
+		) {
+			return sub(
+				Liferay.Language.get(
+					'please-enter-a-value-greater-than-or-equal-to-x'
+				),
+				min
+			);
+		}
+	};
+
 const notNull: ValidationFunction = (value) => {
 	if (value === 'null') {
 		return Liferay.Language.get('name-cannot-be-null');
@@ -102,6 +120,7 @@ export {
 	alphanumeric,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	notNull,
 	nonNumeric,
 	required,

--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/spaces/SpaceGeneralSettings.tsx
@@ -16,6 +16,7 @@ import {
 	Errors,
 	invalidCharacters,
 	maxLength,
+	minValue,
 	nonNumeric,
 	notNull,
 	required,
@@ -28,6 +29,8 @@ import {ERC_MAX_LENGTH} from '../../common/utils/constants';
 import focusInvalidElement from '../../common/utils/focusInvalidElement';
 import SpaceBaseFields from './SpaceBaseFields';
 import SpacePanel from './SpacePanel';
+
+const MINUTES_PER_DAY = 1440;
 
 export default function SpaceGeneralSettings({
 	backURL,
@@ -67,7 +70,9 @@ export default function SpaceGeneralSettings({
 			sharingEnabled: space.settings?.sharingEnabled ?? false,
 			trashEnabled: space.settings?.trashEnabled ?? true,
 			trashEntriesMaxAge: String(
-				space.settings?.trashEntriesMaxAge ?? ''
+				Math.round(
+					(space.settings?.trashEntriesMaxAge ?? 0) / MINUTES_PER_DAY
+				)
 			),
 		},
 		onSubmit: async (values) => {
@@ -93,7 +98,8 @@ export default function SpaceGeneralSettings({
 						logoColor,
 						sharingEnabled,
 						trashEnabled,
-						trashEntriesMaxAge: Number(trashEntriesMaxAge),
+						trashEntriesMaxAge:
+							Number(trashEntriesMaxAge) * MINUTES_PER_DAY,
 					},
 				}
 			);
@@ -156,7 +162,7 @@ export default function SpaceGeneralSettings({
 						maxLength(150),
 					],
 					trashEntriesMaxAge: values.trashEnabled
-						? [required, validNumber]
+						? [minValue(1), required, validNumber]
 						: [],
 				},
 				values,

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/spaces/SpaceGeneralSettings.test.tsx
@@ -37,7 +37,7 @@ const SPACE: Partial<Space> = {
 		logoColor: 'outline-2',
 		sharingEnabled: true,
 		trashEnabled: true,
-		trashEntriesMaxAge: 0,
+		trashEntriesMaxAge: 2880,
 	},
 };
 
@@ -196,6 +196,65 @@ describe('SpaceGeneralSettings', () => {
 		});
 
 		await closeToast();
+	});
+
+	describe('Trash entries max age', () => {
+		it('displays the value in days converted from the stored minutes', () => {
+			renderComponent({
+				space: {
+					...SPACE,
+					settings: {
+						...SPACE.settings!,
+						trashEntriesMaxAge: 7200,
+					},
+				} as Partial<Space>,
+			});
+
+			expect(screen.getByLabelText('trash-entries-max-age')).toHaveValue(
+				5
+			);
+		});
+
+		it('converts the value to minutes on save', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '5');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			await waitFor(() => {
+				expect(SpaceService.updateSpace).toBeCalledWith(
+					expect.any(String),
+					expect.objectContaining({
+						settings: expect.objectContaining({
+							trashEntriesMaxAge: 7200,
+						}),
+					})
+				);
+			});
+
+			await closeToast();
+		});
+
+		it('does not save when the value is less than 1', async () => {
+			renderComponent();
+
+			const trashEntriesMaxAgeField = screen.getByLabelText(
+				'trash-entries-max-age'
+			);
+
+			await userEvent.clear(trashEntriesMaxAgeField);
+			await userEvent.type(trashEntriesMaxAgeField, '0');
+
+			await userEvent.click(screen.getByRole('button', {name: 'save'}));
+
+			expect(SpaceService.updateSpace).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('Errors', () => {

--- a/modules/test/playwright/pages/account-admin-web/EditAccountPage.ts
+++ b/modules/test/playwright/pages/account-admin-web/EditAccountPage.ts
@@ -57,6 +57,7 @@ export class EditAccountPage {
 	readonly setBillingDefaultAddressButton: Locator;
 	readonly setShippingDefaultAddressButton: Locator;
 	readonly tagInput: (name: string) => Locator;
+	readonly tagsCombobox: Locator;
 	readonly taxIDInput: Locator;
 	readonly typeInput: Locator;
 	readonly uploadImageSelectImageButton: Locator;
@@ -198,6 +199,7 @@ export class EditAccountPage {
 			.locator('[class$=btn-group-spaced]')
 			.getByText('Save');
 		this.tagInput = (name) => page.getByRole('row', {name});
+		this.tagsCombobox = page.getByRole('combobox', {name: 'Tags'});
 		this.taxIDInput = page.getByLabel('Tax ID');
 		this.typeInput = page.getByLabel('Type');
 		this.uploadImageSelectImageButton = page

--- a/modules/test/playwright/pages/users-admin-web/PersonalMenuInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/PersonalMenuInstanceSettingsPage.ts
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page, expect} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
 export class PersonalMenuInstanceSettingsPage {
@@ -16,9 +17,9 @@ export class PersonalMenuInstanceSettingsPage {
 	constructor(page: Page) {
 		this.instanceSettingsPage = new InstanceSettingsPage(page);
 		this.page = page;
-		this.personalApplicationsLookAndFeelSelect = page.getByLabel(
-			'Personal Applications Look and Feel'
-		);
+		this.personalApplicationsLookAndFeelSelect = page.getByRole('combobox', {
+			name: 'Personal Applications Look and Feel',
+		});
 		this.showInControlMenuCheckbox = page.getByLabel(
 			'Show in Control Menu'
 		);
@@ -36,12 +37,10 @@ export class PersonalMenuInstanceSettingsPage {
 	}
 
 	async selectPersonalApplicationsLookAndFeel(option: string) {
-		await expect(async () => {
-			await this.personalApplicationsLookAndFeelSelect.click();
-
-			await this.page
-				.getByRole('option', {name: option})
-				.click({timeout: 1000});
-		}).toPass({timeout: 5000});
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('option', {name: option}),
+			trigger: this.personalApplicationsLookAndFeelSelect,
+		});
 	}
 }

--- a/modules/test/playwright/pages/users-admin-web/PersonalMenuInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/PersonalMenuInstanceSettingsPage.ts
@@ -17,9 +17,12 @@ export class PersonalMenuInstanceSettingsPage {
 	constructor(page: Page) {
 		this.instanceSettingsPage = new InstanceSettingsPage(page);
 		this.page = page;
-		this.personalApplicationsLookAndFeelSelect = page.getByRole('combobox', {
-			name: 'Personal Applications Look and Feel',
-		});
+		this.personalApplicationsLookAndFeelSelect = page.getByRole(
+			'combobox',
+			{
+				name: 'Personal Applications Look and Feel',
+			}
+		);
 		this.showInControlMenuCheckbox = page.getByLabel(
 			'Show in Control Menu'
 		);

--- a/modules/test/playwright/tests/account-admin-web/main/accounts.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/main/accounts.spec.ts
@@ -35,296 +35,331 @@ export const test = mergeTests(
 	usersAndOrganizationsPagesTest
 );
 
-test('LPD-18485 Update account contact information fields', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountContactInformationPage,
-	editAccountContactPage,
-	editAccountPage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: 'test',
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.contactLink.click();
-	await editAccountContactPage.contactInformationLink.click();
-	await editAccountContactInformationPage.updateContactInformation(
-		'facebookInput',
-		'jabberInput',
-		'skypeInput',
-		'smsInput',
-		'twitterInput'
-	);
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
-	await page.reload();
-
-	await expect(editAccountContactInformationPage.facebookInput).toHaveValue(
-		'facebookInput'
-	);
-});
-
-test('LPD-18484 Add account contact address', async ({
-	accountContactAddressPage,
-	accountsPage,
-	apiHelpers,
-	editAccountContactAddressPage,
-	editAccountPage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: 'test',
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.contactLink.click();
-	await accountContactAddressPage.addAddressesButton.click();
-	await editAccountContactAddressPage.updateAddress(
-		'city',
-		'United States',
-		getRandomString(),
-		'California',
-		'address1'
-	);
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
-	await expect(
-		await editAccountContactAddressPage.addressDisplay('address1city')
-	).toBeVisible();
-});
-
-test('LPD-18482 Add account phone', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountContactInformationPage,
-	editAccountContactPage,
-	editAccountPage,
-	editAccountPhonePage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: 'test',
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.contactLink.click();
-	await editAccountContactPage.contactInformationLink.click();
-	await editAccountContactInformationPage.addPhoneNumbersButton.click();
-	await editAccountPhonePage.updatePhoneNumber('111-111-1111');
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
-	await expect(page.getByRole('cell', {name: '111-111-1111'})).toBeVisible();
-});
-
-test('LPD-18483 Add account email address', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountContactInformationPage,
-	editAccountContactPage,
-	editAccountEmailAddressPage,
-	editAccountPage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: 'test',
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.contactLink.click();
-	await editAccountContactPage.contactInformationLink.click();
-	await editAccountContactInformationPage.addEmailAddressesButton.click();
-	await editAccountEmailAddressPage.updateEmailAddress(
-		'emailAddress@liferay.com'
-	);
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
-	await expect(
-		page.getByRole('cell', {name: 'emailAddress@liferay.com'})
-	).toBeVisible();
-});
-
-test('LPD-18484 Add account website', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountContactInformationPage,
-	editAccountContactPage,
-	editAccountPage,
-	editAccountWebsitePage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: 'test',
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.contactLink.click();
-	await editAccountContactPage.contactInformationLink.click();
-	await editAccountContactInformationPage.addWebsitesButton.click();
-	await editAccountWebsitePage.updateWebsite('https://www.website.com');
-
-	await expect(
-		page.getByText('Success:Your request completed successfully.')
-	).toBeVisible();
-
-	await expect(
-		page.getByRole('cell', {name: 'https://www.website.com'})
-	).toBeVisible();
-});
-
-test('LPD-28161 Can view role and organization name escaped', async ({
-	accountRolesPage,
-	accountUsersPage,
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-
-	const roleName = 'My title<script>confirm("compromised")</script>';
-
-	const accountRole =
-		await apiHelpers.headlessAdminUser.postAccountAccountRoles(account.id, {
-			name: roleName,
+test(
+	'Update account contact information fields',
+	{tag: '@LPD-18485'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountContactInformationPage,
+		editAccountContactPage,
+		editAccountPage,
+		page,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: 'test',
+			type: 'business',
 		});
 
-	apiHelpers.data.push({id: accountRole.id, type: 'role'});
+		await accountsPage.goto();
 
-	const user = await apiHelpers.headlessAdminUser.postUserAccount();
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.contactLink.click();
+		await editAccountContactPage.contactInformationLink.click();
+		await editAccountContactInformationPage.updateContactInformation(
+			'facebookInput',
+			'jabberInput',
+			'skypeInput',
+			'smsInput',
+			'twitterInput'
+		);
 
-	await apiHelpers.headlessAdminUser.postAccountUserAccountByEmailAddress(
-		account.id,
-		[accountRole.id],
-		[user.emailAddress]
-	);
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
 
-	const organizationName = 'My org1<script>confirm("compromised")</script>';
+		await page.reload();
 
-	const organization = await apiHelpers.headlessAdminUser.postOrganization({
-		name: organizationName,
-	});
+		await expect(
+			editAccountContactInformationPage.facebookInput
+		).toHaveValue('facebookInput');
+	}
+);
 
-	await apiHelpers.headlessAdminUser.postOrganizationAccounts(
-		Number(organization.id),
-		[account.id]
-	);
+test(
+	'Add account contact address',
+	{tag: '@LPD-18484'},
+	async ({
+		accountContactAddressPage,
+		accountsPage,
+		apiHelpers,
+		editAccountContactAddressPage,
+		editAccountPage,
+		page,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: 'test',
+			type: 'business',
+		});
 
-	await accountsPage.goto();
+		await accountsPage.goto();
 
-	await expect(
-		await accountsPage.organizationName(organizationName)
-	).toBeVisible();
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.contactLink.click();
+		await accountContactAddressPage.addAddressesButton.click();
+		await editAccountContactAddressPage.updateAddress(
+			'city',
+			'United States',
+			getRandomString(),
+			'California',
+			'address1'
+		);
 
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.rolesLink.click();
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
 
-	await expect(await accountRolesPage.roleName(roleName)).toBeVisible();
+		await expect(
+			await editAccountContactAddressPage.addressDisplay('address1city')
+		).toBeVisible();
+	}
+);
 
-	await editAccountPage.usersLink.click();
+test(
+	'Add account phone',
+	{tag: '@LPD-18482'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountContactInformationPage,
+		editAccountContactPage,
+		editAccountPage,
+		editAccountPhonePage,
+		page,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: 'test',
+			type: 'business',
+		});
 
-	await expect(await accountUsersPage.roleName(roleName)).toBeVisible();
-});
+		await accountsPage.goto();
 
-test('LPD-32045 All account entry can be seen by admin user', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	const account1 = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-	const account2 = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-	const account3 = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.contactLink.click();
+		await editAccountContactPage.contactInformationLink.click();
+		await editAccountContactInformationPage.addPhoneNumbersButton.click();
+		await editAccountPhonePage.updatePhoneNumber('111-111-1111');
 
-	const userAccount = await apiHelpers.headlessAdminUser.postUserAccount();
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
 
-	userData[userAccount.alternateName] = {
-		name: userAccount.givenName,
-		password: 'test',
-		surname: userAccount.familyName,
-	};
+		await expect(
+			page.getByRole('cell', {name: '111-111-1111'})
+		).toBeVisible();
+	}
+);
 
-	const role =
-		await apiHelpers.headlessAdminUser.getRoleByName('Administrator');
+test(
+	'Add account email address',
+	{tag: '@LPD-18483'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountContactInformationPage,
+		editAccountContactPage,
+		editAccountEmailAddressPage,
+		editAccountPage,
+		page,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: 'test',
+			type: 'business',
+		});
 
-	await apiHelpers.headlessAdminUser.postRoleByExternalReferenceCodeUserAccountAssociation(
-		role.externalReferenceCode,
-		userAccount.id
-	);
+		await accountsPage.goto();
 
-	await performUserSwitch(page, userAccount.alternateName);
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.contactLink.click();
+		await editAccountContactPage.contactInformationLink.click();
+		await editAccountContactInformationPage.addEmailAddressesButton.click();
+		await editAccountEmailAddressPage.updateEmailAddress(
+			'emailAddress@liferay.com'
+		);
 
-	try {
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'emailAddress@liferay.com'})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Add account website',
+	{tag: '@LPD-18484'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountContactInformationPage,
+		editAccountContactPage,
+		editAccountPage,
+		editAccountWebsitePage,
+		page,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: 'test',
+			type: 'business',
+		});
+
+		await accountsPage.goto();
+
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.contactLink.click();
+		await editAccountContactPage.contactInformationLink.click();
+		await editAccountContactInformationPage.addWebsitesButton.click();
+		await editAccountWebsitePage.updateWebsite('https://www.website.com');
+
+		await expect(
+			page.getByText('Success:Your request completed successfully.')
+		).toBeVisible();
+
+		await expect(
+			page.getByRole('cell', {name: 'https://www.website.com'})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Can view role and organization name escaped',
+	{tag: '@LPD-28161'},
+	async ({
+		accountRolesPage,
+		accountUsersPage,
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
+
+		const roleName = 'My title<script>confirm("compromised")</script>';
+
+		const accountRole =
+			await apiHelpers.headlessAdminUser.postAccountAccountRoles(
+				account.id,
+				{
+					name: roleName,
+				}
+			);
+
+		apiHelpers.data.push({id: accountRole.id, type: 'role'});
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		await apiHelpers.headlessAdminUser.postAccountUserAccountByEmailAddress(
+			account.id,
+			[accountRole.id],
+			[user.emailAddress]
+		);
+
+		const organizationName =
+			'My org1<script>confirm("compromised")</script>';
+
+		const organization =
+			await apiHelpers.headlessAdminUser.postOrganization({
+				name: organizationName,
+			});
+
+		await apiHelpers.headlessAdminUser.postOrganizationAccounts(
+			Number(organization.id),
+			[account.id]
+		);
+
 		await accountsPage.goto();
 
 		await expect(
-			await accountsPage.accountsTable.cellLink(account1.name)
-		).toHaveCount(1);
-		await expect(
-			await accountsPage.accountsTable.cellLink(account2.name)
-		).toHaveCount(1);
-		await expect(
-			await accountsPage.accountsTable.cellLink(account3.name)
-		).toHaveCount(1);
+			await accountsPage.organizationName(organizationName)
+		).toBeVisible();
+
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.rolesLink.click();
+
+		await expect(await accountRolesPage.roleName(roleName)).toBeVisible();
+
+		await editAccountPage.usersLink.click();
+
+		await expect(await accountUsersPage.roleName(roleName)).toBeVisible();
 	}
-	finally {
-		await performUserSwitch(page, 'test');
+);
+
+test(
+	'All account entry can be seen by admin user',
+	{tag: '@LPD-32045'},
+	async ({accountsPage, apiHelpers, page}) => {
+		const account1 = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
+		const account2 = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
+		const account3 = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
+
+		const userAccount =
+			await apiHelpers.headlessAdminUser.postUserAccount();
+
+		userData[userAccount.alternateName] = {
+			name: userAccount.givenName,
+			password: 'test',
+			surname: userAccount.familyName,
+		};
+
+		const role =
+			await apiHelpers.headlessAdminUser.getRoleByName('Administrator');
+
+		await apiHelpers.headlessAdminUser.postRoleByExternalReferenceCodeUserAccountAssociation(
+			role.externalReferenceCode,
+			userAccount.id
+		);
+
+		await performUserSwitch(page, userAccount.alternateName);
+
+		try {
+			await accountsPage.goto();
+
+			await expect(
+				await accountsPage.accountsTable.cellLink(account1.name)
+			).toHaveCount(1);
+			await expect(
+				await accountsPage.accountsTable.cellLink(account2.name)
+			).toHaveCount(1);
+			await expect(
+				await accountsPage.accountsTable.cellLink(account3.name)
+			).toHaveCount(1);
+		}
+		finally {
+			await performUserSwitch(page, 'test');
+		}
 	}
-});
+);
 
-test('LPD-33636 Email address is not deleted by saving in the UI', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	globalMenuPage,
-	page,
-	serverAdministrationPage,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount();
+test(
+	'Email address is not deleted by saving in the UI',
+	{tag: '@LPD-33636'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+		globalMenuPage,
+		page,
+		serverAdministrationPage,
+	}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount();
 
-	await globalMenuPage.goToControlPanel('Server Administration');
+		await globalMenuPage.goToControlPanel('Server Administration');
 
-	const emailAddress = getRandomString() + '@liferay.com';
+		const emailAddress = getRandomString() + '@liferay.com';
 
-	const script = `
+		const script = `
 		import com.liferay.account.model.*;
 		import com.liferay.account.service.*;
 		AccountEntry account = AccountEntryLocalServiceUtil.fetchAccountEntry(${account.id});
@@ -332,478 +367,566 @@ test('LPD-33636 Email address is not deleted by saving in the UI', async ({
 		AccountEntryLocalServiceUtil.updateAccountEntry(account);
     `;
 
-	await serverAdministrationPage.executeScript(script);
+		await serverAdministrationPage.executeScript(script);
 
-	await accountsPage.goto();
-	await (await accountsPage.accountsTable.cellLink(account.name)).click();
-	await editAccountPage.saveButton.click();
-	await waitForAlert(page);
+		await accountsPage.goto();
+		await (await accountsPage.accountsTable.cellLink(account.name)).click();
+		await editAccountPage.saveButton.click();
+		await waitForAlert(page);
 
-	await globalMenuPage.goToControlPanel('Server Administration');
+		await globalMenuPage.goToControlPanel('Server Administration');
 
-	const fetchScript = `
+		const fetchScript = `
 		import com.liferay.account.model.*; 
 		import com.liferay.account.service.*;
 		AccountEntry account = AccountEntryLocalServiceUtil.fetchAccountEntry(${account.id});
 		out.println(account);
 	`;
 
-	await serverAdministrationPage.executeScript(fetchScript);
-	await expect(
-		page.getByText('"emailAddress": "' + emailAddress)
-	).toBeVisible();
-});
+		await serverAdministrationPage.executeScript(fetchScript);
+		await expect(
+			page.getByText('"emailAddress": "' + emailAddress)
+		).toBeVisible();
+	}
+);
 
-test('LPD-44526 Can activate and deactivate an account', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	page.on('dialog', (dialog) => {
-		dialog.accept().catch(() => {});
-	});
+test(
+	'Can activate and deactivate an account',
+	{tag: '@LPD-44526'},
+	async ({accountsPage, apiHelpers, page}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
 
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account.name)
-		).click();
-
-		await expect(accountsPage.deactivateButton).toBeVisible({timeout: 300});
-	}).toPass();
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toBeVisible();
-
-	await (await accountsPage.accountsTable.rowActions(account.name)).click();
-	await accountsPage.activateButton.click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Active').click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toBeVisible();
-});
-
-test('LPD-44526 Can deactivate and activate accounts in bulk', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	const accounts = [];
-
-	for (let i = 1; i < 7; i++) {
 		const account = await apiHelpers.headlessAdminUser.postAccount({
-			name: `Account ${i}`,
+			name: getRandomString(),
 			type: 'business',
 		});
 
-		accounts.push(account);
-	}
+		await accountsPage.goto();
 
-	await accountsPage.goto();
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account.name)
+			).click();
 
-	const accountNames: string[] = [
-		accounts[0].name,
-		accounts[2].name,
-		accounts[4].name,
-	];
-
-	for (const name of accountNames) {
-		await (await accountsPage.accountsTable.rowCheckbox(name)).click();
-	}
-
-	page.on('dialog', async (dialog) => await dialog.accept());
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	for (const name of accountNames) {
-		try {
-			await accountsPage.accountsTable.cellLink(name);
-		}
-		catch (error) {
-			expect(error).toBeDefined();
-		}
-	}
-
-	await accountsPage.changeFilter('Inactive');
-
-	for (const name of accountNames) {
-		await expect(
-			(await accountsPage.accountsTable.row(1, name, true)).row
-		).toBeVisible();
-	}
-
-	for (const name of accountNames) {
-		await (await accountsPage.accountsTable.rowCheckbox(name)).click();
-	}
-
-	await accountsPage.activateButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.noAccountsMessage).toBeVisible();
-
-	await accountsPage.changeFilter('Active');
-
-	for (const account of accounts) {
-		await expect(
-			(await accountsPage.accountsTable.row(1, account.name, true)).row
-		).toBeVisible();
-	}
-});
-
-test('LPD-45897 Can delete an account', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	page.on('dialog', (dialog) => {
-		dialog.accept().catch(() => {});
-	});
-
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account.name)
-		).click();
-
-		await expect(accountsPage.deleteButton).toBeVisible({timeout: 300});
-	}).toPass();
-
-	await accountsPage.deleteButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-});
-
-test('LPD-45897 Can delete an inactive account', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	page.on('dialog', (dialog) => {
-		dialog.accept().catch(() => {});
-	});
-
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account.name)
-		).click();
-
-		await expect(accountsPage.deactivateButton).toBeVisible({timeout: 500});
-	}).toPass();
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await expect(accountsPage.accountsTable.searchInput).toBeEnabled();
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(1);
-
-	await (await accountsPage.accountsTable.rowActions(account.name)).click();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account.name)
-		).click();
-
-		await expect(accountsPage.deleteButton).toBeVisible({timeout: 500});
-	}).toPass();
-
-	await accountsPage.deleteButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-});
-
-test('LPD-45897 Can delete accounts in bulk', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	page.on('dialog', async (dialog) => await dialog.accept());
-
-	for (let i = 1; i < 7; i++) {
-		if (i < 4) {
-			await apiHelpers.headlessAdminUser.postAccount({
-				name: `Account ${i}`,
-				type: 'business',
+			await expect(accountsPage.deactivateButton).toBeVisible({
+				timeout: 300,
 			});
-		}
-		else {
-			await apiHelpers.headlessAdminUser.postAccount({
-				name: `Account ${i}`,
-				type: 'person',
-			});
-		}
-	}
+		}).toPass();
 
-	await accountsPage.goto();
+		await accountsPage.deactivateButton.click();
 
-	for (const i of [1, 2, 4, 6]) {
-		await (
-			await accountsPage.accountsTable.rowCheckbox(`Account ${i}`)
-		).click();
-	}
+		await waitForAlert(page);
 
-	await accountsPage.deleteButton.click();
-
-	await waitForAlert(page);
-
-	for (const i of [1, 2, 4, 6]) {
-		await expect(
-			accountsPage.accountsTable.cell(`Account ${i}`)
-		).not.toBeVisible();
-	}
-
-	for (const i of [3, 5]) {
-		await expect(
-			accountsPage.accountsTable.cell(`Account ${i}`)
-		).toBeVisible();
-	}
-
-	await accountsPage.changeFilter('Inactive');
-
-	await expect(accountsPage.noAccountsMessage).toBeVisible();
-});
-
-test('LPS-195988 An account name should be limited to 250 characters', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-}) => {
-	const name =
-		'Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet';
-
-	await accountsPage.goto();
-
-	await expect(accountsPage.accountsTable.searchInput).toBeEditable();
-
-	await accountsPage.accountsTable.newButton.click();
-	await editAccountPage.createAccount(apiHelpers, {name});
-	await editAccountPage.backButton.click();
-
-	await expect(accountsPage.accountsTable.cell(name)).toHaveCount(0);
-	await expect(
-		accountsPage.accountsTable.cell(name.substring(0, 250))
-	).toBeVisible();
-
-	await (
-		await accountsPage.accountsTable.cellLink(name.substring(0, 250))
-	).click();
-
-	await expect(editAccountPage.accountNameInput).toHaveValue(
-		name.substring(0, 250)
-	);
-});
-
-test('LPS-195988 The account external reference code should be unique', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		externalReferenceCode: getRandomString(),
-		name: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(accountsPage.accountsTable.searchInput).toBeEditable();
-
-	await accountsPage.accountsTable.newButton.click();
-	await editAccountPage.accountNameInput.fill(getRandomString());
-	await editAccountPage.externalReferenceCodeInput.fill(
-		account.externalReferenceCode
-	);
-
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(
-		page,
-		'The given external reference code belongs to another account',
-		{type: 'danger'}
-	);
-});
-
-test('LPS-195988 Can create different type of accounts', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-}) => {
-	await accountsPage.goto();
-
-	await expect(accountsPage.accountsTable.searchInput).toBeEditable();
-
-	const accounts = [
-		{name: getRandomString(), type: 'business'},
-		{name: getRandomString(), type: 'guest'},
-		{name: getRandomString(), type: 'person'},
-		{name: getRandomString(), type: 'supplier'},
-	];
-
-	for (const {name, type} of accounts) {
-		await accountsPage.accountsTable.newButton.click();
-		await editAccountPage.createAccount(apiHelpers, {name, type});
-		await editAccountPage.backButton.click();
-
-		await expect(
-			await accountsPage.accountsTable.cellLink(name)
-		).toBeVisible();
-
-		await (await accountsPage.accountsTable.cellLink(name)).click();
-
-		await expect(editAccountPage.accountNameInput).toBeVisible();
-		await expect(editAccountPage.typeInput).toHaveValue(
-			new RegExp(type, 'i')
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
 		);
 
-		await editAccountPage.backButton.click();
-	}
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
 
-	for (const account of accounts) {
+		await expect(
+			accountsPage.accountsTable.cell(account.name)
+		).toBeVisible();
+
+		await (
+			await accountsPage.accountsTable.rowActions(account.name)
+		).click();
+		await accountsPage.activateButton.click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Active').click();
+
 		await expect(
 			accountsPage.accountsTable.cell(account.name)
 		).toBeVisible();
 	}
+);
 
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Business').click();
+test(
+	'Can deactivate and activate accounts in bulk',
+	{tag: '@LPD-44526'},
+	async ({accountsPage, apiHelpers, page}) => {
+		const accounts = [];
 
-	for (const account of accounts) {
-		if (account.type === 'business') {
+		for (let i = 1; i < 7; i++) {
+			const account = await apiHelpers.headlessAdminUser.postAccount({
+				name: `Account ${i}`,
+				type: 'business',
+			});
+
+			accounts.push(account);
+		}
+
+		await accountsPage.goto();
+
+		const accountNames: string[] = [
+			accounts[0].name,
+			accounts[2].name,
+			accounts[4].name,
+		];
+
+		for (const name of accountNames) {
+			await (await accountsPage.accountsTable.rowCheckbox(name)).click();
+		}
+
+		page.on('dialog', async (dialog) => await dialog.accept());
+
+		await accountsPage.deactivateButton.click();
+
+		await waitForAlert(page);
+
+		for (const name of accountNames) {
+			try {
+				await accountsPage.accountsTable.cellLink(name);
+			}
+			catch (error) {
+				expect(error).toBeDefined();
+			}
+		}
+
+		await accountsPage.changeFilter('Inactive');
+
+		for (const name of accountNames) {
 			await expect(
-				accountsPage.accountsTable.cell(account.name)
+				(await accountsPage.accountsTable.row(1, name, true)).row
 			).toBeVisible();
 		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
+
+		for (const name of accountNames) {
+			await (await accountsPage.accountsTable.rowCheckbox(name)).click();
 		}
-	}
 
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Guest').click();
+		await accountsPage.activateButton.click();
 
-	for (const account of accounts) {
-		if (account.type === 'guest') {
+		await waitForAlert(page);
+
+		await expect(accountsPage.noAccountsMessage).toBeVisible();
+
+		await accountsPage.changeFilter('Active');
+
+		for (const account of accounts) {
 			await expect(
-				accountsPage.accountsTable.cell(account.name)
+				(await accountsPage.accountsTable.row(1, account.name, true))
+					.row
 			).toBeVisible();
 		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
-		}
 	}
+);
 
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Person').click();
+test(
+	'Can delete an account',
+	{tag: '@LPD-45897'},
+	async ({accountsPage, apiHelpers, page}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
 
-	for (const account of accounts) {
-		if (account.type === 'person') {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toBeVisible();
-		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
-		}
-	}
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Supplier').click();
-
-	for (const account of accounts) {
-		if (account.type === 'supplier') {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toBeVisible();
-		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
-		}
-	}
-});
-
-test('LPS-195988 Multiple accounts can be added with the same domain', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	emailDomainsInstanceSettingsPage,
-}) => {
-	const accounts = [
-		{
-			domains: ['liferay.com'],
+		const account = await apiHelpers.headlessAdminUser.postAccount({
 			name: getRandomString(),
 			type: 'business',
-		},
-		{
-			domains: ['liferay.com'],
+		});
+
+		await accountsPage.goto();
+
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account.name)
+			).click();
+
+			await expect(accountsPage.deleteButton).toBeVisible({timeout: 300});
+		}).toPass();
+
+		await accountsPage.deleteButton.click();
+
+		await waitForAlert(page);
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+	}
+);
+
+test(
+	'Can delete an inactive account',
+	{tag: '@LPD-45897'},
+	async ({accountsPage, apiHelpers, page}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
+
+		const account = await apiHelpers.headlessAdminUser.postAccount({
 			name: getRandomString(),
 			type: 'business',
-		},
-	];
+		});
 
-	await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
+		await accountsPage.goto();
 
-	try {
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account.name)
+			).click();
+
+			await expect(accountsPage.deactivateButton).toBeVisible({
+				timeout: 500,
+			});
+		}).toPass();
+
+		await accountsPage.deactivateButton.click();
+
+		await waitForAlert(page);
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
+
+		await expect(accountsPage.accountsTable.searchInput).toBeEnabled();
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			1
+		);
+
+		await (
+			await accountsPage.accountsTable.rowActions(account.name)
+		).click();
+
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account.name)
+			).click();
+
+			await expect(accountsPage.deleteButton).toBeVisible({timeout: 500});
+		}).toPass();
+
+		await accountsPage.deleteButton.click();
+
+		await waitForAlert(page);
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+	}
+);
+
+test(
+	'Can delete accounts in bulk',
+	{tag: '@LPD-45897'},
+	async ({accountsPage, apiHelpers, page}) => {
+		page.on('dialog', async (dialog) => await dialog.accept());
+
+		for (let i = 1; i < 7; i++) {
+			if (i < 4) {
+				await apiHelpers.headlessAdminUser.postAccount({
+					name: `Account ${i}`,
+					type: 'business',
+				});
+			}
+			else {
+				await apiHelpers.headlessAdminUser.postAccount({
+					name: `Account ${i}`,
+					type: 'person',
+				});
+			}
+		}
+
+		await accountsPage.goto();
+
+		for (const i of [1, 2, 4, 6]) {
+			await (
+				await accountsPage.accountsTable.rowCheckbox(`Account ${i}`)
+			).click();
+		}
+
+		await accountsPage.deleteButton.click();
+
+		await waitForAlert(page);
+
+		for (const i of [1, 2, 4, 6]) {
+			await expect(
+				accountsPage.accountsTable.cell(`Account ${i}`)
+			).not.toBeVisible();
+		}
+
+		for (const i of [3, 5]) {
+			await expect(
+				accountsPage.accountsTable.cell(`Account ${i}`)
+			).toBeVisible();
+		}
+
+		await accountsPage.changeFilter('Inactive');
+
+		await expect(accountsPage.noAccountsMessage).toBeVisible();
+	}
+);
+
+test(
+	'An account name should be limited to 250 characters',
+	{tag: '@LPS-195988'},
+	async ({accountsPage, apiHelpers, editAccountPage}) => {
+		const name =
+			'Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet';
+
 		await accountsPage.goto();
 
 		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
 
-		for (const {domains, name, type} of accounts) {
+		await accountsPage.accountsTable.newButton.click();
+		await editAccountPage.createAccount(apiHelpers, {name});
+		await editAccountPage.backButton.click();
+
+		await expect(accountsPage.accountsTable.cell(name)).toHaveCount(0);
+		await expect(
+			accountsPage.accountsTable.cell(name.substring(0, 250))
+		).toBeVisible();
+
+		await (
+			await accountsPage.accountsTable.cellLink(name.substring(0, 250))
+		).click();
+
+		await expect(editAccountPage.accountNameInput).toHaveValue(
+			name.substring(0, 250)
+		);
+	}
+);
+
+test(
+	'The account external reference code should be unique',
+	{tag: '@LPS-195988'},
+	async ({accountsPage, apiHelpers, editAccountPage, page}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			externalReferenceCode: getRandomString(),
+			name: getRandomString(),
+			type: 'business',
+		});
+
+		await accountsPage.goto();
+
+		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+
+		await accountsPage.accountsTable.newButton.click();
+		await editAccountPage.accountNameInput.fill(getRandomString());
+		await editAccountPage.externalReferenceCodeInput.fill(
+			account.externalReferenceCode
+		);
+
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(
+			page,
+			'The given external reference code belongs to another account',
+			{type: 'danger'}
+		);
+	}
+);
+
+test(
+	'Can create different type of accounts',
+	{tag: '@LPS-195988'},
+	async ({accountsPage, apiHelpers, editAccountPage}) => {
+		await accountsPage.goto();
+
+		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+
+		const accounts = [
+			{name: getRandomString(), type: 'business'},
+			{name: getRandomString(), type: 'guest'},
+			{name: getRandomString(), type: 'person'},
+			{name: getRandomString(), type: 'supplier'},
+		];
+
+		for (const {name, type} of accounts) {
+			await accountsPage.accountsTable.newButton.click();
+			await editAccountPage.createAccount(apiHelpers, {name, type});
+			await editAccountPage.backButton.click();
+
+			await expect(
+				await accountsPage.accountsTable.cellLink(name)
+			).toBeVisible();
+
+			await (await accountsPage.accountsTable.cellLink(name)).click();
+
+			await expect(editAccountPage.accountNameInput).toBeVisible();
+			await expect(editAccountPage.typeInput).toHaveValue(
+				new RegExp(type, 'i')
+			);
+
+			await editAccountPage.backButton.click();
+		}
+
+		for (const account of accounts) {
+			await expect(
+				accountsPage.accountsTable.cell(account.name)
+			).toBeVisible();
+		}
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Business').click();
+
+		for (const account of accounts) {
+			if (account.type === 'business') {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+		}
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Guest').click();
+
+		for (const account of accounts) {
+			if (account.type === 'guest') {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+		}
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Person').click();
+
+		for (const account of accounts) {
+			if (account.type === 'person') {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+		}
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Supplier').click();
+
+		for (const account of accounts) {
+			if (account.type === 'supplier') {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+		}
+	}
+);
+
+test(
+	'Multiple accounts can be added with the same domain',
+	{tag: '@LPS-195988'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+		emailDomainsInstanceSettingsPage,
+	}) => {
+		const accounts = [
+			{
+				domains: ['liferay.com'],
+				name: getRandomString(),
+				type: 'business',
+			},
+			{
+				domains: ['liferay.com'],
+				name: getRandomString(),
+				type: 'business',
+			},
+		];
+
+		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
+
+		try {
+			await accountsPage.goto();
+
+			await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+
+			for (const {domains, name, type} of accounts) {
+				await accountsPage.accountsTable.newButton.click();
+				await editAccountPage.createAccount(apiHelpers, {
+					domains,
+					name,
+					type,
+				});
+
+				for (const domain of domains) {
+					await expect(
+						editAccountPage.domainCell(domain)
+					).toBeVisible();
+				}
+
+				await editAccountPage.backButton.click();
+
+				await (await accountsPage.accountsTable.cellLink(name)).click();
+
+				for (const domain of domains) {
+					await expect(
+						editAccountPage.domainCell(domain)
+					).toBeVisible();
+				}
+
+				await editAccountPage.backButton.click();
+			}
+		}
+		finally {
+			await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
+				false
+			);
+		}
+	}
+);
+
+test(
+	'A business account can have more than one domain',
+	{tag: '@LPS-195988'},
+	async ({
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+		emailDomainsInstanceSettingsPage,
+	}) => {
+		const account = {
+			domains: ['liferay.com', 'google.com', 'si-na.com', '9teen.com'],
+			name: getRandomString(),
+			type: 'business',
+		};
+
+		const {domains, name, type} = account;
+
+		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
+
+		try {
+			await accountsPage.goto();
+
+			await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+
 			await accountsPage.accountsTable.newButton.click();
 			await editAccountPage.createAccount(apiHelpers, {
 				domains,
@@ -819,510 +942,511 @@ test('LPS-195988 Multiple accounts can be added with the same domain', async ({
 
 			await (await accountsPage.accountsTable.cellLink(name)).click();
 
-			for (const domain of domains) {
-				await expect(editAccountPage.domainCell(domain)).toBeVisible();
-			}
+			await editAccountPage.domainRemoveButton(domains[0]).click();
 
-			await editAccountPage.backButton.click();
+			for (const [index, domain] of domains.entries()) {
+				if (index === 0) {
+					await expect(
+						editAccountPage.domainCell(domain)
+					).toHaveCount(0);
+				}
+				else {
+					await expect(
+						editAccountPage.domainCell(domain)
+					).toBeVisible();
+				}
+			}
+		}
+		finally {
+			await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
+				false
+			);
 		}
 	}
-	finally {
-		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
-			false
-		);
+);
+
+test(
+	'Domain validation is not present in Person Accounts',
+	{tag: '@LPS-195988'},
+	async ({
+		accountsPage,
+		editAccountPage,
+		emailDomainsInstanceSettingsPage,
+	}) => {
+		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
+
+		try {
+			await accountsPage.goto();
+
+			await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+
+			await accountsPage.accountsTable.newButton.click();
+
+			await expect(editAccountPage.validDomainsHeading).toBeVisible();
+
+			await editAccountPage.typeInput.selectOption('person');
+
+			await expect(editAccountPage.validDomainsHeading).toHaveCount(0);
+
+			await editAccountPage.typeInput.selectOption('business');
+
+			await expect(editAccountPage.validDomainsHeading).toBeVisible();
+		}
+		finally {
+			await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
+				false
+			);
+		}
 	}
-});
+);
 
-test('LPS-195988 A business account can have more than one domain', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	emailDomainsInstanceSettingsPage,
-}) => {
-	const account = {
-		domains: ['liferay.com', 'google.com', 'si-na.com', '9teen.com'],
-		name: getRandomString(),
-		type: 'business',
-	};
+test(
+	'Account list should be paginated',
+	{tag: '@LPS-101893'},
+	async ({accountsPage, apiHelpers, page}) => {
+		const accounts = [];
 
-	const {domains, name, type} = account;
+		for (let i = 1; i <= 21; i++) {
+			const account = await apiHelpers.headlessAdminUser.postAccount({
+				name: `Account ${String(i).padStart(2, '0')}`,
+				type: 'business',
+			});
 
-	await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
+			accounts.push(account);
+		}
 
-	try {
+		await accountsPage.goto();
+
+		await setItemsPerPage(page, 20);
+
+		for (const [index, account] of accounts.entries()) {
+			if (index < 20) {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+		}
+
+		await nextPage(page);
+
+		for (const [index, account] of accounts.entries()) {
+			if (index < 20) {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toHaveCount(0);
+			}
+			else {
+				await expect(
+					accountsPage.accountsTable.cell(account.name)
+				).toBeVisible();
+			}
+		}
+	}
+);
+
+test(
+	'An account avatar can be added in creation',
+	{tag: '@LPS-157661'},
+	async ({accountsPage, apiHelpers, editAccountPage}) => {
+		const name = getRandomString();
+
 		await accountsPage.goto();
 
 		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
 
 		await accountsPage.accountsTable.newButton.click();
-		await editAccountPage.createAccount(apiHelpers, {domains, name, type});
-
-		for (const domain of domains) {
-			await expect(editAccountPage.domainCell(domain)).toBeVisible();
-		}
-
+		await editAccountPage.createAccount(apiHelpers, {
+			avatar: path.join(__dirname, '/dependencies/liferay.png'),
+			name,
+		});
 		await editAccountPage.backButton.click();
 
 		await (await accountsPage.accountsTable.cellLink(name)).click();
 
-		await editAccountPage.domainRemoveButton(domains[0]).click();
-
-		for (const [index, domain] of domains.entries()) {
-			if (index === 0) {
-				await expect(editAccountPage.domainCell(domain)).toHaveCount(0);
-			}
-			else {
-				await expect(editAccountPage.domainCell(domain)).toBeVisible();
-			}
-		}
+		await expect(editAccountPage.imageInput).toHaveValue('Custom Image');
 	}
-	finally {
-		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
-			false
-		);
-	}
-});
+);
 
-test('LPS-195988 Domain validation is not present in Person Accounts', async ({
-	accountsPage,
-	editAccountPage,
-	emailDomainsInstanceSettingsPage,
-}) => {
-	await emailDomainsInstanceSettingsPage.enableEmailDomainValidation();
-
-	try {
-		await accountsPage.goto();
-
-		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
-
-		await accountsPage.accountsTable.newButton.click();
-
-		await expect(editAccountPage.validDomainsHeading).toBeVisible();
-
-		await editAccountPage.typeInput.selectOption('person');
-
-		await expect(editAccountPage.validDomainsHeading).toHaveCount(0);
-
-		await editAccountPage.typeInput.selectOption('business');
-
-		await expect(editAccountPage.validDomainsHeading).toBeVisible();
-	}
-	finally {
-		await emailDomainsInstanceSettingsPage.enableEmailDomainValidation(
-			false
-		);
-	}
-});
-
-test('LPS-101893 Account list should be paginated', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	const accounts = [];
-
-	for (let i = 1; i <= 21; i++) {
+test(
+	'An account can be updated',
+	{tag: '@LPS-195988'},
+	async ({accountsPage, apiHelpers, editAccountPage, page}) => {
 		const account = await apiHelpers.headlessAdminUser.postAccount({
-			name: `Account ${String(i).padStart(2, '0')}`,
+			description: getRandomString(),
 			type: 'business',
 		});
 
-		accounts.push(account);
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		await expect(editAccountPage.accountNameInput).toHaveValue(
+			account.name
+		);
+		await expect(editAccountPage.descriptionInput).toHaveValue(
+			account.description
+		);
+		await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
+			account.externalReferenceCode
+		);
+
+		const updatedAccount = {
+			description: getRandomString(),
+			externalReferenceCode: getRandomString(),
+			name: getRandomString(),
+		};
+
+		await editAccountPage.accountNameInput.fill(updatedAccount.name);
+		await editAccountPage.descriptionInput.fill(updatedAccount.description);
+		await editAccountPage.externalReferenceCodeInput.fill(
+			updatedAccount.externalReferenceCode
+		);
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await editAccountPage.backButton.click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+
+		await accountsPage.accountNameLink(updatedAccount.name).click();
+
+		await expect(editAccountPage.accountNameInput).toHaveValue(
+			updatedAccount.name
+		);
+		await expect(editAccountPage.descriptionInput).toHaveValue(
+			updatedAccount.description
+		);
+		await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
+			updatedAccount.externalReferenceCode
+		);
 	}
+);
 
-	await accountsPage.goto();
+test(
+	'An inactive account can be updated',
+	{tag: '@LPS-101221'},
+	async ({accountsPage, apiHelpers, editAccountPage, page}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
 
-	await setItemsPerPage(page, 20);
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			description: getRandomString(),
+			type: 'business',
+		});
 
-	for (const [index, account] of accounts.entries()) {
-		if (index < 20) {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toBeVisible();
-		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
-		}
+		await accountsPage.goto();
+
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account.name)
+			).click();
+
+			await expect(accountsPage.deactivateButton).toBeVisible({
+				timeout: 300,
+			});
+		}).toPass();
+
+		await accountsPage.deactivateButton.click();
+
+		await waitForAlert(page);
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		await expect(editAccountPage.accountNameInput).toHaveValue(
+			account.name
+		);
+		await expect(editAccountPage.descriptionInput).toHaveValue(
+			account.description
+		);
+		await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
+			account.externalReferenceCode
+		);
+
+		const updatedAccount = {
+			description: getRandomString(),
+			externalReferenceCode: getRandomString(),
+			name: getRandomString(),
+		};
+
+		await editAccountPage.accountNameInput.fill(updatedAccount.name);
+		await editAccountPage.descriptionInput.fill(updatedAccount.description);
+		await editAccountPage.externalReferenceCodeInput.fill(
+			updatedAccount.externalReferenceCode
+		);
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await editAccountPage.backButton.click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+		await expect(
+			accountsPage.accountsTable.cell(updatedAccount.name)
+		).toBeVisible();
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Active').click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+		await expect(
+			accountsPage.accountsTable.cell(updatedAccount.name)
+		).toHaveCount(0);
+
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
+
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+		await expect(
+			accountsPage.accountsTable.cell(updatedAccount.name)
+		).toBeVisible();
 	}
+);
 
-	await nextPage(page);
+test(
+	'Can search an account',
+	{tag: '@LPS-101221'},
+	async ({accountsPage, apiHelpers, page}) => {
+		page.on('dialog', (dialog) => {
+			dialog.accept().catch(() => {});
+		});
 
-	for (const [index, account] of accounts.entries()) {
-		if (index < 20) {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toHaveCount(0);
-		}
-		else {
-			await expect(
-				accountsPage.accountsTable.cell(account.name)
-			).toBeVisible();
-		}
-	}
-});
+		const account1 = await apiHelpers.headlessAdminUser.postAccount({
+			description: getRandomString(),
+			type: 'business',
+		});
+		const account2 = await apiHelpers.headlessAdminUser.postAccount({
+			description: getRandomString(),
+			type: 'business',
+		});
 
-test('LPS-157661 An account avatar can be added in creation', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-}) => {
-	const name = getRandomString();
+		await accountsPage.goto();
 
-	await accountsPage.goto();
+		await expect(async () => {
+			await (
+				await accountsPage.accountsTable.rowActions(account1.name)
+			).click();
 
-	await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+			await expect(accountsPage.deactivateButton).toBeVisible({
+				timeout: 300,
+			});
+		}).toPass();
 
-	await accountsPage.accountsTable.newButton.click();
-	await editAccountPage.createAccount(apiHelpers, {
-		avatar: path.join(__dirname, '/dependencies/liferay.png'),
-		name,
-	});
-	await editAccountPage.backButton.click();
+		await accountsPage.deactivateButton.click();
 
-	await (await accountsPage.accountsTable.cellLink(name)).click();
+		await waitForAlert(page);
 
-	await expect(editAccountPage.imageInput).toHaveValue('Custom Image');
-});
-
-test('LPS-195988 An account can be updated', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		description: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await accountsPage.accountNameLink(account.name).click();
-
-	await expect(editAccountPage.accountNameInput).toHaveValue(account.name);
-	await expect(editAccountPage.descriptionInput).toHaveValue(
-		account.description
-	);
-	await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
-		account.externalReferenceCode
-	);
-
-	const updatedAccount = {
-		description: getRandomString(),
-		externalReferenceCode: getRandomString(),
-		name: getRandomString(),
-	};
-
-	await editAccountPage.accountNameInput.fill(updatedAccount.name);
-	await editAccountPage.descriptionInput.fill(updatedAccount.description);
-	await editAccountPage.externalReferenceCodeInput.fill(
-		updatedAccount.externalReferenceCode
-	);
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(page);
-
-	await editAccountPage.backButton.click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-
-	await accountsPage.accountNameLink(updatedAccount.name).click();
-
-	await expect(editAccountPage.accountNameInput).toHaveValue(
-		updatedAccount.name
-	);
-	await expect(editAccountPage.descriptionInput).toHaveValue(
-		updatedAccount.description
-	);
-	await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
-		updatedAccount.externalReferenceCode
-	);
-});
-
-test('LPS-101221 An inactive account can be updated', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-}) => {
-	page.on('dialog', (dialog) => {
-		dialog.accept().catch(() => {});
-	});
-
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		description: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account.name)
-		).click();
-
-		await expect(accountsPage.deactivateButton).toBeVisible({timeout: 300});
-	}).toPass();
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await accountsPage.accountNameLink(account.name).click();
-
-	await expect(editAccountPage.accountNameInput).toHaveValue(account.name);
-	await expect(editAccountPage.descriptionInput).toHaveValue(
-		account.description
-	);
-	await expect(editAccountPage.externalReferenceCodeInput).toHaveValue(
-		account.externalReferenceCode
-	);
-
-	const updatedAccount = {
-		description: getRandomString(),
-		externalReferenceCode: getRandomString(),
-		name: getRandomString(),
-	};
-
-	await editAccountPage.accountNameInput.fill(updatedAccount.name);
-	await editAccountPage.descriptionInput.fill(updatedAccount.description);
-	await editAccountPage.externalReferenceCodeInput.fill(
-		updatedAccount.externalReferenceCode
-	);
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(page);
-
-	await editAccountPage.backButton.click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-	await expect(
-		accountsPage.accountsTable.cell(updatedAccount.name)
-	).toBeVisible();
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Active').click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-	await expect(
-		accountsPage.accountsTable.cell(updatedAccount.name)
-	).toHaveCount(0);
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-	await expect(
-		accountsPage.accountsTable.cell(updatedAccount.name)
-	).toBeVisible();
-});
-
-test('LPS-101221 Can search an account', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	page.on('dialog', (dialog) => {
-		dialog.accept().catch(() => {});
-	});
-
-	const account1 = await apiHelpers.headlessAdminUser.postAccount({
-		description: getRandomString(),
-		type: 'business',
-	});
-	const account2 = await apiHelpers.headlessAdminUser.postAccount({
-		description: getRandomString(),
-		type: 'business',
-	});
-
-	await accountsPage.goto();
-
-	await expect(async () => {
-		await (
-			await accountsPage.accountsTable.rowActions(account1.name)
-		).click();
-
-		await expect(accountsPage.deactivateButton).toBeVisible({timeout: 300});
-	}).toPass();
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	await accountsPage.accountsTable.search(account1.name);
-
-	await expect(accountsPage.accountsTable.cell(account1.name)).toHaveCount(0);
-	await expect(accountsPage.accountsTable.cell(account2.name)).toHaveCount(0);
-
-	await accountsPage.accountsTable.search(account2.name);
-
-	await expect(accountsPage.accountsTable.cell(account1.name)).toHaveCount(0);
-	await expect(accountsPage.accountsTable.cell(account2.name)).toBeVisible();
-
-	await expect(accountsPage.accountsTable.searchInput).toBeEnabled();
-
-	await accountsPage.accountsTable.filterButton.click();
-	await accountsPage.accountsTable.filterMenuItem('Inactive').click();
-
-	await expect(async () => {
 		await accountsPage.accountsTable.search(account1.name);
 
 		await expect(
 			accountsPage.accountsTable.cell(account1.name)
-		).toBeVisible({timeout: 500});
+		).toHaveCount(0);
 		await expect(
 			accountsPage.accountsTable.cell(account2.name)
 		).toHaveCount(0);
-	}).toPass();
-});
 
-test('LPD-47225 Can edit account custom fields', async ({
-	accountsPage,
-	addCustomFieldPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-}) => {
-	const customField: TCustomField = {
-		fieldName: getRandomString(),
-		fieldType: 'inputField',
-		resource: 'Account Entry',
-	};
+		await accountsPage.accountsTable.search(account2.name);
 
-	await addCustomFieldPage.addCustomField(customField);
+		await expect(
+			accountsPage.accountsTable.cell(account1.name)
+		).toHaveCount(0);
+		await expect(
+			accountsPage.accountsTable.cell(account2.name)
+		).toBeVisible();
 
-	const account = await apiHelpers.headlessAdminUser.postAccount();
+		await expect(accountsPage.accountsTable.searchInput).toBeEnabled();
 
-	await accountsPage.goto();
+		await accountsPage.accountsTable.filterButton.click();
+		await accountsPage.accountsTable.filterMenuItem('Inactive').click();
 
-	await accountsPage.accountNameLink(account.name).click();
+		await expect(async () => {
+			await accountsPage.accountsTable.search(account1.name);
 
-	const randomString = getRandomString();
-
-	await editAccountPage
-		.customFieldInput(customField.fieldName)
-		.fill(randomString);
-
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(page);
-
-	await accountsPage.goto();
-
-	await accountsPage.accountNameLink(account.name).click();
-
-	await expect(
-		editAccountPage.customFieldInput(customField.fieldName)
-	).toHaveValue(randomString);
-});
-
-test('LPD-47225 Can add and remove categories to an account', async ({
-	accountCategorySelectorPage,
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-}) => {
-	const categoryNames = [
-		{name: getRandomString()},
-		{name: getRandomString()},
-	];
-	const vocabularyName = getRandomString();
-
-	const categories: Array<any> = await createCategories({
-		apiHelpers,
-		categoryNames,
-		siteId: await getGlobalSiteId(apiHelpers),
-		vocabularyName,
-	});
-
-	apiHelpers.data.push({
-		id: categories[0].vocabularyId,
-		type: 'taxonomyVocabulary',
-	});
-
-	const account = await apiHelpers.headlessAdminUser.postAccount();
-
-	await accountsPage.goto();
-
-	await accountsPage.accountNameLink(account.name).click();
-	await editAccountPage.selectCategoriesButton(vocabularyName).click();
-	await accountCategorySelectorPage.selectCategories(
-		[categoryNames[0].name],
-		vocabularyName
-	);
-
-	await expect(editAccountPage.vocabularyLabel(vocabularyName)).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[0].name)
-	).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[1].name)
-	).toHaveCount(0);
-
-	await editAccountPage.selectCategoriesButton(vocabularyName).click();
-	await accountCategorySelectorPage.selectCategories(
-		[categoryNames[1].name],
-		vocabularyName
-	);
-
-	await expect(editAccountPage.vocabularyLabel(vocabularyName)).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[0].name)
-	).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[1].name)
-	).toBeVisible();
-
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(page);
-
-	await accountsPage.goto();
-
-	await accountsPage.accountNameLink(account.name).click();
-
-	await expect(editAccountPage.vocabularyLabel(vocabularyName)).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[0].name)
-	).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[1].name)
-	).toBeVisible();
-
-	await editAccountPage.categoryClearAllButton.click();
-
-	await expect(async () => {
-		await editAccountPage.categoryLabel(vocabularyName).press('Tab');
-
-		await expect(editAccountPage.saveButton).toBeVisible();
-	}).toPass();
-
-	await editAccountPage.saveButton.click();
-
-	await waitForAlert(page);
-
-	await accountsPage.goto();
-
-	await accountsPage.accountNameLink(account.name).click();
-
-	await expect(editAccountPage.vocabularyLabel(vocabularyName)).toBeVisible();
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[0].name)
-	).toHaveCount(0);
-	await expect(
-		editAccountPage.categoryLabel(categoryNames[1].name)
-	).toHaveCount(0);
-});
+			await expect(
+				accountsPage.accountsTable.cell(account1.name)
+			).toBeVisible({timeout: 500});
+			await expect(
+				accountsPage.accountsTable.cell(account2.name)
+			).toHaveCount(0);
+		}).toPass();
+	}
+);
 
 test(
-	'LPD-47225 Tabs are visile only after account creation',
-	{tag: ['@LPS-169033']},
+	'Can edit account custom fields',
+	{tag: '@LPD-47225'},
+	async ({
+		accountsPage,
+		addCustomFieldPage,
+		apiHelpers,
+		editAccountPage,
+		page,
+	}) => {
+		const customField: TCustomField = {
+			fieldName: getRandomString(),
+			fieldType: 'inputField',
+			resource: 'Account Entry',
+		};
+
+		await addCustomFieldPage.addCustomField(customField);
+
+		const account = await apiHelpers.headlessAdminUser.postAccount();
+
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		const randomString = getRandomString();
+
+		await editAccountPage
+			.customFieldInput(customField.fieldName)
+			.fill(randomString);
+
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		await expect(
+			editAccountPage.customFieldInput(customField.fieldName)
+		).toHaveValue(randomString);
+	}
+);
+
+test(
+	'Can add and remove categories to an account',
+	{tag: '@LPD-47225'},
+	async ({
+		accountCategorySelectorPage,
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+		page,
+	}) => {
+		const categoryNames = [
+			{name: getRandomString()},
+			{name: getRandomString()},
+		];
+		const vocabularyName = getRandomString();
+
+		const categories: Array<any> = await createCategories({
+			apiHelpers,
+			categoryNames,
+			siteId: await getGlobalSiteId(apiHelpers),
+			vocabularyName,
+		});
+
+		apiHelpers.data.push({
+			id: categories[0].vocabularyId,
+			type: 'taxonomyVocabulary',
+		});
+
+		const account = await apiHelpers.headlessAdminUser.postAccount();
+
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+		await editAccountPage.selectCategoriesButton(vocabularyName).click();
+		await accountCategorySelectorPage.selectCategories(
+			[categoryNames[0].name],
+			vocabularyName
+		);
+
+		await expect(
+			editAccountPage.vocabularyLabel(vocabularyName)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[0].name)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[1].name)
+		).toHaveCount(0);
+
+		await editAccountPage.selectCategoriesButton(vocabularyName).click();
+		await accountCategorySelectorPage.selectCategories(
+			[categoryNames[1].name],
+			vocabularyName
+		);
+
+		await expect(
+			editAccountPage.vocabularyLabel(vocabularyName)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[0].name)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[1].name)
+		).toBeVisible();
+
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		await expect(
+			editAccountPage.vocabularyLabel(vocabularyName)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[0].name)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[1].name)
+		).toBeVisible();
+
+		await editAccountPage.categoryClearAllButton.click();
+
+		await expect(async () => {
+			await editAccountPage.categoryLabel(vocabularyName).press('Tab');
+
+			await expect(editAccountPage.saveButton).toBeVisible();
+		}).toPass();
+
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await accountsPage.goto();
+
+		await accountsPage.accountNameLink(account.name).click();
+
+		await expect(
+			editAccountPage.vocabularyLabel(vocabularyName)
+		).toBeVisible();
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[0].name)
+		).toHaveCount(0);
+		await expect(
+			editAccountPage.categoryLabel(categoryNames[1].name)
+		).toHaveCount(0);
+	}
+);
+
+test(
+	'Tabs are visible only after account creation',
+	{tag: ['@LPD-47225', '@LPS-169033']},
 	async ({accountsPage, apiHelpers, editAccountPage}) => {
 		let account = {
 			name: getRandomString(),
@@ -1404,235 +1528,249 @@ test(
 	}
 );
 
-test('LPD-47225 Can add and remove tags to an account', async ({
-	accountTagSelectorPage,
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-	page,
-	tagsEditPage,
-}) => {
-	const tags = [
-		{name: getRandomString(), siteUrl: '/global'},
-		{name: getRandomString(), siteUrl: '/global'},
-		{name: getRandomString(), siteUrl: '/guest'},
-	];
+test(
+	'Can add and remove tags to an account',
+	{tag: '@LPD-47225'},
+	async ({
+		accountTagSelectorPage,
+		accountsPage,
+		apiHelpers,
+		editAccountPage,
+		page,
+		tagsEditPage,
+	}) => {
+		const tags = [
+			{name: getRandomString(), siteUrl: '/global'},
+			{name: getRandomString(), siteUrl: '/global'},
+			{name: getRandomString(), siteUrl: '/guest'},
+		];
 
-	for (const {name, siteUrl} of tags) {
-		await tagsEditPage.add(name, siteUrl);
-	}
+		for (const {name, siteUrl} of tags) {
+			await tagsEditPage.add(name, siteUrl);
+		}
 
-	const account = await apiHelpers.headlessAdminUser.postAccount();
+		const account = await apiHelpers.headlessAdminUser.postAccount();
 
-	await accountsPage.goto();
+		await accountsPage.goto();
 
-	await accountsPage.accountNameLink(account.name).click();
+		await accountsPage.accountNameLink(account.name).click();
 
-	await editAccountPage.selectTagsButton.click();
-	await accountTagSelectorPage.selectTag([tags[0].name, tags[1].name]);
+		await editAccountPage.selectTagsButton.click();
+		await accountTagSelectorPage.selectTag([tags[0].name, tags[1].name]);
 
-	await expect(editAccountPage.tagInput(tags[0].name)).toBeVisible();
-	await expect(editAccountPage.tagInput(tags[1].name)).toBeVisible();
-	await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
+		await expect(editAccountPage.tagInput(tags[0].name)).toBeVisible();
+		await expect(editAccountPage.tagInput(tags[1].name)).toBeVisible();
+		await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
 
-	await editAccountPage.saveButton.click();
+		await editAccountPage.saveButton.click();
 
-	await waitForAlert(page);
+		await waitForAlert(page);
 
-	await editAccountPage.backButton.click();
-	await accountsPage.accountNameLink(account.name).click();
+		await editAccountPage.backButton.click();
+		await accountsPage.accountNameLink(account.name).click();
 
-	await expect(editAccountPage.tagInput(tags[0].name)).toBeVisible();
-	await expect(editAccountPage.tagInput(tags[1].name)).toBeVisible();
-	await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
+		await expect(editAccountPage.tagInput(tags[0].name)).toBeVisible();
+		await expect(editAccountPage.tagInput(tags[1].name)).toBeVisible();
+		await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
 
-	await editAccountPage.categoryClearAllButton.click({force: true});
+		await editAccountPage.categoryClearAllButton.click({force: true});
 
-	await expect(async () => {
-		await editAccountPage.tagsCombobox.press('Tab');
+		await expect(async () => {
+			await editAccountPage.tagsCombobox.press('Tab');
+
+			await expect(editAccountPage.tagInput(tags[0].name)).toHaveCount(0);
+			await expect(editAccountPage.tagInput(tags[1].name)).toHaveCount(0);
+			await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
+		}).toPass();
+
+		await editAccountPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		await editAccountPage.backButton.click();
+		await accountsPage.accountNameLink(account.name).click();
 
 		await expect(editAccountPage.tagInput(tags[0].name)).toHaveCount(0);
 		await expect(editAccountPage.tagInput(tags[1].name)).toHaveCount(0);
 		await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
-	}).toPass();
+	}
+);
 
-	await editAccountPage.saveButton.click();
+test(
+	'Smoke test',
+	{tag: '@LPD-47225'},
+	async ({accountsPage, apiHelpers, editAccountPage}) => {
+		const account = {
+			name: getRandomString(),
+			taxID: getRandomString(),
+		};
 
-	await waitForAlert(page);
+		await accountsPage.goto();
 
-	await editAccountPage.backButton.click();
-	await accountsPage.accountNameLink(account.name).click();
+		await expect(accountsPage.accountsTable.searchInput).toBeEditable();
 
-	await expect(editAccountPage.tagInput(tags[0].name)).toHaveCount(0);
-	await expect(editAccountPage.tagInput(tags[1].name)).toHaveCount(0);
-	await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
-});
+		await accountsPage.accountsTable.newButton.click();
+		await editAccountPage.createAccount(apiHelpers, account);
+		await editAccountPage.backButton.click();
+		await accountsPage.accountsTable.search(account.name);
 
-test('LPD-47225 Smoke test', async ({
-	accountsPage,
-	apiHelpers,
-	editAccountPage,
-}) => {
-	const account = {
-		name: getRandomString(),
-		taxID: getRandomString(),
-	};
+		await expect(
+			accountsPage.accountsTable.cell(account.name)
+		).toBeVisible();
+		await expect(
+			(await accountsPage.accountsTable.row(1, account.name, true)).row
+		).toContainText('Active');
 
-	await accountsPage.goto();
+		await accountsPage.accountNameLink(account.name).click();
 
-	await expect(accountsPage.accountsTable.searchInput).toBeEditable();
+		await expect(editAccountPage.accountNameInput).toHaveValue(
+			account.name
+		);
+		await expect(editAccountPage.taxIDInput).toHaveValue(account.taxID);
+	}
+);
 
-	await accountsPage.accountsTable.newButton.click();
-	await editAccountPage.createAccount(apiHelpers, account);
-	await editAccountPage.backButton.click();
-	await accountsPage.accountsTable.search(account.name);
+test(
+	'Smoke test for service accounts',
+	{tag: '@LPD-47225'},
+	async ({editUserPage, page, serviceAccountsPage}) => {
+		const roleName = 'Portal Content Reviewer';
 
-	await expect(accountsPage.accountsTable.cell(account.name)).toBeVisible();
-	await expect(
-		(await accountsPage.accountsTable.row(1, account.name, true)).row
-	).toContainText('Active');
+		await serviceAccountsPage.goto();
 
-	await accountsPage.accountNameLink(account.name).click();
+		await expect(
+			serviceAccountsPage.usersTable.cell('default-service-account')
+		).toBeVisible();
 
-	await expect(editAccountPage.accountNameInput).toHaveValue(account.name);
-	await expect(editAccountPage.taxIDInput).toHaveValue(account.taxID);
-});
+		await (
+			await serviceAccountsPage.usersTable.cellLink(
+				'default-service-account',
+				1,
+				false
+			)
+		).click();
 
-test('LPD-47225 Smoke test for service accounts', async ({
-	editUserPage,
-	page,
-	serviceAccountsPage,
-}) => {
-	const roleName = 'Portal Content Reviewer';
+		await expect(editUserPage.appsLink).toBeVisible();
+		await expect(editUserPage.informationLink).toBeVisible();
+		await expect(editUserPage.membershipsLink).toBeVisible();
+		await expect(editUserPage.organizationsLink).toBeVisible();
+		await expect(editUserPage.passwordLink).toHaveCount(0);
+		await expect(editUserPage.profileAndDashboardLink).toBeVisible();
+		await expect(editUserPage.rolesLink).toBeVisible();
+		await expect(editUserPage.screenNameInput).toBeDisabled();
 
-	await serviceAccountsPage.goto();
+		await editUserPage.rolesLink.click();
+		await editUserPage.selectRegularRolesButton.click();
 
-	await expect(
-		serviceAccountsPage.usersTable.cell('default-service-account')
-	).toBeVisible();
+		await expect(editUserPage.selectRegularRolesSearchInput).toBeEnabled();
 
-	await (
-		await serviceAccountsPage.usersTable.cellLink(
-			'default-service-account',
-			1,
-			false
-		)
-	).click();
+		await editUserPage.selectRegularRolesChooseButton(roleName).click();
 
-	await expect(editUserPage.appsLink).toBeVisible();
-	await expect(editUserPage.informationLink).toBeVisible();
-	await expect(editUserPage.membershipsLink).toBeVisible();
-	await expect(editUserPage.organizationsLink).toBeVisible();
-	await expect(editUserPage.passwordLink).toHaveCount(0);
-	await expect(editUserPage.profileAndDashboardLink).toBeVisible();
-	await expect(editUserPage.rolesLink).toBeVisible();
-	await expect(editUserPage.screenNameInput).toBeDisabled();
+		await expect(editUserPage.regularRoleCell(roleName)).toBeVisible();
 
-	await editUserPage.rolesLink.click();
-	await editUserPage.selectRegularRolesButton.click();
+		await editUserPage.saveButton.click();
 
-	await expect(editUserPage.selectRegularRolesSearchInput).toBeEnabled();
+		await waitForAlert(page);
 
-	await editUserPage.selectRegularRolesChooseButton(roleName).click();
+		await page.reload();
 
-	await expect(editUserPage.regularRoleCell(roleName)).toBeVisible();
+		await expect(editUserPage.regularRoleCell(roleName)).toBeVisible();
 
-	await editUserPage.saveButton.click();
+		await editUserPage.regularRoleCellButton(roleName).click();
 
-	await waitForAlert(page);
+		await expect(editUserPage.regularRoleCell(roleName)).toHaveCount(0);
 
-	await page.reload();
+		await editUserPage.saveButton.click();
 
-	await expect(editUserPage.regularRoleCell(roleName)).toBeVisible();
+		await waitForAlert(page);
 
-	await editUserPage.regularRoleCellButton(roleName).click();
+		await page.reload();
 
-	await expect(editUserPage.regularRoleCell(roleName)).toHaveCount(0);
+		await expect(editUserPage.regularRoleCell(roleName)).toHaveCount(0);
+	}
+);
 
-	await editUserPage.saveButton.click();
+test(
+	'Check delete and deactivate permissions work independently',
+	{tag: '@LPD-47589'},
+	async ({accountsPage, apiHelpers, page}) => {
+		const account = await apiHelpers.headlessAdminUser.postAccount({
+			name: getRandomString(),
+			type: 'business',
+		});
 
-	await waitForAlert(page);
+		const companyId = await page.evaluate(() => {
+			return Liferay.ThemeDisplay.getCompanyId();
+		});
 
-	await page.reload();
+		const role = await apiHelpers.headlessAdminUser.postRole({
+			name: 'Test Role ' + getRandomString(),
+			rolePermissions: [
+				{
+					actionIds: ['VIEW_CONTROL_PANEL'],
+					primaryKey: companyId,
+					resourceName: '90',
+					scope: 1,
+				},
+				{
+					actionIds: ['ACCESS_IN_CONTROL_PANEL', 'VIEW'],
+					primaryKey: companyId,
+					resourceName:
+						'com_liferay_account_admin_web_internal_portlet_AccountEntriesAdminPortlet',
+					scope: 1,
+				},
+				{
+					actionIds: ['DEACTIVATE', 'UPDATE', 'VIEW'],
+					primaryKey: companyId,
+					resourceName: 'com.liferay.account.model.AccountEntry',
+					scope: 1,
+				},
+				{
+					actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+					primaryKey: companyId,
+					resourceName:
+						'com_liferay_depot_web_portlet_DepotAdminPortlet',
+					scope: 1,
+				},
+			],
+		});
 
-	await expect(editUserPage.regularRoleCell(roleName)).toHaveCount(0);
-});
+		const userAccount =
+			await apiHelpers.headlessAdminUser.postUserAccount();
 
-test('LPD-47589 Check delete and deactivate permissions work independently', async ({
-	accountsPage,
-	apiHelpers,
-	page,
-}) => {
-	const account = await apiHelpers.headlessAdminUser.postAccount({
-		name: getRandomString(),
-		type: 'business',
-	});
+		await apiHelpers.headlessAdminUser.postRoleByExternalReferenceCodeUserAccountAssociation(
+			role.externalReferenceCode,
+			userAccount.id
+		);
 
-	const companyId = await page.evaluate(() => {
-		return Liferay.ThemeDisplay.getCompanyId();
-	});
+		userData[userAccount.alternateName] = {
+			name: userAccount.givenName,
+			password: 'test',
+			surname: userAccount.familyName,
+		};
 
-	const role = await apiHelpers.headlessAdminUser.postRole({
-		name: 'Test Role ' + getRandomString(),
-		rolePermissions: [
-			{
-				actionIds: ['VIEW_CONTROL_PANEL'],
-				primaryKey: companyId,
-				resourceName: '90',
-				scope: 1,
-			},
-			{
-				actionIds: ['ACCESS_IN_CONTROL_PANEL', 'VIEW'],
-				primaryKey: companyId,
-				resourceName:
-					'com_liferay_account_admin_web_internal_portlet_AccountEntriesAdminPortlet',
-				scope: 1,
-			},
-			{
-				actionIds: ['DEACTIVATE', 'UPDATE', 'VIEW'],
-				primaryKey: companyId,
-				resourceName: 'com.liferay.account.model.AccountEntry',
-				scope: 1,
-			},
-			{
-				actionIds: ['ACCESS_IN_CONTROL_PANEL'],
-				primaryKey: companyId,
-				resourceName: 'com_liferay_depot_web_portlet_DepotAdminPortlet',
-				scope: 1,
-			},
-		],
-	});
+		await performUserSwitch(page, userAccount.alternateName);
 
-	const userAccount = await apiHelpers.headlessAdminUser.postUserAccount();
+		await accountsPage.goto();
 
-	await apiHelpers.headlessAdminUser.postRoleByExternalReferenceCodeUserAccountAssociation(
-		role.externalReferenceCode,
-		userAccount.id
-	);
+		await (
+			await accountsPage.accountsTable.rowActions(account.name)
+		).click();
 
-	userData[userAccount.alternateName] = {
-		name: userAccount.givenName,
-		password: 'test',
-		surname: userAccount.familyName,
-	};
+		await expect(await accountsPage.deactivateButton).toBeVisible();
+		await expect(await accountsPage.deleteButton).not.toBeVisible();
 
-	await performUserSwitch(page, userAccount.alternateName);
+		page.on('dialog', async (dialog) => await dialog.accept());
 
-	await accountsPage.goto();
+		await accountsPage.deactivateButton.click();
 
-	await (await accountsPage.accountsTable.rowActions(account.name)).click();
+		await waitForAlert(page);
 
-	await expect(await accountsPage.deactivateButton).toBeVisible();
-	await expect(await accountsPage.deleteButton).not.toBeVisible();
-
-	page.on('dialog', async (dialog) => await dialog.accept());
-
-	await accountsPage.deactivateButton.click();
-
-	await waitForAlert(page);
-
-	await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(0);
-});
+		await expect(accountsPage.accountsTable.cell(account.name)).toHaveCount(
+			0
+		);
+	}
+);
 
 test(
 	'Phone number and phone extension should display as phone number and phone extension',

--- a/modules/test/playwright/tests/account-admin-web/main/accounts.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/main/accounts.spec.ts
@@ -1446,10 +1446,10 @@ test('LPD-47225 Can add and remove tags to an account', async ({
 	await expect(editAccountPage.tagInput(tags[1].name)).toBeVisible();
 	await expect(editAccountPage.tagInput(tags[2].name)).toHaveCount(0);
 
-	await editAccountPage.categoryClearAllButton.click();
+	await editAccountPage.categoryClearAllButton.click({force: true});
 
 	await expect(async () => {
-		await page.getByLabel('Tags', {exact: true}).press('Tab');
+		await editAccountPage.tagsCombobox.press('Tab');
 
 		await expect(editAccountPage.tagInput(tags[0].name)).toHaveCount(0);
 		await expect(editAccountPage.tagInput(tags[1].name)).toHaveCount(0);

--- a/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor5-sample-web/pages/InputLocalizedPage.ts
@@ -57,18 +57,27 @@ export class InputLocalizedPage {
 
 	/**
 	 * Opens the editor's language dropdown, selects the given option, and
-	 * verifies the language button reflects the new locale. The whole flow is
-	 * retried as a unit: on slower environments the option click can register
-	 * as a highlight without committing the selection (the menu is still
-	 * rendering when the click lands), leaving the dropdown open and the locale
-	 * unchanged. Re-running open + click until the button text updates recovers
-	 * from that missed click instead of polling a value that never changes.
+	 * verifies the language button reflects the new locale.
+	 *
+	 * The dropdown menu is a portal aligned to its trigger. When the trigger
+	 * sits low on the page the menu opens below the viewport fold, so clicking
+	 * an option forces a page scroll that realigns the menu; on a slow CI
+	 * machine the menu shifts in the gap between Playwright computing the click
+	 * point and dispatching the event, and the click lands off the option
+	 * without committing the selection. Scrolling the trigger up first lets the
+	 * menu open fully on-screen, so the option click needs no scroll and lands
+	 * cleanly. The open/click/verify flow is still retried as a unit as a
+	 * safety net.
 	 */
 	async switchLanguage(
 		languageButton: Locator,
 		option: Locator,
 		expectedLanguageId: string
 	) {
+		await languageButton.evaluate((element) =>
+			element.scrollIntoView({block: 'start'})
+		);
+
 		await expect(async () => {
 			const expanded = await languageButton.getAttribute('aria-expanded');
 

--- a/modules/test/playwright/tests/layout-admin-web/main/widgetPage.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/main/widgetPage.spec.ts
@@ -228,6 +228,101 @@ test.describe('Content tab add panel', () => {
 			page.locator('.portlet-journal-content').getByText(webContentTitle)
 		).toBeVisible();
 	});
+
+	test(
+		'Content item stacks the subtitle below the title and centers the add button on the right',
+		{
+			tag: '@LPD-94654',
+		},
+		async ({apiHelpers, page, site, widgetPagePage}) => {
+
+			// Add required web content
+
+			const webContentTitle = getRandomString();
+
+			const contentStructureId =
+				await getBasicWebContentStructureId(apiHelpers);
+
+			await addApprovedStructuredContent({
+				apiHelpers,
+				contentStructureId,
+				siteId: site.id,
+				title: webContentTitle,
+			});
+
+			// Create page, go to view mode and open the Content panel
+
+			const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+				groupId: site.id,
+				title: getRandomString(),
+			});
+
+			await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+			await widgetPagePage.openAddPanel();
+
+			await widgetPagePage.contentTab.click();
+
+			// Wait for the content item to render
+
+			const item = page
+				.locator('.sidebar-body__add-panel__tab-item')
+				.filter({hasText: webContentTitle})
+				.first();
+
+			await expect(item).toBeVisible();
+
+			// Measure the content item layout, retrying until it settles
+
+			await expect(async () => {
+				await item.hover({timeout: 2000});
+
+				const itemBox = await item.boundingBox({timeout: 2000});
+				const titleBox = await item
+					.locator('.title')
+					.boundingBox({timeout: 2000});
+				const subtitleBox = await item
+					.locator('.subtitle')
+					.boundingBox({timeout: 2000});
+				const addButtonBox = await item
+					.getByRole('button', {name: 'Add Content'})
+					.boundingBox({timeout: 2000});
+
+				if (!itemBox || !titleBox || !subtitleBox || !addButtonBox) {
+					throw new Error(
+						'Expected the content item layout to be measurable'
+					);
+				}
+
+				// The subtitle sits below the title and is left-aligned with it
+
+				expect(subtitleBox.y).toBeGreaterThanOrEqual(
+					titleBox.y + titleBox.height - 2
+				);
+				expect(
+					Math.abs(subtitleBox.x - titleBox.x)
+				).toBeLessThanOrEqual(2);
+
+				// The add button is vertically centered within the row
+
+				expect(
+					Math.abs(
+						addButtonBox.y +
+							addButtonBox.height / 2 -
+							(itemBox.y + itemBox.height / 2)
+					)
+				).toBeLessThanOrEqual(3);
+
+				// The add button is anchored to the right edge of the row
+
+				expect(
+					itemBox.x +
+						itemBox.width -
+						(addButtonBox.x + addButtonBox.width)
+				).toBeLessThanOrEqual(12);
+			}).toPass({timeout: 10000});
+		}
+	);
 });
 
 test.describe('Customization settings', () => {

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/collectionFiltersCMSCategorization.spec.ts
@@ -10,6 +10,7 @@ import {dataApiHelpersTest} from '../../../../fixtures/dataApiHelpersTest';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../fixtures/loginTest';
+import {clickAndExpectToBeVisible} from '../../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../../utils/getRandomString';
 import {PORTLET_URLS} from '../../../../utils/portletUrls';
 import {waitForAlert} from '../../../../utils/waitForAlert';
@@ -143,9 +144,11 @@ test(
 		});
 
 		await test.step('CMS tag is available in the tag filter selector', async () => {
-			await page.getByRole('button', {name: 'Filter'}).click();
-
-			await page.getByRole('button', {name: 'Select Tags'}).click();
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('button', {name: 'Select Tags'}),
+				trigger: page.getByRole('button', {name: 'Filter'}),
+			});
 
 			const tagFrame = page.frameLocator('iframe[title="Tags"]');
 

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/spaces/spaceManagement.spec.ts
@@ -99,6 +99,50 @@ test(
 );
 
 test(
+	'Trash entries max age field shows the company default in days and rejects values below 1',
+	{tag: '@LPD-91035'},
+	async ({apiHelpers, page, spaceSummaryPage}) => {
+		const spaceName = `Space ${getRandomString()}`;
+
+		await apiHelpers.headlessAssetLibrary.createAssetLibrary({
+			name: spaceName,
+			settings: {},
+			type: 'Space',
+		});
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		const trashEntriesMaxAgeField = page.getByRole('spinbutton', {
+			name: 'Trash Entries Max Age',
+		});
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('30');
+
+		await trashEntriesMaxAgeField.fill('0');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await expect(
+			page.getByText('Please enter a value greater than or equal to 1')
+		).toBeVisible();
+
+		await trashEntriesMaxAgeField.fill('7');
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await waitForAlert(page, 'Success');
+
+		await spaceSummaryPage.goto(spaceName);
+
+		await page.getByRole('button', {name: 'More Actions'}).click();
+		await page.getByRole('menuitem', {name: 'Settings'}).click();
+
+		await expect(trashEntriesMaxAgeField).toHaveValue('7');
+	}
+);
+
+test(
 	'The Permissions modal can be opened from the All Spaces row actions',
 	{tag: '@LPD-85670'},
 	async ({apiHelpers, page}) => {

--- a/modules/test/playwright/tests/users-admin-web/main/personalMenu.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/main/personalMenu.spec.ts
@@ -12,6 +12,7 @@ import {instanceSettingsPagesTest} from '../../../fixtures/instanceSettingsPages
 import {loginTest} from '../../../fixtures/loginTest';
 import {usersAndOrganizationsPagesTest} from '../../../fixtures/usersAndOrganizationsPagesTest';
 import {liferayConfig} from '../../../liferay.config';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import {
 	performLogout,
@@ -100,8 +101,11 @@ test(
 			await page.goto('/');
 			await page.waitForLoadState('networkidle');
 
-			await personalMenuPage.userPersonalMenuButton.click();
-			await personalMenuPage.notificationsMenuItem.click();
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: personalMenuPage.notificationsMenuItem,
+				trigger: personalMenuPage.userPersonalMenuButton,
+			});
 
 			await expect(page).not.toHaveURL(/\/user\//);
 		});
@@ -118,8 +122,11 @@ test(
 			await page.goto('/');
 			await page.waitForLoadState('networkidle');
 
-			await personalMenuPage.userPersonalMenuButton.click();
-			await personalMenuPage.notificationsMenuItem.click();
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: personalMenuPage.notificationsMenuItem,
+				trigger: personalMenuPage.userPersonalMenuButton,
+			});
 
 			await expect(page).toHaveURL(/\/user\//);
 		});
@@ -175,13 +182,19 @@ test(
 	async ({page, personalMenuPage}) => {
 		await page.goto(liferayConfig.environment.baseUrl);
 
-		await personalMenuPage.userPersonalMenuButton.click();
-		await personalMenuPage.notificationsMenuItem.click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: personalMenuPage.notificationsMenuItem,
+			trigger: personalMenuPage.userPersonalMenuButton,
+		});
 
 		await expect(personalMenuPage.notificationsHeading).toBeVisible();
 
-		await personalMenuPage.userPersonalMenuButton.click();
-		await personalMenuPage.notificationsMenuItem.click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: personalMenuPage.notificationsMenuItem,
+			trigger: personalMenuPage.userPersonalMenuButton,
+		});
 
 		await expect(personalMenuPage.notificationsHeading).toBeVisible();
 
@@ -189,13 +202,19 @@ test(
 			`${liferayConfig.environment.baseUrl}/group/control_panel/manage/-/com_liferay_users_admin_web_portlet_UsersAdminPortlet`
 		);
 
-		await personalMenuPage.userPersonalMenuButton.click();
-		await personalMenuPage.notificationsMenuItem.click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: personalMenuPage.notificationsMenuItem,
+			trigger: personalMenuPage.userPersonalMenuButton,
+		});
 
 		await expect(personalMenuPage.notificationsHeading).toBeVisible();
 
-		await personalMenuPage.userPersonalMenuButton.click();
-		await personalMenuPage.notificationsMenuItem.click();
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: personalMenuPage.notificationsMenuItem,
+			trigger: personalMenuPage.userPersonalMenuButton,
+		});
 
 		await expect(personalMenuPage.notificationsHeading).toBeVisible();
 	}

--- a/pr-reviewer/run.sh
+++ b/pr-reviewer/run.sh
@@ -834,7 +834,7 @@ Output ONLY valid JSON, with no Markdown code fence and no surrounding prose: {"
 
 _IGNORED_FILENAMES="CHANGELOG.md package-lock.json package.json"
 _IGNORED_PATTERNS="(^|/)Language_.*[.]properties$"
-_IGNORED_SUFFIXES="css js lock lockfile macro path scss snap testcase ts tsx"
+_IGNORED_SUFFIXES="css js jsx lock lockfile macro path scss snap testcase ts tsx"
 #_MODELS=(deepseek-v4-flash deepseek-v4-pro glm-5 mimo-v2-5 minimax-m2-7)
 _MODELS=(sonnet-4.6)
 _NAME_ONLY_SUFFIXES="bmp gif ico jpeg jpg png svg webp"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/TeamMembers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/TeamMembers.jsx
@@ -85,6 +85,7 @@ const TeamMembers = () => {
 				/>
 
 				<ManageProductUsers
+					hasPaaSExperience={hasPaaSExperience}
 					koroneikiAccount={koroneikiAccount}
 					loading={loading}
 				/>

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
@@ -26,7 +26,7 @@ const getManagedContactURL = (manageContactsURL, activationProductName) => {
 	}
 };
 
-const ManageProductUsers = ({koroneikiAccount, loading}) => {
+const ManageProductUsers = ({hasPaaSExperience, koroneikiAccount, loading}) => {
 	const {
 		data,
 		loading: accountSubscriptionGroupsLoading,
@@ -40,6 +40,20 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 	);
 
 	const accountSubscriptionGroups = data?.c.accountSubscriptionGroups.items;
+
+	const visibleAccountSubscriptionGroups = useMemo(() => {
+		if (!hasPaaSExperience) {
+			return accountSubscriptionGroups;
+		}
+
+		return accountSubscriptionGroups?.filter(
+			({activationProductName}) =>
+				!activationProductName
+					.split(',')
+					.includes(PRODUCT_TYPES.dxpCloud)
+		);
+	}, [accountSubscriptionGroups, hasPaaSExperience]);
+
 	const accountSubscriptionGroupLiferayExperienceCloud = useMemo(
 		() =>
 			accountSubscriptionGroups?.find(
@@ -72,7 +86,7 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 
 		return (
 			<div className="d-flex">
-				{accountSubscriptionGroups?.map(
+				{visibleAccountSubscriptionGroups?.map(
 					({activationProductName, manageContactsURL, name}, index) => {
 						if (activationProductName.split(',')
 								.includes(PRODUCT_TYPES.dxpCloud)) {
@@ -112,7 +126,7 @@ const ManageProductUsers = ({koroneikiAccount, loading}) => {
 	return (
 		(accountSubscriptionGroupsLoading ||
 			Boolean(accountSubscriptionGroupLiferayExperienceCloud) ||
-			Boolean(accountSubscriptionGroups?.length)) && (
+			Boolean(visibleAccountSubscriptionGroups?.length)) && (
 			<div className="bg-brand-primary-lighten-6 cp-manage-product-users mt-4 p-4 rounded-lg">
 				{accountSubscriptionGroupsLoading ? (
 					<Skeleton height={25} width={224} />

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/pages/Project/TeamMembers/components/ManageProductUsers/ManageProductUsers.jsx
@@ -49,7 +49,7 @@ const ManageProductUsers = ({hasPaaSExperience, koroneikiAccount, loading}) => {
 		return accountSubscriptionGroups?.filter(
 			({activationProductName}) =>
 				!activationProductName
-					.split(',')
+					?.split(',')
 					.includes(PRODUCT_TYPES.dxpCloud)
 		);
 	}, [accountSubscriptionGroups, hasPaaSExperience]);

--- a/workspaces/liferay-one-workspace/.gitignore
+++ b/workspaces/liferay-one-workspace/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.idea
 /bundles
+/client-extensions/liferay-one-etc-spring-boot/liferay-release-tool-ee
 /poshi/poshi-ext.properties
 /poshi/test-results
 /poshi/tests

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -25,16 +25,6 @@ clean {
 	delete liferayReleaseToolEEDir
 }
 
-def executeCommand = {
-	String command ->
-	def process = command.execute()
-
-	if (process.waitFor() != 0) {
-		throw new GradleException(
-			"Failed: ${command}\n${process.err.text}")
-	}
-}
-
 task cloneReleaseToolEE
 
 cloneReleaseToolEE {
@@ -45,9 +35,17 @@ cloneReleaseToolEE {
 	}
 
 	doLast {
-		executeCommand("git clone --branch master --filter=blob:none --no-checkout git@github.com:liferay/liferay-release-tool-ee.git ${liferayReleaseToolEEDir.absolutePath}")
-		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} sparse-checkout set --no-cone ext/shared")
-		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} checkout HEAD")
+		exec {
+			commandLine "git", "clone", "--branch", "master", "--filter=blob:none", "--no-checkout", "git@github.com:liferay/liferay-release-tool-ee.git", liferayReleaseToolEEDir.absolutePath
+		}
+
+		exec {
+			commandLine "git", "-C", liferayReleaseToolEEDir.absolutePath, "sparse-checkout", "set", "--no-cone", "ext/shared"
+		}
+
+		exec {
+			commandLine "git", "-C", liferayReleaseToolEEDir.absolutePath, "checkout", "HEAD"
+		}
 	}
 }
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
 	implementation group: "com.liferay", name: "com.liferay.notification.rest.client", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -19,6 +19,38 @@ apply plugin: "com.liferay.source.formatter"
 apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
+def liferayReleaseToolEEDir = file("liferay-release-tool-ee")
+
+clean {
+	delete liferayReleaseToolEEDir
+}
+
+def executeCommand = {
+	String command ->
+	def process = command.execute()
+
+	if (process.waitFor() != 0) {
+		throw new GradleException(
+			"Failed: ${command}\n${process.err.text}")
+	}
+}
+
+task cloneReleaseToolEE
+
+cloneReleaseToolEE {
+	outputs.dir liferayReleaseToolEEDir
+
+	onlyIf {
+		!liferayReleaseToolEEDir.exists()
+	}
+
+	doLast {
+		executeCommand("git clone --branch master --filter=blob:none --no-checkout git@github.com:liferay/liferay-release-tool-ee.git ${liferayReleaseToolEEDir.absolutePath}")
+		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} sparse-checkout set --no-cone ext/shared")
+		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} checkout HEAD")
+	}
+}
+
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
@@ -41,3 +73,13 @@ repositories {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 	}
 }
+
+sourceSets {
+	main {
+		java {
+			srcDirs += "liferay-release-tool-ee/ext/shared/ext-impl/src"
+		}
+	}
+}
+
+compileJava.dependsOn cloneReleaseToolEE

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/source-formatter.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/source-formatter.properties
@@ -1,0 +1,6 @@
+##
+## Exclusions
+##
+
+    source.formatter.excludes=\
+        liferay-release-tool-ee/**

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Kyle Bischof
+ */
+public class ProductVersion {
+
+	public static final String COMMERCE_LICENSE_VERSION_1 = "1";
+
+	public static final String DXP_VERSION_7_0 = "7.0";
+
+	public static final String DXP_VERSION_7_1 = "7.1";
+
+	public static final String DXP_VERSION_7_2 = "7.2";
+
+	public static final String DXP_VERSION_7_3 = "7.3";
+
+	public static final String DXP_VERSION_7_4 = "7.4";
+
+	public static final String PORTAL_VERSION_5_1_3 = "5.1";
+
+	public static final String PORTAL_VERSION_5_1_4 = "5.1 SP1";
+
+	public static final String PORTAL_VERSION_5_1_5 = "5.1 SP2";
+
+	public static final String PORTAL_VERSION_5_1_6 = "5.1 SP3";
+
+	public static final String PORTAL_VERSION_5_1_7 = "5.1 SP4";
+
+	public static final String PORTAL_VERSION_5_1_8 = "5.1 SP5";
+
+	public static final String PORTAL_VERSION_5_2_4 = "5.2";
+
+	public static final String PORTAL_VERSION_5_2_5 = "5.2 SP1";
+
+	public static final String PORTAL_VERSION_5_2_6 = "5.2 SP2";
+
+	public static final String PORTAL_VERSION_5_2_7 = "5.2 SP3";
+
+	public static final String PORTAL_VERSION_5_2_8 = "5.2 SP4";
+
+	public static final String PORTAL_VERSION_5_2_9 = "5.2 SP5";
+
+	public static final String PORTAL_VERSION_6_0_10 = "6.0";
+
+	public static final String PORTAL_VERSION_6_0_11 = "6.0 SP1";
+
+	public static final String PORTAL_VERSION_6_0_12 = "6.0 SP2";
+
+	public static final String PORTAL_VERSION_6_1_10 = "6.1 GA1";
+
+	public static final String PORTAL_VERSION_6_1_20 = "6.1 GA2";
+
+	public static final String PORTAL_VERSION_6_1_30 = "6.1 GA3";
+
+	public static final String PORTAL_VERSION_6_2_10 = "6.2 EE";
+
+	public static String extractQuarterlyRelease(String version) {
+		if (Validator.isNotNull(version)) {
+			Matcher matcher = getQuarterlyReleaseMatcher(version);
+
+			if (matcher.find()) {
+				return StringUtil.toUpperCase(matcher.group());
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	public static Matcher getQuarterlyReleaseMatcher(String version) {
+		return _quarterlyReleaseVersionPattern.matcher(version);
+	}
+
+	private static final Pattern _quarterlyReleaseVersionPattern =
+		Pattern.compile("(\\d{4})\\.Q([1-4])", Pattern.CASE_INSENSITIVE);
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -6,25 +6,19 @@
 package com.liferay.one.license;
 
 import com.liferay.one.constants.ProductVersion;
-import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.ee.license.shared.KeyGenerator;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
-import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
-
-import java.io.IOException;
-import java.io.ObjectOutputStream;
 
 import java.text.DateFormat;
 
@@ -33,8 +27,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 import java.util.TimeZone;
 
 import org.springframework.stereotype.Component;
@@ -93,94 +85,6 @@ public class LicenseKeyExporter {
 		}
 
 		return formatFileName(sb.toString());
-	}
-
-	public String toEncodedLicenseFile(String serverId, String key) {
-		Properties licenseProperties = new Properties();
-
-		licenseProperties.setProperty("serverId", serverId);
-		licenseProperties.setProperty("licenseKey", key);
-
-		String licenseFileDecoded = PropertiesUtil.toString(licenseProperties);
-
-		return Base64.objectToString(licenseFileDecoded);
-	}
-
-	public String toLI(
-			String key, String accountName, String licenseEntryName,
-			String licenseType, int licenseVersion, String productName,
-			String productId, String productVersion, String owner,
-			int maxClusterNodes, int maxServers, int maxHttpSessions,
-			long maxConcurrentUsers, long maxUsers, String sizing,
-			String description, String domains, String hostName,
-			String ipAddresses, String macAddresses, String serverId,
-			Date startDate, Date expirationDate)
-		throws IOException {
-
-		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-				new UnsyncByteArrayOutputStream();
-
-			ObjectOutputStream objectOutputStream = new ObjectOutputStream(
-				unsyncByteArrayOutputStream)) {
-
-			objectOutputStream.writeInt(4);
-			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
-			objectOutputStream.writeUTF(GetterUtil.getString(description));
-			objectOutputStream.writeObject(StringUtil.split(domains));
-			objectOutputStream.writeObject(expirationDate);
-
-			String[] hostNames = null;
-
-			if (Validator.isNotNull(hostName)) {
-				hostNames = new String[] {hostName};
-			}
-			else {
-				hostNames = new String[0];
-			}
-
-			objectOutputStream.writeObject(hostNames);
-
-			objectOutputStream.writeObject(StringUtil.split(ipAddresses));
-			objectOutputStream.writeUTF(GetterUtil.getString(key));
-			objectOutputStream.writeLong(System.currentTimeMillis());
-			objectOutputStream.writeUTF(GetterUtil.getString(licenseEntryName));
-			objectOutputStream.writeUTF(GetterUtil.getString(licenseType));
-			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
-			objectOutputStream.writeObject(StringUtil.split(macAddresses));
-
-			if (Objects.equals(
-					LicenseConstants.TYPE_VIRTUAL_CLUSTER, licenseType)) {
-
-				objectOutputStream.writeInt(maxClusterNodes);
-			}
-
-			objectOutputStream.writeInt(maxHttpSessions);
-			objectOutputStream.writeInt(maxServers);
-			objectOutputStream.writeLong(maxConcurrentUsers);
-			objectOutputStream.writeLong(maxUsers);
-			objectOutputStream.writeUTF(sizing);
-			objectOutputStream.writeUTF(GetterUtil.getString(owner));
-			objectOutputStream.writeUTF(GetterUtil.getString(productName));
-			objectOutputStream.writeUTF(GetterUtil.getString(productId));
-			objectOutputStream.writeUTF(productVersion);
-
-			String[] serverIds = null;
-
-			if (Validator.isNotNull(serverId)) {
-				serverIds = new String[] {serverId};
-			}
-			else {
-				serverIds = new String[0];
-			}
-
-			objectOutputStream.writeObject(serverIds);
-
-			objectOutputStream.writeObject(startDate);
-
-			objectOutputStream.flush();
-
-			return Base64.encode(unsyncByteArrayOutputStream.toByteArray());
-		}
 	}
 
 	public String toXML(
@@ -344,20 +248,26 @@ public class LicenseKeyExporter {
 		Element rootElement = document.addElement("license");
 
 		String licenseEntryType = properties.get("type");
-		String licenseVersion = properties.get("version");
 
 		_addElement(
 			rootElement, "account-name", properties.get("accountEntryName"));
+
 		_addElement(rootElement, "owner", properties.get("owner"));
+
 		_addElement(rootElement, "description", properties.get("description"));
+
 		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
+
 		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
+
 		_addElement(
 			rootElement, "license-name", properties.get("licenseEntryName"));
+
 		_addElement(rootElement, "license-type", licenseEntryType);
-		_addElement(rootElement, "license-version", licenseVersion);
+
+		_addElement(rootElement, "license-version", properties.get("version"));
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
 			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
@@ -427,7 +337,9 @@ public class LicenseKeyExporter {
 		}
 
 		_addElement(rootElement, "owner", properties.get("owner"));
+
 		_addElement(rootElement, "description", properties.get("description"));
+
 		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
 
@@ -445,6 +357,7 @@ public class LicenseKeyExporter {
 		}
 
 		_addElement(rootElement, "license-type", licenseEntryType);
+
 		_addElement(
 			rootElement, "license-version", String.valueOf(licenseVersion));
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -3,23 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.osb.provisioning.license.exporter.internal;
+package com.liferay.one.license;
 
-import com.liferay.osb.provisioning.license.exporter.LicenseKeyExporter;
-import com.liferay.osb.provisioning.license.generator.KeyGenerator;
-import com.liferay.osb.provisioning.license.helper.constants.LicenseType;
-import com.liferay.osb.provisioning.license.helper.constants.ProductVersion;
+import com.liferay.one.constants.ProductVersion;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.petra.xml.DocUtil;
-import com.liferay.portal.kernel.io.Base64OutputStream;
-import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.ee.license.shared.KeyGenerator;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
@@ -40,14 +37,13 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.TimeZone;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Amos Fong
  */
-@Component(immediate = true, service = LicenseKeyExporter.class)
-public class LicenseKeyExporterImpl implements LicenseKeyExporter {
+@Component
+public class LicenseKeyExporter {
 
 	public String aggregateXMLs(String[] xmls) throws Exception {
 		Document document = SAXReaderUtil.createDocument();
@@ -121,13 +117,11 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			Date startDate, Date expirationDate)
 		throws IOException {
 
-		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-			new UnsyncByteArrayOutputStream();
-		ObjectOutputStream objectOutputStream = null;
+		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+				new UnsyncByteArrayOutputStream();
 
-		try {
-			objectOutputStream = new ObjectOutputStream(
-				new Base64OutputStream(unsyncByteArrayOutputStream));
+			ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+				unsyncByteArrayOutputStream)) {
 
 			objectOutputStream.writeInt(4);
 			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
@@ -154,7 +148,9 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
 			objectOutputStream.writeObject(StringUtil.split(macAddresses));
 
-			if (Objects.equals(LicenseType.VIRTUAL_CLUSTER, licenseType)) {
+			if (Objects.equals(
+					LicenseConstants.TYPE_VIRTUAL_CLUSTER, licenseType)) {
+
 				objectOutputStream.writeInt(maxClusterNodes);
 			}
 
@@ -183,16 +179,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 
 			objectOutputStream.flush();
 
-			return new String(unsyncByteArrayOutputStream.toByteArray());
-		}
-		finally {
-			if (objectOutputStream != null) {
-				objectOutputStream.close();
-			}
-
-			if (unsyncByteArrayOutputStream != null) {
-				unsyncByteArrayOutputStream.close();
-			}
+			return Base64.encode(unsyncByteArrayOutputStream.toByteArray());
 		}
 	}
 
@@ -215,7 +202,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			serverIds[0], startDate, expirationDate, createDate);
 
 		if ((licenseVersion >= 4) &&
-			licenseType.equals(LicenseType.PRODUCTION)) {
+			licenseType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
 			properties.put("maxServers", String.valueOf(serverIds.length));
 		}
@@ -264,9 +251,9 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
 		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
 
-		String key = _keyGenerator.generate(properties);
+		String key = KeyGenerator.encrypt(properties);
 
-		DocUtil.add(rootElement, "key", key);
+		_addElement(rootElement, "key", key);
 
 		return document.formattedString();
 	}
@@ -309,7 +296,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String[] hostNames = StringUtil.split(properties.get("hostNames"));
 
 		for (String hostName : hostNames) {
-			DocUtil.add(hostNamesElement, "host-name", hostName);
+			_addElement(hostNamesElement, "host-name", hostName);
 		}
 
 		Element ipAddressesElement = element.addElement("ip-addresses");
@@ -317,7 +304,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String[] ipAddresses = StringUtil.split(properties.get("ipAddresses"));
 
 		for (String ipAddress : ipAddresses) {
-			DocUtil.add(ipAddressesElement, "ip-address", ipAddress);
+			_addElement(ipAddressesElement, "ip-address", ipAddress);
 		}
 
 		Element macAddressesElement = element.addElement("mac-addresses");
@@ -326,7 +313,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			properties.get("macAddresses"));
 
 		for (String macAddress : macAddresses) {
-			DocUtil.add(macAddressesElement, "mac-address", macAddress);
+			_addElement(macAddressesElement, "mac-address", macAddress);
 		}
 
 		String[] serverIds = StringUtil.split(properties.get("serverIds"));
@@ -335,7 +322,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			Element serverIdElement = element.addElement("server-ids");
 
 			for (String serverId : serverIds) {
-				DocUtil.add(serverIdElement, "server-id", serverId);
+				_addElement(serverIdElement, "server-id", serverId);
 			}
 		}
 	}
@@ -359,18 +346,18 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String licenseEntryType = properties.get("type");
 		String licenseVersion = properties.get("version");
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "account-name", properties.get("accountEntryName"));
-		DocUtil.add(rootElement, "owner", properties.get("owner"));
-		DocUtil.add(rootElement, "description", properties.get("description"));
-		DocUtil.add(
+		_addElement(rootElement, "owner", properties.get("owner"));
+		_addElement(rootElement, "description", properties.get("description"));
+		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
-		DocUtil.add(
+		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
-		DocUtil.add(
+		_addElement(
 			rootElement, "license-name", properties.get("licenseEntryName"));
-		DocUtil.add(rootElement, "license-type", licenseEntryType);
-		DocUtil.add(rootElement, "license-version", licenseVersion);
+		_addElement(rootElement, "license-type", licenseEntryType);
+		_addElement(rootElement, "license-version", licenseVersion);
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
 			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
@@ -380,43 +367,43 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		Date startDate = new Date(
 			GetterUtil.getLong(properties.get("startDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "start-date",
 			longDateFormatDateTime.format(startDate));
 
 		Date expirationDate = new Date(
 			GetterUtil.getLong(properties.get("expirationDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "expiration-date",
 			longDateFormatDateTime.format(expirationDate));
 
-		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-servers", properties.get("maxServers"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-http-sessions",
 				properties.get("maxHttpSessions"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.PRODUCTION)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 			Element serverIdElement = rootElement.addElement("server-ids");
 
 			String[] serverIds = StringUtil.split(properties.get("serverIds"));
 
 			for (String serverId : serverIds) {
-				DocUtil.add(serverIdElement, "server-id", serverId);
+				_addElement(serverIdElement, "server-id", serverId);
 			}
 		}
 
-		DocUtil.add(rootElement, "key", key);
+		_addElement(rootElement, "key", key);
 
 		return document;
 	}
@@ -434,31 +421,31 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		long licenseVersion = GetterUtil.getLong(properties.get("version"));
 
 		if (Validator.isNull(productId)) {
-			DocUtil.add(
+			_addElement(
 				rootElement, "account-name",
 				properties.get("accountEntryName"));
 		}
 
-		DocUtil.add(rootElement, "owner", properties.get("owner"));
-		DocUtil.add(rootElement, "description", properties.get("description"));
-		DocUtil.add(
+		_addElement(rootElement, "owner", properties.get("owner"));
+		_addElement(rootElement, "description", properties.get("description"));
+		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
 
 		if (Validator.isNotNull(productId)) {
-			DocUtil.add(rootElement, "product-id", productId);
+			_addElement(rootElement, "product-id", productId);
 		}
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
 
 		if (Validator.isNull(productId)) {
-			DocUtil.add(
+			_addElement(
 				rootElement, "license-name",
 				properties.get("licenseEntryName"));
 		}
 
-		DocUtil.add(rootElement, "license-type", licenseEntryType);
-		DocUtil.add(
+		_addElement(rootElement, "license-type", licenseEntryType);
+		_addElement(
 			rootElement, "license-version", String.valueOf(licenseVersion));
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
@@ -469,57 +456,57 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		Date startDate = new Date(
 			GetterUtil.getLong(properties.get("startDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "start-date",
 			longDateFormatDateTime.format(startDate));
 
 		Date expirationDate = new Date(
 			GetterUtil.getLong(properties.get("expirationDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "expiration-date",
 			longDateFormatDateTime.format(expirationDate));
 
-		if (licenseEntryType.equals(LicenseType.FREE) ||
-			licenseEntryType.equals(LicenseType.VIRTUAL_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_FREE) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_VIRTUAL_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-cluster-nodes",
 				properties.get("max-cluster-nodes"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+		if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
 			((licenseVersion >= 4) &&
-			 (licenseEntryType.equals(LicenseType.LIMITED) ||
-			  licenseEntryType.equals(LicenseType.PRODUCTION)))) {
+			 (licenseEntryType.equals(LicenseConstants.TYPE_LIMITED) ||
+			  licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)))) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-servers", properties.get("maxServers"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-http-sessions",
 				properties.get("maxHttpSessions"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.FREE)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_FREE)) {
 			Element domainsElement = rootElement.addElement("domains");
 
 			String[] domains = StringUtil.split(properties.get("domains"));
 
 			for (String domain : domains) {
-				DocUtil.add(domainsElement, "domain", domain);
+				_addElement(domainsElement, "domain", domain);
 			}
 		}
 
-		if (licenseEntryType.equals(LicenseType.PER_USER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_PER_USER)) {
 			String maxConcurrentUsers = properties.get("maxConcurrentUsers");
 
 			if (Validator.isNotNull(maxConcurrentUsers)) {
-				DocUtil.add(
+				_addElement(
 					rootElement, "max-concurrent-users",
 					properties.get("maxConcurrentUsers"));
 			}
@@ -527,7 +514,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			String maxUsers = properties.get("maxUsers");
 
 			if (Validator.isNotNull(maxUsers)) {
-				DocUtil.add(
+				_addElement(
 					rootElement, "max-users", properties.get("maxUsers"));
 			}
 		}
@@ -535,22 +522,30 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String instanceSize = properties.get("instanceSize");
 
 		if (Validator.isNotNull(instanceSize)) {
-			DocUtil.add(rootElement, "instance-size", instanceSize);
+			_addElement(rootElement, "instance-size", instanceSize);
 		}
 
 		if (!aggregate) {
-			if (licenseEntryType.equals(LicenseType.CLUSTER) ||
-				licenseEntryType.equals(LicenseType.LIMITED) ||
-				licenseEntryType.equals(LicenseType.PER_USER) ||
-				licenseEntryType.equals(LicenseType.PRODUCTION)) {
+			if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_LIMITED) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_PER_USER) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
 				exportServerToXML(rootElement, properties);
 			}
 
-			DocUtil.add(rootElement, "key", key);
+			_addElement(rootElement, "key", key);
 		}
 
 		return document;
+	}
+
+	private void _addElement(Element parentElement, String name, String value) {
+		Element childElement = parentElement.addElement(name);
+
+		if (value != null) {
+			childElement.addText(value);
+		}
 	}
 
 	private Map<String, String> _getProperties(
@@ -563,12 +558,13 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String serverIds, Date startDate, Date expirationDate,
 		Date createDate) {
 
-		Map<String, String> properties = _keyGenerator.getProperties(
-			accountName, licenseEntryName, licenseType, licenseVersion,
-			productName, productId, productVersion, owner, maxClusterNodes,
-			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
-			description, domains, hostNames, ipAddresses, macAddresses,
-			new String[] {serverIds}, startDate, expirationDate);
+		Map<String, String> properties = KeyGenerator.getProperties(
+			accountName, description, StringUtil.split(domains), expirationDate,
+			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
+			licenseEntryName, licenseType, String.valueOf(licenseVersion),
+			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
+			maxHttpSessions, maxServers, maxUsers, owner, productName,
+			productId, productVersion, new String[] {serverIds}, startDate);
 
 		// See LRDCOM-2568
 
@@ -588,8 +584,5 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 
 		return properties;
 	}
-
-	@Reference
-	private KeyGenerator _keyGenerator;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -1,0 +1,595 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.provisioning.license.exporter.internal;
+
+import com.liferay.osb.provisioning.license.exporter.LicenseKeyExporter;
+import com.liferay.osb.provisioning.license.generator.KeyGenerator;
+import com.liferay.osb.provisioning.license.helper.constants.LicenseType;
+import com.liferay.osb.provisioning.license.helper.constants.ProductVersion;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.xml.DocUtil;
+import com.liferay.portal.kernel.io.Base64OutputStream;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropertiesUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Amos Fong
+ */
+@Component(immediate = true, service = LicenseKeyExporter.class)
+public class LicenseKeyExporterImpl implements LicenseKeyExporter {
+
+	public String aggregateXMLs(String[] xmls) throws Exception {
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("licenses");
+
+		for (String xml : xmls) {
+			Document curDocument = SAXReaderUtil.read(xml);
+
+			rootElement.add(curDocument.getRootElement());
+		}
+
+		return document.formattedString();
+	}
+
+	public String getFileName(
+		String productName, String productVersion, String licenseKeyName) {
+
+		StringBundler sb = new StringBundler(6);
+
+		productName = StringUtil.extractChars(productName);
+
+		sb.append("activation-key-");
+		sb.append(productName);
+		sb.append(StringPool.DASH);
+		sb.append(productVersion);
+		sb.append(StringPool.DASH);
+		sb.append(licenseKeyName);
+
+		return formatFileName(sb.toString());
+	}
+
+	public String getFileName(String[] productNames, String[] licenseKeyNames) {
+		StringBundler sb = new StringBundler(
+			1 + (2 * productNames.length) + (2 * licenseKeyNames.length));
+
+		sb.append("activation-key");
+
+		for (String productName : productNames) {
+			sb.append(StringPool.DASH);
+			sb.append(StringUtil.extractChars(productName));
+		}
+
+		for (String licenseKeyName : licenseKeyNames) {
+			sb.append(StringPool.DASH);
+			sb.append(licenseKeyName);
+		}
+
+		return formatFileName(sb.toString());
+	}
+
+	public String toEncodedLicenseFile(String serverId, String key) {
+		Properties licenseProperties = new Properties();
+
+		licenseProperties.setProperty("serverId", serverId);
+		licenseProperties.setProperty("licenseKey", key);
+
+		String licenseFileDecoded = PropertiesUtil.toString(licenseProperties);
+
+		return Base64.objectToString(licenseFileDecoded);
+	}
+
+	public String toLI(
+			String key, String accountName, String licenseEntryName,
+			String licenseType, int licenseVersion, String productName,
+			String productId, String productVersion, String owner,
+			int maxClusterNodes, int maxServers, int maxHttpSessions,
+			long maxConcurrentUsers, long maxUsers, String sizing,
+			String description, String domains, String hostName,
+			String ipAddresses, String macAddresses, String serverId,
+			Date startDate, Date expirationDate)
+		throws IOException {
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+		ObjectOutputStream objectOutputStream = null;
+
+		try {
+			objectOutputStream = new ObjectOutputStream(
+				new Base64OutputStream(unsyncByteArrayOutputStream));
+
+			objectOutputStream.writeInt(4);
+			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
+			objectOutputStream.writeUTF(GetterUtil.getString(description));
+			objectOutputStream.writeObject(StringUtil.split(domains));
+			objectOutputStream.writeObject(expirationDate);
+
+			String[] hostNames = null;
+
+			if (Validator.isNotNull(hostName)) {
+				hostNames = new String[] {hostName};
+			}
+			else {
+				hostNames = new String[0];
+			}
+
+			objectOutputStream.writeObject(hostNames);
+
+			objectOutputStream.writeObject(StringUtil.split(ipAddresses));
+			objectOutputStream.writeUTF(GetterUtil.getString(key));
+			objectOutputStream.writeLong(System.currentTimeMillis());
+			objectOutputStream.writeUTF(GetterUtil.getString(licenseEntryName));
+			objectOutputStream.writeUTF(GetterUtil.getString(licenseType));
+			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
+			objectOutputStream.writeObject(StringUtil.split(macAddresses));
+
+			if (Objects.equals(LicenseType.VIRTUAL_CLUSTER, licenseType)) {
+				objectOutputStream.writeInt(maxClusterNodes);
+			}
+
+			objectOutputStream.writeInt(maxHttpSessions);
+			objectOutputStream.writeInt(maxServers);
+			objectOutputStream.writeLong(maxConcurrentUsers);
+			objectOutputStream.writeLong(maxUsers);
+			objectOutputStream.writeUTF(sizing);
+			objectOutputStream.writeUTF(GetterUtil.getString(owner));
+			objectOutputStream.writeUTF(GetterUtil.getString(productName));
+			objectOutputStream.writeUTF(GetterUtil.getString(productId));
+			objectOutputStream.writeUTF(productVersion);
+
+			String[] serverIds = null;
+
+			if (Validator.isNotNull(serverId)) {
+				serverIds = new String[] {serverId};
+			}
+			else {
+				serverIds = new String[0];
+			}
+
+			objectOutputStream.writeObject(serverIds);
+
+			objectOutputStream.writeObject(startDate);
+
+			objectOutputStream.flush();
+
+			return new String(unsyncByteArrayOutputStream.toByteArray());
+		}
+		finally {
+			if (objectOutputStream != null) {
+				objectOutputStream.close();
+			}
+
+			if (unsyncByteArrayOutputStream != null) {
+				unsyncByteArrayOutputStream.close();
+			}
+		}
+	}
+
+	public String toXML(
+			String accountName, String licenseEntryName, String licenseType,
+			int licenseVersion, String productName, String productId,
+			String productVersion, String owner, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String description, String domains,
+			String[] hostNames, String[] ipAddresses, String[] macAddresses,
+			String[] serverIds, Date startDate, Date expirationDate,
+			Date createDate)
+		throws Exception {
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames[0], ipAddresses[0], macAddresses[0],
+			serverIds[0], startDate, expirationDate, createDate);
+
+		if ((licenseVersion >= 4) &&
+			licenseType.equals(LicenseType.PRODUCTION)) {
+
+			properties.put("maxServers", String.valueOf(serverIds.length));
+		}
+
+		Document document = toXMLVersion3_4(properties, StringPool.BLANK, true);
+
+		Element rootElement = document.getRootElement();
+
+		List<String> allHostNames = new ArrayList<>();
+		List<String> allIpAddresses = new ArrayList<>();
+		List<String> allMacAddresses = new ArrayList<>();
+
+		Element serversElement = rootElement.addElement("servers");
+
+		for (int i = 0; i < serverIds.length; i++) {
+			Map<String, String> curProperties = _getProperties(
+				accountName, licenseEntryName, licenseType, licenseVersion,
+				productName, productId, productVersion, owner, maxClusterNodes,
+				maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers,
+				sizing, description, domains, hostNames[i], ipAddresses[i],
+				macAddresses[i], serverIds[i], startDate, expirationDate,
+				createDate);
+
+			Element serverElement = serversElement.addElement("server");
+
+			exportServerToXML(serverElement, curProperties);
+
+			String curHostName = curProperties.get("hostNames");
+
+			if (Validator.isNotNull(curHostName)) {
+				allHostNames.add(curHostName);
+			}
+
+			List<String> curIpAddresses = ListUtil.fromArray(
+				StringUtil.split(curProperties.get("ipAddresses")));
+
+			allIpAddresses.addAll(curIpAddresses);
+
+			List<String> curMacAddresses = ListUtil.fromArray(
+				StringUtil.split(curProperties.get("macAddresses")));
+
+			allMacAddresses.addAll(curMacAddresses);
+		}
+
+		properties.put("hostNames", StringUtil.merge(allHostNames));
+		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
+		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
+
+		String key = _keyGenerator.generate(properties);
+
+		DocUtil.add(rootElement, "key", key);
+
+		return document.formattedString();
+	}
+
+	public String toXML(
+			String key, String accountName, String licenseEntryName,
+			String licenseType, int licenseVersion, String productName,
+			String productId, String productVersion, String owner,
+			int maxClusterNodes, int maxServers, int maxHttpSessions,
+			long maxConcurrentUsers, long maxUsers, String sizing,
+			String description, String domains, String hostNames,
+			String ipAddresses, String macAddresses, String serverIds,
+			Date startDate, Date expirationDate, Date createDate)
+		throws Exception {
+
+		Document document = null;
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			serverIds, startDate, expirationDate, createDate);
+
+		if (licenseVersion >= 3) {
+			document = toXMLVersion3_4(properties, key, false);
+		}
+		else {
+			document = toXMLVersion2(properties, key);
+		}
+
+		return document.formattedString();
+	}
+
+	protected void exportServerToXML(
+		Element element, Map<String, String> properties) {
+
+		Element hostNamesElement = element.addElement("host-names");
+
+		String[] hostNames = StringUtil.split(properties.get("hostNames"));
+
+		for (String hostName : hostNames) {
+			DocUtil.add(hostNamesElement, "host-name", hostName);
+		}
+
+		Element ipAddressesElement = element.addElement("ip-addresses");
+
+		String[] ipAddresses = StringUtil.split(properties.get("ipAddresses"));
+
+		for (String ipAddress : ipAddresses) {
+			DocUtil.add(ipAddressesElement, "ip-address", ipAddress);
+		}
+
+		Element macAddressesElement = element.addElement("mac-addresses");
+
+		String[] macAddresses = StringUtil.split(
+			properties.get("macAddresses"));
+
+		for (String macAddress : macAddresses) {
+			DocUtil.add(macAddressesElement, "mac-address", macAddress);
+		}
+
+		String[] serverIds = StringUtil.split(properties.get("serverIds"));
+
+		if (serverIds.length > 0) {
+			Element serverIdElement = element.addElement("server-ids");
+
+			for (String serverId : serverIds) {
+				DocUtil.add(serverIdElement, "server-id", serverId);
+			}
+		}
+	}
+
+	protected String formatFileName(String fileName) {
+		fileName = StringUtil.replace(
+			fileName, CharPool.SPACE, StringPool.BLANK);
+		fileName = StringUtil.toLowerCase(fileName);
+		fileName = fileName.substring(0, Math.min(fileName.length(), 251));
+
+		return fileName.concat(".xml");
+	}
+
+	protected Document toXMLVersion2(Map<String, String> properties, String key)
+		throws Exception {
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("license");
+
+		String licenseEntryType = properties.get("type");
+		String licenseVersion = properties.get("version");
+
+		DocUtil.add(
+			rootElement, "account-name", properties.get("accountEntryName"));
+		DocUtil.add(rootElement, "owner", properties.get("owner"));
+		DocUtil.add(rootElement, "description", properties.get("description"));
+		DocUtil.add(
+			rootElement, "product-name", properties.get("productEntryName"));
+		DocUtil.add(
+			rootElement, "product-version", properties.get("productVersion"));
+		DocUtil.add(
+			rootElement, "license-name", properties.get("licenseEntryName"));
+		DocUtil.add(rootElement, "license-type", licenseEntryType);
+		DocUtil.add(rootElement, "license-version", licenseVersion);
+
+		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
+			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
+
+		longDateFormatDateTime.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+		Date startDate = new Date(
+			GetterUtil.getLong(properties.get("startDate")));
+
+		DocUtil.add(
+			rootElement, "start-date",
+			longDateFormatDateTime.format(startDate));
+
+		Date expirationDate = new Date(
+			GetterUtil.getLong(properties.get("expirationDate")));
+
+		DocUtil.add(
+			rootElement, "expiration-date",
+			longDateFormatDateTime.format(expirationDate));
+
+		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-servers", properties.get("maxServers"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-http-sessions",
+				properties.get("maxHttpSessions"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.PRODUCTION)) {
+			Element serverIdElement = rootElement.addElement("server-ids");
+
+			String[] serverIds = StringUtil.split(properties.get("serverIds"));
+
+			for (String serverId : serverIds) {
+				DocUtil.add(serverIdElement, "server-id", serverId);
+			}
+		}
+
+		DocUtil.add(rootElement, "key", key);
+
+		return document;
+	}
+
+	protected Document toXMLVersion3_4(
+			Map<String, String> properties, String key, boolean aggregate)
+		throws Exception {
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("license");
+
+		String productId = properties.get("productId");
+		String licenseEntryType = properties.get("type");
+		long licenseVersion = GetterUtil.getLong(properties.get("version"));
+
+		if (Validator.isNull(productId)) {
+			DocUtil.add(
+				rootElement, "account-name",
+				properties.get("accountEntryName"));
+		}
+
+		DocUtil.add(rootElement, "owner", properties.get("owner"));
+		DocUtil.add(rootElement, "description", properties.get("description"));
+		DocUtil.add(
+			rootElement, "product-name", properties.get("productEntryName"));
+
+		if (Validator.isNotNull(productId)) {
+			DocUtil.add(rootElement, "product-id", productId);
+		}
+
+		DocUtil.add(
+			rootElement, "product-version", properties.get("productVersion"));
+
+		if (Validator.isNull(productId)) {
+			DocUtil.add(
+				rootElement, "license-name",
+				properties.get("licenseEntryName"));
+		}
+
+		DocUtil.add(rootElement, "license-type", licenseEntryType);
+		DocUtil.add(
+			rootElement, "license-version", String.valueOf(licenseVersion));
+
+		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
+			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
+
+		longDateFormatDateTime.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+		Date startDate = new Date(
+			GetterUtil.getLong(properties.get("startDate")));
+
+		DocUtil.add(
+			rootElement, "start-date",
+			longDateFormatDateTime.format(startDate));
+
+		Date expirationDate = new Date(
+			GetterUtil.getLong(properties.get("expirationDate")));
+
+		DocUtil.add(
+			rootElement, "expiration-date",
+			longDateFormatDateTime.format(expirationDate));
+
+		if (licenseEntryType.equals(LicenseType.FREE) ||
+			licenseEntryType.equals(LicenseType.VIRTUAL_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-cluster-nodes",
+				properties.get("max-cluster-nodes"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+			((licenseVersion >= 4) &&
+			 (licenseEntryType.equals(LicenseType.LIMITED) ||
+			  licenseEntryType.equals(LicenseType.PRODUCTION)))) {
+
+			DocUtil.add(
+				rootElement, "max-servers", properties.get("maxServers"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-http-sessions",
+				properties.get("maxHttpSessions"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.FREE)) {
+			Element domainsElement = rootElement.addElement("domains");
+
+			String[] domains = StringUtil.split(properties.get("domains"));
+
+			for (String domain : domains) {
+				DocUtil.add(domainsElement, "domain", domain);
+			}
+		}
+
+		if (licenseEntryType.equals(LicenseType.PER_USER)) {
+			String maxConcurrentUsers = properties.get("maxConcurrentUsers");
+
+			if (Validator.isNotNull(maxConcurrentUsers)) {
+				DocUtil.add(
+					rootElement, "max-concurrent-users",
+					properties.get("maxConcurrentUsers"));
+			}
+
+			String maxUsers = properties.get("maxUsers");
+
+			if (Validator.isNotNull(maxUsers)) {
+				DocUtil.add(
+					rootElement, "max-users", properties.get("maxUsers"));
+			}
+		}
+
+		String instanceSize = properties.get("instanceSize");
+
+		if (Validator.isNotNull(instanceSize)) {
+			DocUtil.add(rootElement, "instance-size", instanceSize);
+		}
+
+		if (!aggregate) {
+			if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+				licenseEntryType.equals(LicenseType.LIMITED) ||
+				licenseEntryType.equals(LicenseType.PER_USER) ||
+				licenseEntryType.equals(LicenseType.PRODUCTION)) {
+
+				exportServerToXML(rootElement, properties);
+			}
+
+			DocUtil.add(rootElement, "key", key);
+		}
+
+		return document;
+	}
+
+	private Map<String, String> _getProperties(
+		String accountName, String licenseEntryName, String licenseType,
+		int licenseVersion, String productName, String productId,
+		String productVersion, String owner, int maxClusterNodes,
+		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+		long maxUsers, String sizing, String description, String domains,
+		String hostNames, String ipAddresses, String macAddresses,
+		String serverIds, Date startDate, Date expirationDate,
+		Date createDate) {
+
+		Map<String, String> properties = _keyGenerator.getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			new String[] {serverIds}, startDate, expirationDate);
+
+		// See LRDCOM-2568
+
+		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
+			productVersion.equals("6.1 GA 1")) {
+
+			Calendar cal = Calendar.getInstance();
+
+			cal.set(Calendar.DAY_OF_MONTH, 31);
+			cal.set(Calendar.MONTH, 6);
+			cal.set(Calendar.YEAR, 2012);
+
+			if (createDate.before(cal.getTime())) {
+				properties.put("productVersion", "6.1");
+			}
+		}
+
+		return properties;
+	}
+
+	@Reference
+	private KeyGenerator _keyGenerator;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -65,7 +65,7 @@ public class LicenseKeyExporter {
 		sb.append(StringPool.DASH);
 		sb.append(licenseKeyName);
 
-		return formatFileName(sb.toString());
+		return _formatFileName(sb.toString());
 	}
 
 	public String getFileName(String[] productNames, String[] licenseKeyNames) {
@@ -84,7 +84,37 @@ public class LicenseKeyExporter {
 			sb.append(licenseKeyName);
 		}
 
-		return formatFileName(sb.toString());
+		return _formatFileName(sb.toString());
+	}
+
+	public String toXML(
+			String accountName, String licenseEntryName, String licenseType,
+			int licenseVersion, String productName, String productId,
+			String productVersion, String owner, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String description, String domains,
+			String hostNames, String ipAddresses, String macAddresses,
+			String serverIds, Date startDate, Date expirationDate,
+			Date createDate, String key)
+		throws Exception {
+
+		Document document = null;
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			serverIds, startDate, expirationDate, createDate);
+
+		if (licenseVersion >= 3) {
+			document = _toXMLVersion3_4(properties, false, key);
+		}
+		else {
+			document = _toXMLVersion2(properties, key);
+		}
+
+		return document.formattedString();
 	}
 
 	public String toXML(
@@ -111,7 +141,8 @@ public class LicenseKeyExporter {
 			properties.put("maxServers", String.valueOf(serverIds.length));
 		}
 
-		Document document = toXMLVersion3_4(properties, StringPool.BLANK, true);
+		Document document = _toXMLVersion3_4(
+			properties, true, StringPool.BLANK);
 
 		Element rootElement = document.getRootElement();
 
@@ -132,7 +163,7 @@ public class LicenseKeyExporter {
 
 			Element serverElement = serversElement.addElement("server");
 
-			exportServerToXML(serverElement, curProperties);
+			_exportServerToXML(serverElement, curProperties);
 
 			String curHostName = curProperties.get("hostNames");
 
@@ -155,44 +186,20 @@ public class LicenseKeyExporter {
 		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
 		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
 
-		String key = KeyGenerator.encrypt(properties);
-
-		_addElement(rootElement, "key", key);
+		_addElement(rootElement, "key", KeyGenerator.encrypt(properties));
 
 		return document.formattedString();
 	}
 
-	public String toXML(
-			String key, String accountName, String licenseEntryName,
-			String licenseType, int licenseVersion, String productName,
-			String productId, String productVersion, String owner,
-			int maxClusterNodes, int maxServers, int maxHttpSessions,
-			long maxConcurrentUsers, long maxUsers, String sizing,
-			String description, String domains, String hostNames,
-			String ipAddresses, String macAddresses, String serverIds,
-			Date startDate, Date expirationDate, Date createDate)
-		throws Exception {
+	private void _addElement(Element parentElement, String name, String value) {
+		Element childElement = parentElement.addElement(name);
 
-		Document document = null;
-
-		Map<String, String> properties = _getProperties(
-			accountName, licenseEntryName, licenseType, licenseVersion,
-			productName, productId, productVersion, owner, maxClusterNodes,
-			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
-			description, domains, hostNames, ipAddresses, macAddresses,
-			serverIds, startDate, expirationDate, createDate);
-
-		if (licenseVersion >= 3) {
-			document = toXMLVersion3_4(properties, key, false);
+		if (value != null) {
+			childElement.addText(value);
 		}
-		else {
-			document = toXMLVersion2(properties, key);
-		}
-
-		return document.formattedString();
 	}
 
-	protected void exportServerToXML(
+	private void _exportServerToXML(
 		Element element, Map<String, String> properties) {
 
 		Element hostNamesElement = element.addElement("host-names");
@@ -231,7 +238,7 @@ public class LicenseKeyExporter {
 		}
 	}
 
-	protected String formatFileName(String fileName) {
+	private String _formatFileName(String fileName) {
 		fileName = StringUtil.replace(
 			fileName, CharPool.SPACE, StringPool.BLANK);
 		fileName = StringUtil.toLowerCase(fileName);
@@ -240,7 +247,44 @@ public class LicenseKeyExporter {
 		return fileName.concat(".xml");
 	}
 
-	protected Document toXMLVersion2(Map<String, String> properties, String key)
+	private Map<String, String> _getProperties(
+		String accountName, String licenseEntryName, String licenseType,
+		int licenseVersion, String productName, String productId,
+		String productVersion, String owner, int maxClusterNodes,
+		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+		long maxUsers, String sizing, String description, String domains,
+		String hostNames, String ipAddresses, String macAddresses,
+		String serverIds, Date startDate, Date expirationDate,
+		Date createDate) {
+
+		Map<String, String> properties = KeyGenerator.getProperties(
+			accountName, description, StringUtil.split(domains), expirationDate,
+			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
+			licenseEntryName, licenseType, String.valueOf(licenseVersion),
+			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
+			maxHttpSessions, maxServers, maxUsers, owner, productName,
+			productId, productVersion, new String[] {serverIds}, startDate);
+
+		// See LRDCOM-2568
+
+		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
+			productVersion.equals("6.1 GA 1")) {
+
+			Calendar cal = Calendar.getInstance();
+
+			cal.set(Calendar.DAY_OF_MONTH, 31);
+			cal.set(Calendar.MONTH, 6);
+			cal.set(Calendar.YEAR, 2012);
+
+			if (createDate.before(cal.getTime())) {
+				properties.put("productVersion", "6.1");
+			}
+		}
+
+		return properties;
+	}
+
+	private Document _toXMLVersion2(Map<String, String> properties, String key)
 		throws Exception {
 
 		Document document = SAXReaderUtil.createDocument();
@@ -318,8 +362,8 @@ public class LicenseKeyExporter {
 		return document;
 	}
 
-	protected Document toXMLVersion3_4(
-			Map<String, String> properties, String key, boolean aggregate)
+	private Document _toXMLVersion3_4(
+			Map<String, String> properties, boolean aggregate, String key)
 		throws Exception {
 
 		Document document = SAXReaderUtil.createDocument();
@@ -444,58 +488,13 @@ public class LicenseKeyExporter {
 				licenseEntryType.equals(LicenseConstants.TYPE_PER_USER) ||
 				licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
-				exportServerToXML(rootElement, properties);
+				_exportServerToXML(rootElement, properties);
 			}
 
 			_addElement(rootElement, "key", key);
 		}
 
 		return document;
-	}
-
-	private void _addElement(Element parentElement, String name, String value) {
-		Element childElement = parentElement.addElement(name);
-
-		if (value != null) {
-			childElement.addText(value);
-		}
-	}
-
-	private Map<String, String> _getProperties(
-		String accountName, String licenseEntryName, String licenseType,
-		int licenseVersion, String productName, String productId,
-		String productVersion, String owner, int maxClusterNodes,
-		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
-		long maxUsers, String sizing, String description, String domains,
-		String hostNames, String ipAddresses, String macAddresses,
-		String serverIds, Date startDate, Date expirationDate,
-		Date createDate) {
-
-		Map<String, String> properties = KeyGenerator.getProperties(
-			accountName, description, StringUtil.split(domains), expirationDate,
-			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
-			licenseEntryName, licenseType, String.valueOf(licenseVersion),
-			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
-			maxHttpSessions, maxServers, maxUsers, owner, productName,
-			productId, productVersion, new String[] {serverIds}, startDate);
-
-		// See LRDCOM-2568
-
-		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
-			productVersion.equals("6.1 GA 1")) {
-
-			Calendar cal = Calendar.getInstance();
-
-			cal.set(Calendar.DAY_OF_MONTH, 31);
-			cal.set(Calendar.MONTH, 6);
-			cal.set(Calendar.YEAR, 2012);
-
-			if (createDate.before(cal.getTime())) {
-				properties.put("productVersion", "6.1");
-			}
-		}
-
-		return properties;
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89421

## What Is Being Fixed

The liferay-one provisioning hub needs to generate and export Liferay activation keys from its Spring Boot client extension. The key-generation logic (KeyGeneratorImpl and the shared license classes) lived only in liferay-release-tool-ee and was not consumable from the workspace.

## How It Is Being Fixed

A cloneReleaseToolEE Gradle task sparse-clones the ext/shared sources from liferay/liferay-release-tool-ee and adds ext-impl/src to the Spring Boot module's main source set, so the ported KeyGenerator and LicenseConstants compile directly into the client extension. compileJava depends on the clone task, the cloned directory is git-ignored, excluded from source formatting, and removed by clean. A new LicenseKeyExporter component consumes the KeyGenerator to build and aggregate activation-key XML and file names, and ProductVersion supplies the product version constants it needs.

## Why Are There No Tests?

The liferay-one workspace does not yet have a test harness, so there is no place to add automated tests for this client extension.

## PR Check

**pr-check: PASS** — tested on `4d993e2b20b0fb1935175030be81a007c19c1005`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "4d993e2b20b0fb1935175030be81a007c19c1005"} -->