### PR TITLE
LPD-89029 Run the Spring Boot client extension as a Compose service

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/skills/one-bootstrap/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-bootstrap/SKILL.md
@@ -10,11 +10,13 @@ name: one-bootstrap
 
 Manage the local Liferay Docker environment via `scripts/bootstrap.sh`. Run from `workspaces/liferay-one-workspace/`.
 
+The `up` bootstrap also builds the `liferay-one-etc-spring-boot:local` image, so the `liferay-one-etc-spring-boot` client extension comes up as a Docker Compose service alongside the portal and database rather than being started separately.
+
 ## Commands
 
 | Command | What it does |
 |---------|-------------|
-| `up` (default) | Extract hotfix/license → build image → tag → `docker compose up` → wait for health → deploy client extensions |
+| `up` (default) | Extract hotfix/license → build image → tag → build `liferay-one-etc-spring-boot:local` image → `docker compose up` → wait for health → deploy client extensions |
 | `start` | `docker compose start` |
 | `stop` | `docker compose stop` |
 | `down` | `docker compose down` |

--- a/workspaces/liferay-one-workspace/.agents/skills/one-deploy/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-deploy/SKILL.md
@@ -36,4 +36,6 @@ Check `git diff --name-only` and pick every touched `client-extensions/liferay-o
     -Ddeploy.docker.container.id=$(docker compose -f ~/repos/lfris-www/docker-compose.yml ps -q liferay)
 ```
 
+Deploy also rebuilds the `liferay-one-etc-spring-boot:local` image and recreates the `liferay-one-etc-spring-boot` container, so the deployed `liferay-one-etc-spring-boot` client extension picks up code changes.
+
 Report: what was deployed, Gradle result, and log evidence of pickup.

--- a/workspaces/liferay-one-workspace/.agents/skills/one-env-down/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-env-down/SKILL.md
@@ -10,7 +10,7 @@ name: one-env-down
 
 Run from `workspaces/liferay-one-workspace/`.
 
-Stops all containers but preserves volumes so the next `/one-env-up` resumes where it left off.
+Stops all containers — the portal, the database, and the `liferay-one-etc-spring-boot` client extension — but preserves volumes so the next `/one-env-up` resumes where it left off.
 
 ```bash
 docker compose stop

--- a/workspaces/liferay-one-workspace/.agents/skills/one-env-up/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-env-up/SKILL.md
@@ -23,7 +23,7 @@ docker image inspect liferay:local &>/dev/null
 
 ## 2. First Run (Bootstrap)
 
-Run `scripts/bootstrap.sh`. It builds the Docker image, tags it, starts the containers, waits for Liferay to be healthy, and deploys the client extensions.
+Run `scripts/bootstrap.sh`. It builds the Docker image, tags it, builds the `liferay-one-etc-spring-boot:local` image, starts the containers, waits for Liferay to be healthy, and deploys the client extensions.
 
 ```bash
 scripts/bootstrap.sh
@@ -33,10 +33,16 @@ Liferay is ready when it prints `Done. Liferay is running at http://localhost:80
 
 ## 3. Day-to-Day Start
 
-Start the existing containers in the background:
+Start the existing containers in the background. This brings up the portal, the database, and the `liferay-one-etc-spring-boot` client extension together:
 
 ```bash
 docker compose up --detach
 ```
 
-Wait until `http://localhost:8080/c/portal/status` returns HTTP 200, then report success.
+Wait until `http://localhost:8080/c/portal/status` returns HTTP 200. Then confirm the client extension is serving on port 58081:
+
+```bash
+curl --fail --silent http://localhost:58081/ready
+```
+
+Report success once both respond.

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/scripts/build_spring_boot_image.sh
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/scripts/build_spring_boot_image.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function main {
+	local script_dir
+
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+	local client_extension_dir="${script_dir}/.."
+	local workspace_dir="${client_extension_dir}/../.."
+
+	cd "${workspace_dir}"
+
+	echo "Building boot jar."
+	./gradlew :client-extensions:liferay-one-etc-spring-boot:bootJar
+
+	local libs_dir="${client_extension_dir}/build/libs"
+	local staging_dir="${client_extension_dir}/build/docker"
+
+	echo "Staging Docker build context in ${staging_dir}."
+	rm -rf "${staging_dir}"
+	mkdir -p "${staging_dir}"
+
+	cp "${libs_dir}/liferay-one-etc-spring-boot.jar" "${staging_dir}"
+	cp "${client_extension_dir}/Dockerfile" "${staging_dir}"
+
+	echo "Building liferay-one-etc-spring-boot:local image."
+	docker build --tag liferay-one-etc-spring-boot:local "${staging_dir}"
+
+	echo "Generating local environment file from application-default.properties."
+	local properties_file="${client_extension_dir}/src/main/resources/application-default.properties"
+	local env_file="${client_extension_dir}/build/local.env"
+
+	grep -oE '[$][{][A-Z0-9_]+[}]' "${properties_file}" | tr -d '${}' | sort -u | sed 's/$/=unused/' > "${env_file}"
+
+	echo "Done. Built liferay-one-etc-spring-boot:local and wrote ${env_file}."
+}
+
+main "${@}"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/scripts/wait-for-routes.sh
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/scripts/wait-for-routes.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+while [ ! -f "${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.mainDomain" ]
+do
+	echo "Waiting for route metadata in ${LIFERAY_ROUTES_DXP}"
+
+	sleep 2
+done
+
+echo "Route metadata is present"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/SalesforceObjectSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/SalesforceObjectSubscriber.java
@@ -26,12 +26,16 @@ import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Kyle Bischof
  */
 @Component
+@ConditionalOnProperty(
+	havingValue = "true", name = "liferay.one.pubsub.subscriber.enabled"
+)
 public class SalesforceObjectSubscriber extends BasePubsubSubscriber {
 
 	@Override

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -46,6 +46,7 @@ liferay.oauth.urls.excludes=/ready
 # Pub/Sub
 #
 
+liferay.one.pubsub.subscriber.enabled=${LIFERAY_ONE_PUBSUB_SUBSCRIBER_ENABLED}
 liferay.one.pubsub.subscriber.salesforce.object.project.id=${LIFERAY_ONE_PUBSUB_SUBSCRIBER_SALESFORCE_OBJECT_PROJECT_ID}
 liferay.one.pubsub.subscriber.salesforce.object.subscription=${LIFERAY_ONE_PUBSUB_SUBSCRIBER_SALESFORCE_OBJECT_SUBSCRIPTION}
 

--- a/workspaces/liferay-one-workspace/docker-compose.yaml
+++ b/workspaces/liferay-one-workspace/docker-compose.yaml
@@ -47,7 +47,32 @@ services:
             -   8000:8000
             -   8080:8080
             -   11311:11311
+            -   58081:58081
         volumes:
             -   liferay_data:/opt/liferay/data
+            -   liferay_routes:/opt/liferay/routes
+    liferay-one-etc-spring-boot:
+        container_name: liferay-one-etc-spring-boot
+        depends_on:
+            liferay:
+                condition: service_healthy
+        env_file:
+            -   ./client-extensions/liferay-one-etc-spring-boot/build/local.env
+        environment:
+            LIFERAY_JAR_RUNNER_JAVA_OPTS: --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED
+            LIFERAY_ROUTES_CLIENT_EXTENSION: /opt/liferay/routes/default/liferay-one-etc-spring-boot
+            LIFERAY_ROUTES_DXP: /opt/liferay/routes/default/dxp
+        healthcheck:
+            interval: 10s
+            retries: 30
+            start_period: 60s
+            test: ["CMD", "curl", "--fail", "--silent", "http://localhost:58081/ready"]
+            timeout: 5s
+        image: liferay-one-etc-spring-boot:local
+        network_mode: service:liferay
+        volumes:
+            -   liferay_routes:/opt/liferay/routes:ro
+            -   ./client-extensions/liferay-one-etc-spring-boot/scripts/wait-for-routes.sh:/usr/local/bin/liferay_jar_runner_set_up.sh:ro
 volumes:
     liferay_data:
+    liferay_routes:

--- a/workspaces/liferay-one-workspace/scripts/bootstrap.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap.sh
@@ -33,6 +33,9 @@ function main {
 	echo "Tagging ${workspace_name}-liferay:${version_tag} as liferay:local."
 	docker tag "${workspace_name}-liferay:${version_tag}" "liferay:local"
 
+	echo "Building Spring Boot client extension image."
+	bash client-extensions/liferay-one-etc-spring-boot/scripts/build_spring_boot_image.sh
+
 	echo "Starting containers."
 	docker compose --file docker-compose.yaml up --detach
 

--- a/workspaces/liferay-one-workspace/scripts/deploy_client_extensions.sh
+++ b/workspaces/liferay-one-workspace/scripts/deploy_client_extensions.sh
@@ -8,7 +8,13 @@ function main {
 	cd ..
 
 	./gradlew deploy \
-		-Ddeploy.docker.container.id="$(docker ps --quiet --filter "name=liferay")"
+		-Ddeploy.docker.container.id="$(docker ps --quiet --filter "name=^liferay$")"
+
+	echo "Rebuilding Spring Boot client extension image."
+	bash client-extensions/liferay-one-etc-spring-boot/scripts/build_spring_boot_image.sh
+
+	echo "Recreating Spring Boot client extension container."
+	docker compose up --detach liferay-one-etc-spring-boot
 }
 
 main "${@}"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89029

## What is being fixed

The liferay-one-etc-spring-boot client extension had no integrated, repeatable way to run locally. It had to be started by hand as a host JVM on port 58081, with route metadata copied out of the portal container and a long list of environment variables set manually — an undocumented, error-prone procedure separate from the rest of the environment workflow.

## How it is being fixed

The client extension now runs as a first-class Docker Compose service built from the liferay/jar-runner image, so /one-env-up, /one-bootstrap, and /one-deploy bring it up, rebuild it, and tear it down alongside the portal and database, and the standalone run skill is retired. The service shares the portal container's network namespace, which lets the LXC route metadata's localhost addresses resolve without rewriting, and the portal's generated routes are shared into the container through a volume so no manual copying is needed. The required configuration is generated from application-default.properties into a gitignored env file instead of being duplicated in the compose file, keeping a single source of truth. The Salesforce object subscriber also gains a liferay.one.pubsub.subscriber.enabled property so it can be turned off where Google Pub/Sub credentials are unavailable, such as local runs, defined as a no-default property consistent with the other subscriber configuration.