### PR TITLE
LPD-54024 Add publisher dashboard

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
@@ -3633,6 +3633,24 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_FULL_NAME",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Full Name"
+					},
+					"name": "fullName",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
 					"externalReferenceCode": "C_PUBLISHER_DETAILS_LOCATION",
 					"indexed": true,
 					"indexedAsKeyword": false,
@@ -3641,6 +3659,60 @@
 						"en_US": "Location"
 					},
 					"name": "location",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_PAYPAL_ACCOUNT",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Paypal Account"
+					},
+					"name": "paypalAccount",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_PHONE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Phone"
+					},
+					"name": "phone",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_PRIVATE_EMAIL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Private Email"
+					},
+					"name": "privateEmail",
 					"objectFieldSettings": [
 					],
 					"required": false,
@@ -3689,6 +3761,42 @@
 					"type": "Clob"
 				},
 				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_ROLE",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Role"
+					},
+					"name": "role",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_SALES_EMAIL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Sales Email"
+					},
+					"name": "salesEmail",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
 					"DBType": "Boolean",
 					"businessType": "Boolean",
 					"externalReferenceCode": "C_PUBLISHER_DETAILS_SHOW_CONTACT_FORM",
@@ -3723,6 +3831,24 @@
 					"state": false,
 					"system": false,
 					"type": "Boolean"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
+					"externalReferenceCode": "C_PUBLISHER_DETAILS_SUPPORT_EMAIL",
+					"indexed": true,
+					"indexedAsKeyword": false,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Support Email"
+					},
+					"name": "supportEmail",
+					"objectFieldSettings": [
+					],
+					"required": false,
+					"state": false,
+					"system": false,
+					"type": "String"
 				},
 				{
 					"DBType": "Clob",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherCatalog.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherCatalog.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {SWRConfiguration} from 'swr';
+
+import SearchBuilder from '../core/SearchBuilder';
+import {Liferay} from '../liferay/liferay';
+import HeadlessCommerceAdminCatalog from '../services/rest/HeadlessCommerceAdminCatalog';
+
+/**
+ * Resolves the Commerce catalog owned by the currently selected account. The
+ * publisher's catalog scopes every published app and solution, so it is the
+ * anchor for the rest of the dashboard.
+ */
+const usePublisherCatalog = (swrOptions?: SWRConfiguration) => {
+	const accountId = Liferay.CommerceContext.account?.accountId;
+
+	return useSWR(
+		accountId ? `/publisher-catalog/${accountId}` : null,
+		async () => {
+			const {items} = await HeadlessCommerceAdminCatalog.getCatalogs(
+				new URLSearchParams({
+					filter: SearchBuilder.unquote(
+						SearchBuilder.eq('accountId', accountId!)
+					),
+				})
+			);
+
+			return items?.[0] ?? null;
+		},
+		swrOptions
+	);
+};
+
+export default usePublisherCatalog;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherDetails.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/usePublisherDetails.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR, {SWRConfiguration} from 'swr';
+
+import SearchBuilder from '../core/SearchBuilder';
+import PublisherDetails from '../services/rest/PublisherDetails';
+
+/**
+ * Loads the PublisherDetails record for a catalog. There is a single record per
+ * publisher account, keyed to the account's Commerce catalog through catalogId.
+ */
+const usePublisherDetails = (
+	catalogId?: number | null,
+	swrOptions?: SWRConfiguration
+) => {
+	const {data, error, isLoading, mutate} = useSWR(
+		catalogId ? `/publisher-details/${catalogId}` : null,
+		async () => {
+			const {items} = await PublisherDetails.getPublisherDetails(
+				new URLSearchParams({
+					filter: SearchBuilder.unquote(
+						SearchBuilder.eq('catalogId', catalogId!)
+					),
+				})
+			);
+
+			return items?.[0] ?? null;
+		},
+		swrOptions
+	);
+
+	return {error, isLoading, mutate, publisherDetails: data};
+};
+
+export default usePublisherDetails;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -201,7 +201,9 @@ export default {
 	'comment': 'Comment',
 	'comments': 'Comments',
 	'commerce': 'Commerce',
+	'company-address': 'Company Address',
 	'company-description': 'Company Description',
+	'company-email': 'Company Email',
 	'company-name': 'Company Name',
 	'company-profile': 'Company Profile',
 	'compatible-offering': 'Compatible Offering',
@@ -323,6 +325,7 @@ export default {
 	'edit': 'Edit',
 	'edit-details': 'Edit Details',
 	'edit-event': 'Edit Event',
+	'edit-publisher-profile': 'Edit Publisher Profile',
 	'elasticsearch': 'Elasticsearch',
 	'email': 'Email',
 	'email-address': 'Email Address',
@@ -586,6 +589,7 @@ export default {
 	'manage-your-account-and-organization-details':
 		'Manage your account and organization details.',
 	'manage-your-current-trials': 'Manage your current trials',
+	'manage-your-data-and-contacts': 'Manage your data and contacts',
 	'manage-your-products-purchased-from-the-marketplace':
 		'Manage your products purchased from the Marketplace.',
 	'manage-your-teams-trial': "Manage your team's trial",
@@ -647,6 +651,8 @@ export default {
 	'no-orders-yet': 'No Orders Yet',
 	'no-products-yet': 'No Products Yet',
 	'no-projects-available-for-x': 'No projects available for {0}',
+	'no-publisher-catalog-found': 'No Publisher Catalog Found',
+	'no-publisher-profile-to-update': 'There is no publisher profile to update',
 	'no-results-found': 'No Results Found',
 	'no-trials-yet': 'No Trials Yet',
 	'no-x': 'No {0}',
@@ -749,6 +755,7 @@ export default {
 	'primary': 'Primary',
 	'primary-contact': 'Primary Contact',
 	'privacy-policy': 'Privacy Policy',
+	'private-information': 'Private Information',
 	'processing': 'Processing',
 	'product': 'Product',
 	'product-details': 'Product Details',
@@ -772,6 +779,7 @@ export default {
 	'provided-by': 'Provided By',
 	'provisioning': 'Provisioning',
 	'provisioning-details': 'Provisioning Details',
+	'public-information': 'Public Information',
 	'publish-apps-and-they-will-show-up-here':
 		'Publish apps and they will show up here.',
 	'publish-apps-to-the-liferay-marketplace':
@@ -779,6 +787,7 @@ export default {
 	'publish-new-app': 'Publish New App',
 	'published-apps': 'Published Apps',
 	'published-at': 'Published At',
+	'published-solutions': 'Published Solutions',
 	'publisher': 'Publisher',
 	'publisher-account-request': 'Publisher Account Request',
 	'publisher-dashboard': 'Publisher Dashboard',
@@ -786,6 +795,7 @@ export default {
 	'publisher-id': 'Publisher ID',
 	'publisher-name': 'Publisher Name',
 	'publisher-payout': 'Publisher Payout',
+	'publisher-profile': 'Publisher Profile',
 	'publisher-requests': 'Publisher Requests',
 	'publisher-type': 'Publisher Type',
 	'publisher-website': 'Publisher Website',
@@ -816,6 +826,7 @@ export default {
 	'recent-trials': 'Recent Trials',
 	'recently-published': 'Recently Published',
 	'record-actual-event-date': 'Record Actual Event Date',
+	'reimbursement': 'Reimbursement',
 	'reject-request': 'Reject Request',
 	'remove': 'Remove',
 	'remove-all-roles': 'Remove all roles',
@@ -848,6 +859,7 @@ export default {
 	'saas-environments': 'SaaS Environments',
 	'saas-trials': 'SaaS Trials',
 	'sale-type': 'Sale Type',
+	'sales-email': 'Sales Email',
 	'save': 'Save',
 	'save-as-a-draft-exit': 'Save as a Draft & Exit',
 	'save-as-draft': 'Save as Draft',
@@ -1063,6 +1075,7 @@ export default {
 	'unable-to-download-your-license-file-please-try-again-and-or-contact-support-via-the-manage-menu-on-the-dashboard':
 		'Unable to download your license file.  Please try again and/or contact support via the manage menu on the dashboard.',
 	'unable-to-remove-roles': 'Unable to remove roles',
+	'unable-to-update-publisher-profile': 'Unable to update publisher profile',
 	'under-review': 'Under Review',
 	'uninstall': 'Uninstall',
 	'unlock-exclusive-benefits-with-a-business-account':
@@ -1132,6 +1145,8 @@ export default {
 	'workspace-name': 'Workspace Name',
 	'workspace-owner-email': 'Workspace Owner Email',
 	'workspace-timezone': 'Workspace Timezone',
+	'x-apps-available': '{0} apps available',
+	'x-apps-x-solutions': '{0} Apps · {1} Solutions',
 	'x-available-for-you': `{0} available for <b>${Liferay.ThemeDisplay.getUserEmailAddress()}</b> (you)`,
 	'x-in-use': '{0} in use',
 	'x-is-required': '{0} is required',
@@ -1144,6 +1159,7 @@ export default {
 	'x-saved-as-a-draft-successfully':
 		'<b>{0}</b> saved as a <b>draft</b> successfully',
 	'x-selected': 'X Selected',
+	'x-solutions-available': '{0} solutions available',
 	'x-tickets': '{0} Tickets',
 	'x-was-uploaded-successfully': '{0} was uploaded successfully.',
 	'x-will-be-deleted-and-this-action-cant-be-undone-are-you-sure-you-want-to-delete-it':

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/main.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/main.tsx
@@ -25,6 +25,9 @@ const routers: Record<string, React.LazyExoticComponent<RouterComponent>> = {
 	),
 	'admin': React.lazy(() => import('./pages/Admin/AdminRouter')),
 	'my-account': React.lazy(() => import('./pages/MyAccount/MyAccountRouter')),
+	'publisher-dashboard': React.lazy(
+		() => import('./pages/PublisherDashboard/PublisherDashboardRouter')
+	),
 	'support': React.lazy(() => import('./pages/Support/SupportRouter')),
 };
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedApps.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedApps.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ProductTypeVocabulary} from '../../enums/Product';
+import i18n from '../../i18n';
+import {formatDate} from '../../utils/date';
+import PublishedProductsListView, {
+	renderAppType,
+	renderLiferayVersion,
+	renderProductName,
+	renderProductStatus,
+} from './PublishedProductsListView';
+
+export default function PublishedApps() {
+	return (
+		<PublishedProductsListView
+			categoryVocabulary={ProductTypeVocabulary.APP}
+			countWord="x-apps-available"
+			filterSchema="publisherApps"
+			id="publisher-published-apps"
+			tableProps={{
+				actions: [
+					{
+						icon: 'view',
+						name: i18n.translate('view-details'),
+						onClick: (product: Product) =>
+							window.open(product.urls?.en_US, '_blank'),
+					},
+				],
+				columns: [
+					{
+						clickable: true,
+						id: 'name',
+						name: i18n.translate('name'),
+						render: renderProductName,
+						sortable: true,
+					},
+					{
+						id: 'productSpecifications',
+						name: i18n.translate('app-type'),
+						render: renderAppType,
+					},
+					{
+						id: 'catalog',
+						name: i18n.translate('publisher'),
+						render: (catalog) => catalog?.name,
+					},
+					{
+						id: 'modifiedDate',
+						name: i18n.translate('last-update'),
+						render: (modifiedDate) => formatDate(modifiedDate),
+						sortable: true,
+					},
+					{
+						id: 'productSpecifications',
+						name: i18n.translate('liferay-version'),
+						render: renderLiferayVersion,
+					},
+					{
+						id: 'workflowStatusInfo',
+						name: i18n.translate('status'),
+						render: renderProductStatus,
+					},
+				],
+			}}
+			title="published-apps"
+		/>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedProductsListView.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedProductsListView.tsx
@@ -1,0 +1,196 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import EmptyState from '../../components/EmptyState';
+import ListView, {ListViewProps} from '../../components/ListView';
+import Loading from '../../components/Loading';
+import Page from '../../components/Page';
+import SearchBuilder from '../../core/SearchBuilder';
+import {
+	ProductSpecificationKey,
+	ProductTypeLabels,
+	ProductTypeVocabulary,
+	ProductWorkflowStatusCode,
+	ProductWorkflowStatusLabel,
+} from '../../enums/Product';
+import {useFetch} from '../../hooks/useFetch';
+import usePublisherCatalog from '../../hooks/usePublisherCatalog';
+import i18n, {Word} from '../../i18n';
+import {formatDate} from '../../utils/date';
+
+export const PRODUCTS_RESOURCE = `/o/headless-commerce-admin-catalog/v1.0/products?${new URLSearchParams(
+	{
+		'nestedFields': 'catalog,productSpecifications',
+		'productSpecifications.pageSize': '-1',
+		'sort': 'createDate:desc',
+	}
+)}`;
+
+const STATUS_DOT_COLOR: Record<number, string> = {
+	[ProductWorkflowStatusCode.APPROVED]: 'var(--color-success)',
+	[ProductWorkflowStatusCode.DRAFT]: 'var(--color-neutral-5)',
+	[ProductWorkflowStatusCode.PENDING]: 'var(--color-warning)',
+};
+
+export function buildCatalogCategoryFilter(
+	catalogId: number,
+	categoryVocabulary: ProductTypeVocabulary
+) {
+	return new SearchBuilder({useURIEncode: false})
+		.eq('catalogId', catalogId, {unquote: true})
+		.and()
+		.lambda('categoryNames', categoryVocabulary)
+		.build();
+}
+
+function specificationValue(
+	productSpecifications: ProductSpecification[],
+	key: ProductSpecificationKey
+) {
+	return productSpecifications?.find(
+		({specificationKey}) => specificationKey === key
+	)?.value?.en_US;
+}
+
+export function renderProductName(name: Product['name'], product: Product) {
+	return (
+		<div className="align-items-center d-flex">
+			<img
+				alt=""
+				src={product.thumbnail}
+				style={{
+					borderRadius: '0.5rem',
+					height: '2rem',
+					objectFit: 'cover',
+					width: '2rem',
+				}}
+			/>
+
+			<a
+				className="font-weight-semi-bold ml-2 text-nowrap"
+				href={product.urls?.en_US}
+			>
+				{name?.en_US}
+			</a>
+		</div>
+	);
+}
+
+export function renderAppType(productSpecifications: ProductSpecification[]) {
+	const type = specificationValue(
+		productSpecifications,
+		ProductSpecificationKey.APP_TYPE
+	);
+
+	return (
+		<span className="text-capitalize">
+			{ProductTypeLabels[type as keyof typeof ProductTypeLabels] ?? type}
+		</span>
+	);
+}
+
+export function renderLiferayVersion(
+	productSpecifications: ProductSpecification[]
+) {
+	return (
+		specificationValue(
+			productSpecifications,
+			ProductSpecificationKey.LIFERAY_VERSION
+		) ?? '-'
+	);
+}
+
+export function renderProductStatus(
+	workflowStatusInfo: Product['workflowStatusInfo']
+) {
+	return (
+		<span className="align-items-center d-flex">
+			<span
+				style={{
+					backgroundColor:
+						STATUS_DOT_COLOR[workflowStatusInfo.code] ??
+						'var(--color-neutral-5)',
+					borderRadius: '50%',
+					display: 'inline-block',
+					height: '0.5rem',
+					marginRight: '0.5rem',
+					width: '0.5rem',
+				}}
+			/>
+
+			{ProductWorkflowStatusLabel[
+				workflowStatusInfo.code as keyof typeof ProductWorkflowStatusLabel
+			] ?? workflowStatusInfo.label}
+		</span>
+	);
+}
+
+type PublishedProductsListViewProps = {
+	categoryVocabulary: ProductTypeVocabulary;
+	countWord: Word;
+	filterSchema: string;
+	id: string;
+	tableProps: ListViewProps<Product>['tableProps'];
+	title: Word;
+};
+
+export default function PublishedProductsListView({
+	categoryVocabulary,
+	countWord,
+	filterSchema,
+	id,
+	tableProps,
+	title,
+}: PublishedProductsListViewProps) {
+	const {data: catalog, isLoading} = usePublisherCatalog();
+
+	const catalogId = catalog?.id;
+
+	const baseFilter = catalogId
+		? buildCatalogCategoryFilter(catalogId, categoryVocabulary)
+		: undefined;
+
+	const {data: countData} = useFetch(catalogId ? PRODUCTS_RESOURCE : null, {
+		params: {filter: baseFilter, pageSize: 1},
+	});
+
+	if (isLoading) {
+		return <Loading className="mt-3" />;
+	}
+
+	if (!catalog) {
+		return (
+			<Page title={i18n.translate(title)}>
+				<EmptyState
+					title={i18n.translate('no-publisher-catalog-found')}
+					type="EMPTY_STATE"
+				/>
+			</Page>
+		);
+	}
+
+	return (
+		<Page
+			description={
+				countData?.totalCount != null
+					? i18n.sub(countWord, String(countData.totalCount))
+					: undefined
+			}
+			title={i18n.translate(title)}
+		>
+			<ListView<Product>
+				defaultFilters={{filter: baseFilter!}}
+				id={id}
+				managementToolbarProps={{
+					filterSchema,
+					searchVisible: true,
+					visible: true,
+				}}
+				resource={PRODUCTS_RESOURCE}
+				tableProps={tableProps}
+			/>
+		</Page>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedSolutions.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublishedSolutions.tsx
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ProductTypeVocabulary} from '../../enums/Product';
+import i18n from '../../i18n';
+import {formatDate} from '../../utils/date';
+import PublishedProductsListView, {
+	renderProductName,
+	renderProductStatus,
+} from './PublishedProductsListView';
+
+export default function PublishedSolutions() {
+	return (
+		<PublishedProductsListView
+			categoryVocabulary={ProductTypeVocabulary.SOLUTION}
+			countWord="x-solutions-available"
+			filterSchema="publisherSolutions"
+			id="publisher-published-solutions"
+			tableProps={{
+				actions: [
+					{
+						icon: 'view',
+						name: i18n.translate('view-details'),
+						onClick: (product: Product) =>
+							window.open(product.urls?.en_US, '_blank'),
+					},
+				],
+				columns: [
+					{
+						clickable: true,
+						id: 'name',
+						name: i18n.translate('name'),
+						render: renderProductName,
+						sortable: true,
+					},
+					{
+						id: 'modifiedDate',
+						name: i18n.translate('last-update'),
+						render: (modifiedDate) => formatDate(modifiedDate),
+						sortable: true,
+					},
+					{
+						id: 'workflowStatusInfo',
+						name: i18n.translate('status'),
+						render: renderProductStatus,
+					},
+				],
+			}}
+			title="published-solutions"
+		/>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardBreadcrumb.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardBreadcrumb.tsx
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+
+import i18n, {Word} from '../../i18n';
+
+type Crumb = {
+	href?: string;
+	label: Word;
+};
+
+const LINK_COLOR = 'var(--color-neutral-7)';
+const SEPARATOR_COLOR = 'var(--color-neutral-4)';
+const TEXT_COLOR = 'var(--color-neutral-10)';
+
+const TRAIL: Crumb[] = [
+	{href: '/', label: 'home'},
+	{href: '/web/one/my-account', label: 'my-accounts'},
+	{label: 'publisher-dashboard'},
+];
+
+export default function PublisherDashboardBreadcrumb() {
+	return (
+		<nav aria-label={i18n.translate('breadcrumb')} className="mb-3">
+			<ol
+				className="align-items-center d-flex flex-wrap list-unstyled m-0"
+				style={{gap: 'var(--spacer-2)'}}
+			>
+				{TRAIL.map((crumb, index) => {
+					const isLast = index === TRAIL.length - 1;
+					const text = i18n.translate(crumb.label);
+
+					return (
+						<li
+							className="align-items-center d-flex"
+							key={crumb.label}
+							style={{gap: 'var(--spacer-2)'}}
+						>
+							{isLast ? (
+								<span style={{color: TEXT_COLOR, fontWeight: 600}}>
+									{text}
+								</span>
+							) : (
+								<a
+									href={crumb.href}
+									style={{
+										color: LINK_COLOR,
+										textDecoration: 'none',
+									}}
+								>
+									{text}
+								</a>
+							)}
+
+							{!isLast && (
+								<ClayIcon
+									style={{
+										color: SEPARATOR_COLOR,
+										fontSize: '0.5em',
+										marginTop: '0',
+									}}
+									symbol="angle-right"
+								/>
+							)}
+						</li>
+					);
+				})}
+			</ol>
+		</nav>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardLayout.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardLayout.tsx
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useMemo} from 'react';
+
+import AppLayout from '../../components/AppLayout';
+import {buildNavItems} from '../../utils/routes';
+import PublisherDashboardBreadcrumb from './PublisherDashboardBreadcrumb';
+import {publisherDashboardRoutes} from './publisherDashboardRoutes';
+
+export default function PublisherDashboardLayout() {
+	const navItems = useMemo(() => buildNavItems(publisherDashboardRoutes), []);
+
+	return (
+		<AppLayout
+			breadcrumb={<PublisherDashboardBreadcrumb />}
+			navItems={navItems}
+		/>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardRouter.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherDashboardRouter.tsx
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {HashRouter, useRoutes} from 'react-router-dom';
+
+import {toRouteObjects} from '../../utils/routes';
+import PublisherDashboardLayout from './PublisherDashboardLayout';
+import {publisherDashboardRoutes} from './publisherDashboardRoutes';
+
+function PublisherDashboardRoutes() {
+	return useRoutes([
+		{
+			children: toRouteObjects(publisherDashboardRoutes),
+			element: <PublisherDashboardLayout />,
+			path: '/',
+		},
+	]);
+}
+
+export default function PublisherDashboardRouter() {
+	return (
+		<HashRouter>
+			<PublisherDashboardRoutes />
+		</HashRouter>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherProfile.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherProfile.tsx
@@ -1,0 +1,256 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ReactNode} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import Button from '../../components/Button';
+import {DetailedCard} from '../../components/DetailedCard/DetailedCard';
+import Page from '../../components/Page';
+import QATable, {Orientation} from '../../components/QATable';
+import {ProductTypeVocabulary} from '../../enums/Product';
+import {useFetch} from '../../hooks/useFetch';
+import usePublisherCatalog from '../../hooks/usePublisherCatalog';
+import usePublisherDetails from '../../hooks/usePublisherDetails';
+import i18n, {Word} from '../../i18n';
+import {
+	PRODUCTS_RESOURCE,
+	buildCatalogCategoryFilter,
+} from './PublishedProductsListView';
+
+const EMPTY_VALUE = '-';
+
+function ProfileSection({title}: {title: Word}) {
+	return (
+		<p
+			className="font-weight-semi-bold mb-2 mt-4 pb-2 text-secondary"
+			style={{borderBottom: '1px solid var(--color-neutral-3)'}}
+		>
+			{i18n.translate(title)}
+		</p>
+	);
+}
+
+function useProductCount(
+	catalogId: number | undefined,
+	categoryVocabulary: ProductTypeVocabulary
+) {
+	const filter = catalogId
+		? buildCatalogCategoryFilter(catalogId, categoryVocabulary)
+		: undefined;
+
+	const {data} = useFetch(catalogId ? PRODUCTS_RESOURCE : null, {
+		params: {filter, pageSize: 1},
+	});
+
+	return data?.totalCount as number | undefined;
+}
+
+function value(content?: ReactNode) {
+	return <p className="m-0">{content || EMPTY_VALUE}</p>;
+}
+
+export default function PublisherProfile() {
+	const navigate = useNavigate();
+
+	const {data: catalog, isLoading: isLoadingCatalog} = usePublisherCatalog();
+
+	const catalogId = catalog?.id;
+
+	const {isLoading: isLoadingDetails, publisherDetails} =
+		usePublisherDetails(catalogId);
+
+	const appsCount = useProductCount(catalogId, ProductTypeVocabulary.APP);
+	const solutionsCount = useProductCount(
+		catalogId,
+		ProductTypeVocabulary.SOLUTION
+	);
+
+	const details = publisherDetails ?? {};
+
+	return (
+		<Page
+			description={i18n.translate('manage-your-data-and-contacts')}
+			pageRendererProps={{
+				isLoading: isLoadingCatalog || isLoadingDetails,
+			}}
+			rightButton={
+				<Button
+					displayType="secondary"
+					onClick={() => navigate('edit')}
+				>
+					{i18n.translate('edit')}
+				</Button>
+			}
+			title={i18n.translate('publisher-profile')}
+		>
+			<div
+				className="mt-4"
+				style={{
+					display: 'grid',
+					gap: 'var(--spacer-4)',
+					gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
+				}}
+			>
+				<DetailedCard
+					cardIconAltText={i18n.translate('public-information')}
+					cardTitle={i18n.translate('public-information')}
+					clayIcon="globe"
+				>
+					<div className="align-items-center d-flex mb-3 mt-3">
+						{details.publisherProfileImageURL ? (
+							<img
+								alt={details.publisherName}
+								src={details.publisherProfileImageURL}
+								style={{
+									borderRadius: '50%',
+									height: '3rem',
+									objectFit: 'cover',
+									width: '3rem',
+								}}
+							/>
+						) : (
+							<span
+								className="align-items-center bg-neutral-2 d-flex justify-content-center"
+								style={{
+									borderRadius: '50%',
+									height: '3rem',
+									width: '3rem',
+								}}
+							>
+								{details.publisherName?.charAt(0) ?? 'P'}
+							</span>
+						)}
+
+						<div className="ml-3">
+							<p className="font-weight-bold h4 m-0">
+								{details.publisherName || EMPTY_VALUE}
+							</p>
+
+							<p className="m-0 text-secondary">
+								{i18n.sub('x-apps-x-solutions', [
+									String(appsCount ?? 0),
+									String(solutionsCount ?? 0),
+								])}
+							</p>
+						</div>
+					</div>
+
+					<ProfileSection title="profile" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('company-description'),
+								value: value(details.description),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+
+					<ProfileSection title="contacts" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('company-email'),
+								value: value(details.email),
+							},
+							{
+								title: i18n.translate('support-email'),
+								value: value(details.supportEmail),
+							},
+							{
+								title: i18n.translate('sales-email'),
+								value: value(details.salesEmail),
+							},
+							{
+								title: i18n.translate('website'),
+								value: details.websiteURL ? (
+									<a
+										href={details.websiteURL}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										{details.websiteURL}
+									</a>
+								) : (
+									value()
+								),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+
+					<ProfileSection title="address" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('company-address'),
+								value: value(details.location),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+
+				<DetailedCard
+					cardIconAltText={i18n.translate('private-information')}
+					cardTitle={i18n.translate('private-information')}
+					clayIcon="password"
+				>
+					<ProfileSection title="profile" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('full-name'),
+								value: value(details.fullName),
+							},
+							{
+								title: i18n.translate('role'),
+								value: value(details.role),
+							},
+							{
+								title: i18n.translate('publisher-id'),
+								value: value(details.id),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+
+					<ProfileSection title="contacts" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('email'),
+								value: value(details.privateEmail),
+							},
+							{
+								title: i18n.translate('phone'),
+								value: value(details.phone),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+
+					<ProfileSection title="reimbursement" />
+
+					<QATable
+						items={[
+							{
+								title: i18n.translate('paypal-account'),
+								value: value(details.paypalAccount),
+							},
+						]}
+						orientation={Orientation.VERTICAL}
+					/>
+				</DetailedCard>
+			</div>
+		</Page>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherProfileEdit.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/PublisherProfileEdit.tsx
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayAlert from '@clayui/alert';
+import ClayForm, {ClayInput} from '@clayui/form';
+import {ReactNode, useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+import Button from '../../components/Button';
+import {DetailedCard} from '../../components/DetailedCard/DetailedCard';
+import Page from '../../components/Page';
+import usePublisherCatalog from '../../hooks/usePublisherCatalog';
+import usePublisherDetails from '../../hooks/usePublisherDetails';
+import i18n, {Word} from '../../i18n';
+import PublisherDetailsService from '../../services/rest/PublisherDetails';
+
+type EditableField = {
+	component?: 'input' | 'textarea';
+	key: keyof PublisherDetailsEntry;
+	label: Word;
+	type?: string;
+};
+
+const PUBLIC_FIELDS: EditableField[] = [
+	{key: 'publisherName', label: 'publisher-name'},
+	{component: 'textarea', key: 'description', label: 'company-description'},
+	{key: 'email', label: 'company-email', type: 'email'},
+	{key: 'supportEmail', label: 'support-email', type: 'email'},
+	{key: 'salesEmail', label: 'sales-email', type: 'email'},
+	{key: 'websiteURL', label: 'website'},
+	{key: 'location', label: 'company-address'},
+];
+
+const PRIVATE_FIELDS: EditableField[] = [
+	{key: 'fullName', label: 'full-name'},
+	{key: 'role', label: 'role'},
+	{key: 'privateEmail', label: 'email', type: 'email'},
+	{key: 'phone', label: 'phone'},
+	{key: 'paypalAccount', label: 'paypal-account'},
+];
+
+const ALL_FIELDS = [...PUBLIC_FIELDS, ...PRIVATE_FIELDS];
+
+export default function PublisherProfileEdit() {
+	const navigate = useNavigate();
+
+	const {data: catalog, isLoading: isLoadingCatalog} = usePublisherCatalog();
+
+	const catalogId = catalog?.id;
+
+	const {
+		isLoading: isLoadingDetails,
+		mutate,
+		publisherDetails,
+	} = usePublisherDetails(catalogId);
+
+	const [form, setForm] = useState<Partial<PublisherDetailsEntry>>({});
+	const [error, setError] = useState<string>();
+	const [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		if (publisherDetails) {
+			setForm(publisherDetails);
+		}
+	}, [publisherDetails]);
+
+	const onChange = (key: keyof PublisherDetailsEntry, fieldValue: string) =>
+		setForm((previous) => ({...previous, [key]: fieldValue}));
+
+	const onSave = async () => {
+		if (!publisherDetails?.id) {
+			setError(i18n.translate('no-publisher-profile-to-update'));
+
+			return;
+		}
+
+		setError(undefined);
+		setSaving(true);
+
+		try {
+			const body = ALL_FIELDS.reduce<Partial<PublisherDetailsEntry>>(
+				(accumulator, {key}) => {
+					(accumulator as Record<string, unknown>)[key] = form[key];
+
+					return accumulator;
+				},
+				{}
+			);
+
+			await PublisherDetailsService.patchPublisherDetails(
+				publisherDetails.id,
+				body
+			);
+
+			await mutate();
+
+			navigate('..');
+		}
+		catch (requestError) {
+			setError(
+				(requestError as Error)?.message ??
+					i18n.translate('unable-to-update-publisher-profile')
+			);
+		}
+		finally {
+			setSaving(false);
+		}
+	};
+
+	const renderField = ({component, key, label, type}: EditableField) => (
+		<ClayForm.Group key={key}>
+			<label htmlFor={`publisher-${key}`}>{i18n.translate(label)}</label>
+
+			<ClayInput
+				component={component === 'textarea' ? 'textarea' : 'input'}
+				id={`publisher-${key}`}
+				onChange={(event) => onChange(key, event.target.value)}
+				type={type ?? 'text'}
+				value={(form[key] as string) ?? ''}
+			/>
+		</ClayForm.Group>
+	);
+
+	const card = (
+		title: Word,
+		clayIcon: string,
+		fields: EditableField[]
+	): ReactNode => (
+		<DetailedCard
+			cardIconAltText={i18n.translate(title)}
+			cardTitle={i18n.translate(title)}
+			clayIcon={clayIcon}
+		>
+			<div className="mt-3">{fields.map(renderField)}</div>
+		</DetailedCard>
+	);
+
+	return (
+		<Page
+			description={i18n.translate('manage-your-data-and-contacts')}
+			pageRendererProps={{
+				isLoading: isLoadingCatalog || isLoadingDetails,
+			}}
+			rightButton={
+				<div className="d-flex" style={{gap: 'var(--spacer-2)'}}>
+					<Button
+						disabled={saving}
+						displayType="secondary"
+						onClick={() => navigate('..')}
+					>
+						{i18n.translate('cancel')}
+					</Button>
+
+					<Button
+						displayType="primary"
+						isLoading={saving}
+						onClick={onSave}
+					>
+						{i18n.translate('save')}
+					</Button>
+				</div>
+			}
+			title={i18n.translate('edit-publisher-profile')}
+		>
+			{error && (
+				<ClayAlert displayType="danger" title={i18n.translate('error')}>
+					{error}
+				</ClayAlert>
+			)}
+
+			<div
+				className="mt-4"
+				style={{
+					display: 'grid',
+					gap: 'var(--spacer-4)',
+					gridTemplateColumns: 'repeat(auto-fit, minmax(20rem, 1fr))',
+				}}
+			>
+				{card('public-information', 'globe', PUBLIC_FIELDS)}
+
+				{card('private-information', 'password', PRIVATE_FIELDS)}
+			</div>
+		</Page>
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/publisherDashboardRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/PublisherDashboard/publisherDashboardRoutes.tsx
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {lazy} from 'react';
+import {Navigate} from 'react-router-dom';
+
+import {AppRoute} from '../../utils/routes';
+
+const PublishedApps = lazy(() => import('./PublishedApps'));
+const PublishedSolutions = lazy(() => import('./PublishedSolutions'));
+const PublisherProfile = lazy(() => import('./PublisherProfile'));
+const PublisherProfileEdit = lazy(() => import('./PublisherProfileEdit'));
+
+export const publisherDashboardRoutes: AppRoute[] = [
+	{element: <Navigate replace to="published-apps" />, index: true},
+	{
+		element: <PublishedApps />,
+		nav: {icon: 'catalog', label: 'Published Apps'},
+		path: 'published-apps',
+	},
+	{
+		element: <PublishedSolutions />,
+		nav: {icon: 'list', label: 'Published Solutions'},
+		path: 'published-solutions',
+	},
+	{
+		children: [
+			{element: <PublisherProfile />, index: true},
+			{element: <PublisherProfileEdit />, path: 'edit'},
+			{element: <Navigate replace to="." />, path: '*'},
+		],
+		nav: {icon: 'user', label: 'Publisher Profile'},
+		path: 'publisher-profile',
+	},
+	{element: <Navigate replace to="published-apps" />, path: '*'},
+];

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/filters.ts
@@ -463,6 +463,98 @@ export const filterSchema: FilterSchemas = {
 		],
 		name: 'financePayments',
 	},
+	publisherApps: {
+		fields: [
+			overrides(baseFilters.type, {
+				label: i18n.translate('app-type'),
+				name: 'specificationValues|appType',
+				operator: 'lambda',
+				options: [
+					{
+						label: i18n.translate('client-extension'),
+						value: ProductType.CLIENT_EXTENSION,
+					},
+					{
+						label: i18n.translate('cloud-app'),
+						value: ProductType.CLOUD,
+					},
+					{
+						label: i18n.translate('composite-app'),
+						value: ProductType.COMPOSITE_APP,
+					},
+					{
+						label: i18n.translate('dxp-app'),
+						value: ProductType.DXP,
+					},
+					{
+						label: i18n.translate('low-code-configuration'),
+						value: ProductType.LOW_CODE_CONFIGURATION,
+					},
+					{
+						label: i18n.translate('other'),
+						value: ProductType.OTHER,
+					},
+				],
+				type: 'checkbox',
+			}),
+			overrides(baseFilters.version, {
+				label: i18n.translate('liferay-version'),
+				name: 'specificationValues|liferayVersion',
+				operator: 'lambda',
+				resource: `o/headless-admin-list-type/v1.0/list-type-definitions/by-external-reference-code/${LIFERAY_VERSION_PICKLIST}`,
+				transformData: (item) =>
+					item.listTypeEntries.map((entry: any) => ({
+						label: entry.name,
+						value: entry.name,
+					})),
+				type: 'multiselect',
+			}),
+			overrides(baseFilters.status, {
+				name: 'statusCode',
+				options: [
+					{
+						label: i18n.translate('approved'),
+						value: `${ProductWorkflowStatusCode.APPROVED}`,
+					},
+					{
+						label: i18n.translate('draft'),
+						value: `${ProductWorkflowStatusCode.DRAFT}`,
+					},
+					{
+						label: i18n.translate('pending'),
+						value: `${ProductWorkflowStatusCode.PENDING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'select',
+			}),
+		],
+		name: 'publisherApps',
+	},
+	publisherSolutions: {
+		fields: [
+			overrides(baseFilters.status, {
+				name: 'statusCode',
+				options: [
+					{
+						label: i18n.translate('approved'),
+						value: `${ProductWorkflowStatusCode.APPROVED}`,
+					},
+					{
+						label: i18n.translate('draft'),
+						value: `${ProductWorkflowStatusCode.DRAFT}`,
+					},
+					{
+						label: i18n.translate('pending'),
+						value: `${ProductWorkflowStatusCode.PENDING}`,
+					},
+				],
+				removeQuoteMark: true,
+				type: 'select',
+			}),
+		],
+		name: 'publisherSolutions',
+	},
 };
 
 export type FilterSchemaOption = keyof typeof filterSchema;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/PublisherDetails.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/PublisherDetails.ts
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+export default class PublisherDetails {
+	static async getPublisherDetails(params = new URLSearchParams()) {
+		return fetcher<APIResponse<PublisherDetailsEntry>>(
+			`/o/c/publisherdetailses?${params}`
+		);
+	}
+
+	static async getPublisherDetailsById(
+		entryId: number | string,
+		params = new URLSearchParams()
+	) {
+		return fetcher<PublisherDetailsEntry>(
+			`/o/c/publisherdetailses/${entryId}?${params}`
+		);
+	}
+
+	static async patchPublisherDetails(
+		entryId: number | string,
+		body: Partial<PublisherDetailsEntry>
+	) {
+		return fetcher.patch<PublisherDetailsEntry>(
+			`/o/c/publisherdetailses/${entryId}`,
+			body
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/misc.d.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/misc.d.ts
@@ -68,6 +68,29 @@ type ListTypeDefinition = {
 	name: string;
 };
 
+type PublisherDetailsEntry = {
+	catalogId?: number;
+	dateCreated?: string;
+	dateModified?: string;
+	description?: string;
+	email?: string;
+	externalReferenceCode?: string;
+	fullName?: string;
+	id?: number;
+	location?: string;
+	paypalAccount?: string;
+	phone?: string;
+	privateEmail?: string;
+	publisherName?: string;
+	publisherProfileImageURL?: string;
+	role?: string;
+	salesEmail?: string;
+	showContactForm?: boolean;
+	showOnHomePage?: boolean;
+	supportEmail?: string;
+	websiteURL?: string;
+};
+
 type PublisherRequestInfo = {
 	creator: {name: string};
 	dateCreated: string;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-values.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-values.json
@@ -349,7 +349,7 @@
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_PROJECT_AND_ORDERS#]",
 		"columnName": "Submenu Column Span",
-		"data": "4"
+		"data": "6"
 	},
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
@@ -361,7 +361,7 @@
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",
 		"classPk": "[#SITE_NAVIGATION_MENU_ITEM_ID:LO_NAV_MY_ACCOUNT_ACCOUNT_AND_MEMBERS#]",
 		"columnName": "Submenu Column Span",
-		"data": "4"
+		"data": "6"
 	},
 	{
 		"className": "com.liferay.site.navigation.model.SiteNavigationMenuItem",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/02_my-account/01_publisher-dashboard/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/02_my-account/01_publisher-dashboard/page-definition.json
@@ -1,0 +1,61 @@
+{
+	"masterPage": {
+		"key": "liferay-one"
+	},
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"fragmentStyle": {
+						"paddingTop": "3"
+					},
+					"indexed": true,
+					"layout": {
+						"widthType": "Fixed"
+					}
+				},
+				"pageElements": [
+					{
+						"definition": {
+							"gutters": true,
+							"indexed": true,
+							"modulesPerRow": 1,
+							"numberOfColumns": 1,
+							"reverseOrder": false,
+							"verticalAlignment": "top"
+						},
+						"pageElements": [
+							{
+								"definition": {
+									"size": 12
+								},
+								"pageElements": [
+									{
+										"definition": {
+											"widgetInstance": {
+												"widgetConfig": {
+													"properties": "route=publisher-dashboard"
+												},
+												"widgetName": "[$CLIENT_EXTENSION_ENTRY_ERC:LXC:liferay-one-custom-element$]"
+											}
+										},
+										"type": "Widget"
+									}
+								],
+								"type": "Column"
+							}
+						],
+						"type": "Row"
+					}
+				],
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"masterPage": {
+			"key": "liferay-one"
+		}
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/02_my-account/01_publisher-dashboard/page.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/02_my-account/01_publisher-dashboard/page.json
@@ -1,0 +1,11 @@
+{
+	"friendlyURL": "/my-account/publisher-dashboard",
+	"hidden": false,
+	"name": "Publisher Dashboard",
+	"name_i18n": {
+		"en_US": "Publisher Dashboard"
+	},
+	"private": false,
+	"system": false,
+	"type": "Content"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/site-navigation-menus.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/site-navigation-menus.json
@@ -254,7 +254,7 @@
 									"en_US": "Publisher Dashboard"
 								},
 								"type": "url",
-								"url": "/web/one/marketplace/publisher-dashboard",
+								"url": "/web/one/my-account/publisher-dashboard",
 								"useNewTab": "false"
 							}
 						],


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-54024

## What is being fixed

Marketplace publishers had no self-service surface to review and manage
the apps, solutions, and products they publish, or to maintain their
public publisher profile.

## How it is being fixed

This adds a Publisher Dashboard SPA that lives under My Account
(/my-account/publisher-dashboard) and is reachable from the account mega
menu. The dashboard is a new custom-element route (PublisherDashboardRouter)
with views for published apps, published solutions, a published products
list, and a publisher profile with a view and edit mode. Data is sourced
through new usePublisherCatalog and usePublisherDetails hooks and a
PublisherDetails REST service, with supporting filter schema, i18n keys,
and type definitions.

The site initializer wires the page in as a child of My Account and adds
the navigation link, gated to users with the Marketplace Publisher role.
The two account mega-menu sections are set to span six columns each so
they render at an even 50/50 width. A batch object-definition entry backs
the publisher data model.
