### PR TITLE
LPD-89623 Read the Salesforce object name from salesforceObjectName

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/SalesforceObjectSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/SalesforceObjectSubscriber.java
@@ -59,7 +59,8 @@ public class SalesforceObjectSubscriber extends BasePubsubSubscriber {
 			JSONObject jsonObject = new JSONObject(message.getPayload());
 
 			String action = jsonObject.getString("action");
-			String salesforceObjectName = jsonObject.getString("sObjectName");
+			String salesforceObjectName = jsonObject.getString(
+				"salesforceObjectName");
 
 			JSONArray recordsJSONArray = jsonObject.getJSONArray("records");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89623

## What is being fixed

The Salesforce object pub/sub payload contract changed: the field that identifies the Salesforce object is now delivered as `salesforceObjectName` instead of `sObjectName`, and the UAT subscriptions were renamed. With the old field name the subscriber could no longer read the object type and would fail to route Product2 and PricebookEntry records.

## How it is being fixed

`SalesforceObjectSubscriber` now reads the object name from the `salesforceObjectName` payload field. The subscription name itself is resolved from the `LIFERAY_ONE_PUBSUB_SUBSCRIBER_SALESFORCE_OBJECT_SUBSCRIPTION` environment value, so the subscription rename is a deployment-config change and needs no code change.
