### PR TITLE
LPD-89421 Add license key exporter to the liferay-one workspace

### DIFF
--- a/workspaces/liferay-one-workspace/.gitignore
+++ b/workspaces/liferay-one-workspace/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.idea
 /bundles
+/client-extensions/liferay-one-etc-spring-boot/liferay-release-tool-ee
 /poshi/poshi-ext.properties
 /poshi/test-results
 /poshi/tests

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -25,16 +25,6 @@ clean {
 	delete liferayReleaseToolEEDir
 }
 
-def executeCommand = {
-	String command ->
-	def process = command.execute()
-
-	if (process.waitFor() != 0) {
-		throw new GradleException(
-			"Failed: ${command}\n${process.err.text}")
-	}
-}
-
 task cloneReleaseToolEE
 
 cloneReleaseToolEE {
@@ -45,9 +35,17 @@ cloneReleaseToolEE {
 	}
 
 	doLast {
-		executeCommand("git clone --branch master --filter=blob:none --no-checkout git@github.com:liferay/liferay-release-tool-ee.git ${liferayReleaseToolEEDir.absolutePath}")
-		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} sparse-checkout set --no-cone ext/shared")
-		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} checkout HEAD")
+		exec {
+			commandLine "git", "clone", "--branch", "master", "--filter=blob:none", "--no-checkout", "git@github.com:liferay/liferay-release-tool-ee.git", liferayReleaseToolEEDir.absolutePath
+		}
+
+		exec {
+			commandLine "git", "-C", liferayReleaseToolEEDir.absolutePath, "sparse-checkout", "set", "--no-cone", "ext/shared"
+		}
+
+		exec {
+			commandLine "git", "-C", liferayReleaseToolEEDir.absolutePath, "checkout", "HEAD"
+		}
 	}
 }
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
 	implementation group: "com.liferay", name: "com.liferay.notification.rest.client", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -19,6 +19,38 @@ apply plugin: "com.liferay.source.formatter"
 apply plugin: "java-library"
 apply plugin: "org.springframework.boot"
 
+def liferayReleaseToolEEDir = file("liferay-release-tool-ee")
+
+clean {
+	delete liferayReleaseToolEEDir
+}
+
+def executeCommand = {
+	String command ->
+	def process = command.execute()
+
+	if (process.waitFor() != 0) {
+		throw new GradleException(
+			"Failed: ${command}\n${process.err.text}")
+	}
+}
+
+task cloneReleaseToolEE
+
+cloneReleaseToolEE {
+	outputs.dir liferayReleaseToolEEDir
+
+	onlyIf {
+		!liferayReleaseToolEEDir.exists()
+	}
+
+	doLast {
+		executeCommand("git clone --branch master --filter=blob:none --no-checkout git@github.com:liferay/liferay-release-tool-ee.git ${liferayReleaseToolEEDir.absolutePath}")
+		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} sparse-checkout set --no-cone ext/shared")
+		executeCommand("git -C ${liferayReleaseToolEEDir.absolutePath} checkout HEAD")
+	}
+}
+
 dependencies {
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
@@ -41,3 +73,13 @@ repositories {
 		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
 	}
 }
+
+sourceSets {
+	main {
+		java {
+			srcDirs += "liferay-release-tool-ee/ext/shared/ext-impl/src"
+		}
+	}
+}
+
+compileJava.dependsOn cloneReleaseToolEE

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/source-formatter.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/source-formatter.properties
@@ -1,0 +1,6 @@
+##
+## Exclusions
+##
+
+    source.formatter.excludes=\
+        liferay-release-tool-ee/**

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Kyle Bischof
+ */
+public class ProductVersion {
+
+	public static final String COMMERCE_LICENSE_VERSION_1 = "1";
+
+	public static final String DXP_VERSION_7_0 = "7.0";
+
+	public static final String DXP_VERSION_7_1 = "7.1";
+
+	public static final String DXP_VERSION_7_2 = "7.2";
+
+	public static final String DXP_VERSION_7_3 = "7.3";
+
+	public static final String DXP_VERSION_7_4 = "7.4";
+
+	public static final String PORTAL_VERSION_5_1_3 = "5.1";
+
+	public static final String PORTAL_VERSION_5_1_4 = "5.1 SP1";
+
+	public static final String PORTAL_VERSION_5_1_5 = "5.1 SP2";
+
+	public static final String PORTAL_VERSION_5_1_6 = "5.1 SP3";
+
+	public static final String PORTAL_VERSION_5_1_7 = "5.1 SP4";
+
+	public static final String PORTAL_VERSION_5_1_8 = "5.1 SP5";
+
+	public static final String PORTAL_VERSION_5_2_4 = "5.2";
+
+	public static final String PORTAL_VERSION_5_2_5 = "5.2 SP1";
+
+	public static final String PORTAL_VERSION_5_2_6 = "5.2 SP2";
+
+	public static final String PORTAL_VERSION_5_2_7 = "5.2 SP3";
+
+	public static final String PORTAL_VERSION_5_2_8 = "5.2 SP4";
+
+	public static final String PORTAL_VERSION_5_2_9 = "5.2 SP5";
+
+	public static final String PORTAL_VERSION_6_0_10 = "6.0";
+
+	public static final String PORTAL_VERSION_6_0_11 = "6.0 SP1";
+
+	public static final String PORTAL_VERSION_6_0_12 = "6.0 SP2";
+
+	public static final String PORTAL_VERSION_6_1_10 = "6.1 GA1";
+
+	public static final String PORTAL_VERSION_6_1_20 = "6.1 GA2";
+
+	public static final String PORTAL_VERSION_6_1_30 = "6.1 GA3";
+
+	public static final String PORTAL_VERSION_6_2_10 = "6.2 EE";
+
+	public static String extractQuarterlyRelease(String version) {
+		if (Validator.isNotNull(version)) {
+			Matcher matcher = getQuarterlyReleaseMatcher(version);
+
+			if (matcher.find()) {
+				return StringUtil.toUpperCase(matcher.group());
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	public static Matcher getQuarterlyReleaseMatcher(String version) {
+		return _quarterlyReleaseVersionPattern.matcher(version);
+	}
+
+	private static final Pattern _quarterlyReleaseVersionPattern =
+		Pattern.compile("(\\d{4})\\.Q([1-4])", Pattern.CASE_INSENSITIVE);
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -6,25 +6,19 @@
 package com.liferay.one.license;
 
 import com.liferay.one.constants.ProductVersion;
-import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.ee.license.shared.KeyGenerator;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
-import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
-
-import java.io.IOException;
-import java.io.ObjectOutputStream;
 
 import java.text.DateFormat;
 
@@ -33,8 +27,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 import java.util.TimeZone;
 
 import org.springframework.stereotype.Component;
@@ -93,94 +85,6 @@ public class LicenseKeyExporter {
 		}
 
 		return formatFileName(sb.toString());
-	}
-
-	public String toEncodedLicenseFile(String serverId, String key) {
-		Properties licenseProperties = new Properties();
-
-		licenseProperties.setProperty("serverId", serverId);
-		licenseProperties.setProperty("licenseKey", key);
-
-		String licenseFileDecoded = PropertiesUtil.toString(licenseProperties);
-
-		return Base64.objectToString(licenseFileDecoded);
-	}
-
-	public String toLI(
-			String key, String accountName, String licenseEntryName,
-			String licenseType, int licenseVersion, String productName,
-			String productId, String productVersion, String owner,
-			int maxClusterNodes, int maxServers, int maxHttpSessions,
-			long maxConcurrentUsers, long maxUsers, String sizing,
-			String description, String domains, String hostName,
-			String ipAddresses, String macAddresses, String serverId,
-			Date startDate, Date expirationDate)
-		throws IOException {
-
-		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-				new UnsyncByteArrayOutputStream();
-
-			ObjectOutputStream objectOutputStream = new ObjectOutputStream(
-				unsyncByteArrayOutputStream)) {
-
-			objectOutputStream.writeInt(4);
-			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
-			objectOutputStream.writeUTF(GetterUtil.getString(description));
-			objectOutputStream.writeObject(StringUtil.split(domains));
-			objectOutputStream.writeObject(expirationDate);
-
-			String[] hostNames = null;
-
-			if (Validator.isNotNull(hostName)) {
-				hostNames = new String[] {hostName};
-			}
-			else {
-				hostNames = new String[0];
-			}
-
-			objectOutputStream.writeObject(hostNames);
-
-			objectOutputStream.writeObject(StringUtil.split(ipAddresses));
-			objectOutputStream.writeUTF(GetterUtil.getString(key));
-			objectOutputStream.writeLong(System.currentTimeMillis());
-			objectOutputStream.writeUTF(GetterUtil.getString(licenseEntryName));
-			objectOutputStream.writeUTF(GetterUtil.getString(licenseType));
-			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
-			objectOutputStream.writeObject(StringUtil.split(macAddresses));
-
-			if (Objects.equals(
-					LicenseConstants.TYPE_VIRTUAL_CLUSTER, licenseType)) {
-
-				objectOutputStream.writeInt(maxClusterNodes);
-			}
-
-			objectOutputStream.writeInt(maxHttpSessions);
-			objectOutputStream.writeInt(maxServers);
-			objectOutputStream.writeLong(maxConcurrentUsers);
-			objectOutputStream.writeLong(maxUsers);
-			objectOutputStream.writeUTF(sizing);
-			objectOutputStream.writeUTF(GetterUtil.getString(owner));
-			objectOutputStream.writeUTF(GetterUtil.getString(productName));
-			objectOutputStream.writeUTF(GetterUtil.getString(productId));
-			objectOutputStream.writeUTF(productVersion);
-
-			String[] serverIds = null;
-
-			if (Validator.isNotNull(serverId)) {
-				serverIds = new String[] {serverId};
-			}
-			else {
-				serverIds = new String[0];
-			}
-
-			objectOutputStream.writeObject(serverIds);
-
-			objectOutputStream.writeObject(startDate);
-
-			objectOutputStream.flush();
-
-			return Base64.encode(unsyncByteArrayOutputStream.toByteArray());
-		}
 	}
 
 	public String toXML(
@@ -344,20 +248,26 @@ public class LicenseKeyExporter {
 		Element rootElement = document.addElement("license");
 
 		String licenseEntryType = properties.get("type");
-		String licenseVersion = properties.get("version");
 
 		_addElement(
 			rootElement, "account-name", properties.get("accountEntryName"));
+
 		_addElement(rootElement, "owner", properties.get("owner"));
+
 		_addElement(rootElement, "description", properties.get("description"));
+
 		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
+
 		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
+
 		_addElement(
 			rootElement, "license-name", properties.get("licenseEntryName"));
+
 		_addElement(rootElement, "license-type", licenseEntryType);
-		_addElement(rootElement, "license-version", licenseVersion);
+
+		_addElement(rootElement, "license-version", properties.get("version"));
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
 			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
@@ -427,7 +337,9 @@ public class LicenseKeyExporter {
 		}
 
 		_addElement(rootElement, "owner", properties.get("owner"));
+
 		_addElement(rootElement, "description", properties.get("description"));
+
 		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
 
@@ -445,6 +357,7 @@ public class LicenseKeyExporter {
 		}
 
 		_addElement(rootElement, "license-type", licenseEntryType);
+
 		_addElement(
 			rootElement, "license-version", String.valueOf(licenseVersion));
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -3,23 +3,20 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.osb.provisioning.license.exporter.internal;
+package com.liferay.one.license;
 
-import com.liferay.osb.provisioning.license.exporter.LicenseKeyExporter;
-import com.liferay.osb.provisioning.license.generator.KeyGenerator;
-import com.liferay.osb.provisioning.license.helper.constants.LicenseType;
-import com.liferay.osb.provisioning.license.helper.constants.ProductVersion;
+import com.liferay.one.constants.ProductVersion;
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.petra.xml.DocUtil;
-import com.liferay.portal.kernel.io.Base64OutputStream;
-import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.ee.license.shared.KeyGenerator;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
-import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
@@ -40,14 +37,13 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.TimeZone;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
+import org.springframework.stereotype.Component;
 
 /**
  * @author Amos Fong
  */
-@Component(immediate = true, service = LicenseKeyExporter.class)
-public class LicenseKeyExporterImpl implements LicenseKeyExporter {
+@Component
+public class LicenseKeyExporter {
 
 	public String aggregateXMLs(String[] xmls) throws Exception {
 		Document document = SAXReaderUtil.createDocument();
@@ -121,13 +117,11 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			Date startDate, Date expirationDate)
 		throws IOException {
 
-		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
-			new UnsyncByteArrayOutputStream();
-		ObjectOutputStream objectOutputStream = null;
+		try (UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+				new UnsyncByteArrayOutputStream();
 
-		try {
-			objectOutputStream = new ObjectOutputStream(
-				new Base64OutputStream(unsyncByteArrayOutputStream));
+			ObjectOutputStream objectOutputStream = new ObjectOutputStream(
+				unsyncByteArrayOutputStream)) {
 
 			objectOutputStream.writeInt(4);
 			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
@@ -154,7 +148,9 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
 			objectOutputStream.writeObject(StringUtil.split(macAddresses));
 
-			if (Objects.equals(LicenseType.VIRTUAL_CLUSTER, licenseType)) {
+			if (Objects.equals(
+					LicenseConstants.TYPE_VIRTUAL_CLUSTER, licenseType)) {
+
 				objectOutputStream.writeInt(maxClusterNodes);
 			}
 
@@ -183,16 +179,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 
 			objectOutputStream.flush();
 
-			return new String(unsyncByteArrayOutputStream.toByteArray());
-		}
-		finally {
-			if (objectOutputStream != null) {
-				objectOutputStream.close();
-			}
-
-			if (unsyncByteArrayOutputStream != null) {
-				unsyncByteArrayOutputStream.close();
-			}
+			return Base64.encode(unsyncByteArrayOutputStream.toByteArray());
 		}
 	}
 
@@ -215,7 +202,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			serverIds[0], startDate, expirationDate, createDate);
 
 		if ((licenseVersion >= 4) &&
-			licenseType.equals(LicenseType.PRODUCTION)) {
+			licenseType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
 			properties.put("maxServers", String.valueOf(serverIds.length));
 		}
@@ -264,9 +251,9 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
 		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
 
-		String key = _keyGenerator.generate(properties);
+		String key = KeyGenerator.encrypt(properties);
 
-		DocUtil.add(rootElement, "key", key);
+		_addElement(rootElement, "key", key);
 
 		return document.formattedString();
 	}
@@ -309,7 +296,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String[] hostNames = StringUtil.split(properties.get("hostNames"));
 
 		for (String hostName : hostNames) {
-			DocUtil.add(hostNamesElement, "host-name", hostName);
+			_addElement(hostNamesElement, "host-name", hostName);
 		}
 
 		Element ipAddressesElement = element.addElement("ip-addresses");
@@ -317,7 +304,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String[] ipAddresses = StringUtil.split(properties.get("ipAddresses"));
 
 		for (String ipAddress : ipAddresses) {
-			DocUtil.add(ipAddressesElement, "ip-address", ipAddress);
+			_addElement(ipAddressesElement, "ip-address", ipAddress);
 		}
 
 		Element macAddressesElement = element.addElement("mac-addresses");
@@ -326,7 +313,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			properties.get("macAddresses"));
 
 		for (String macAddress : macAddresses) {
-			DocUtil.add(macAddressesElement, "mac-address", macAddress);
+			_addElement(macAddressesElement, "mac-address", macAddress);
 		}
 
 		String[] serverIds = StringUtil.split(properties.get("serverIds"));
@@ -335,7 +322,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			Element serverIdElement = element.addElement("server-ids");
 
 			for (String serverId : serverIds) {
-				DocUtil.add(serverIdElement, "server-id", serverId);
+				_addElement(serverIdElement, "server-id", serverId);
 			}
 		}
 	}
@@ -359,18 +346,18 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String licenseEntryType = properties.get("type");
 		String licenseVersion = properties.get("version");
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "account-name", properties.get("accountEntryName"));
-		DocUtil.add(rootElement, "owner", properties.get("owner"));
-		DocUtil.add(rootElement, "description", properties.get("description"));
-		DocUtil.add(
+		_addElement(rootElement, "owner", properties.get("owner"));
+		_addElement(rootElement, "description", properties.get("description"));
+		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
-		DocUtil.add(
+		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
-		DocUtil.add(
+		_addElement(
 			rootElement, "license-name", properties.get("licenseEntryName"));
-		DocUtil.add(rootElement, "license-type", licenseEntryType);
-		DocUtil.add(rootElement, "license-version", licenseVersion);
+		_addElement(rootElement, "license-type", licenseEntryType);
+		_addElement(rootElement, "license-version", licenseVersion);
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
 			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
@@ -380,43 +367,43 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		Date startDate = new Date(
 			GetterUtil.getLong(properties.get("startDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "start-date",
 			longDateFormatDateTime.format(startDate));
 
 		Date expirationDate = new Date(
 			GetterUtil.getLong(properties.get("expirationDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "expiration-date",
 			longDateFormatDateTime.format(expirationDate));
 
-		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-servers", properties.get("maxServers"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-http-sessions",
 				properties.get("maxHttpSessions"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.PRODUCTION)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 			Element serverIdElement = rootElement.addElement("server-ids");
 
 			String[] serverIds = StringUtil.split(properties.get("serverIds"));
 
 			for (String serverId : serverIds) {
-				DocUtil.add(serverIdElement, "server-id", serverId);
+				_addElement(serverIdElement, "server-id", serverId);
 			}
 		}
 
-		DocUtil.add(rootElement, "key", key);
+		_addElement(rootElement, "key", key);
 
 		return document;
 	}
@@ -434,31 +421,31 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		long licenseVersion = GetterUtil.getLong(properties.get("version"));
 
 		if (Validator.isNull(productId)) {
-			DocUtil.add(
+			_addElement(
 				rootElement, "account-name",
 				properties.get("accountEntryName"));
 		}
 
-		DocUtil.add(rootElement, "owner", properties.get("owner"));
-		DocUtil.add(rootElement, "description", properties.get("description"));
-		DocUtil.add(
+		_addElement(rootElement, "owner", properties.get("owner"));
+		_addElement(rootElement, "description", properties.get("description"));
+		_addElement(
 			rootElement, "product-name", properties.get("productEntryName"));
 
 		if (Validator.isNotNull(productId)) {
-			DocUtil.add(rootElement, "product-id", productId);
+			_addElement(rootElement, "product-id", productId);
 		}
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "product-version", properties.get("productVersion"));
 
 		if (Validator.isNull(productId)) {
-			DocUtil.add(
+			_addElement(
 				rootElement, "license-name",
 				properties.get("licenseEntryName"));
 		}
 
-		DocUtil.add(rootElement, "license-type", licenseEntryType);
-		DocUtil.add(
+		_addElement(rootElement, "license-type", licenseEntryType);
+		_addElement(
 			rootElement, "license-version", String.valueOf(licenseVersion));
 
 		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
@@ -469,57 +456,57 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		Date startDate = new Date(
 			GetterUtil.getLong(properties.get("startDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "start-date",
 			longDateFormatDateTime.format(startDate));
 
 		Date expirationDate = new Date(
 			GetterUtil.getLong(properties.get("expirationDate")));
 
-		DocUtil.add(
+		_addElement(
 			rootElement, "expiration-date",
 			longDateFormatDateTime.format(expirationDate));
 
-		if (licenseEntryType.equals(LicenseType.FREE) ||
-			licenseEntryType.equals(LicenseType.VIRTUAL_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_FREE) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_VIRTUAL_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-cluster-nodes",
 				properties.get("max-cluster-nodes"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+		if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
 			((licenseVersion >= 4) &&
-			 (licenseEntryType.equals(LicenseType.LIMITED) ||
-			  licenseEntryType.equals(LicenseType.PRODUCTION)))) {
+			 (licenseEntryType.equals(LicenseConstants.TYPE_LIMITED) ||
+			  licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)))) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-servers", properties.get("maxServers"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
-			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER) ||
+			licenseEntryType.equals(LicenseConstants.TYPE_DEVELOPER_CLUSTER)) {
 
-			DocUtil.add(
+			_addElement(
 				rootElement, "max-http-sessions",
 				properties.get("maxHttpSessions"));
 		}
 
-		if (licenseEntryType.equals(LicenseType.FREE)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_FREE)) {
 			Element domainsElement = rootElement.addElement("domains");
 
 			String[] domains = StringUtil.split(properties.get("domains"));
 
 			for (String domain : domains) {
-				DocUtil.add(domainsElement, "domain", domain);
+				_addElement(domainsElement, "domain", domain);
 			}
 		}
 
-		if (licenseEntryType.equals(LicenseType.PER_USER)) {
+		if (licenseEntryType.equals(LicenseConstants.TYPE_PER_USER)) {
 			String maxConcurrentUsers = properties.get("maxConcurrentUsers");
 
 			if (Validator.isNotNull(maxConcurrentUsers)) {
-				DocUtil.add(
+				_addElement(
 					rootElement, "max-concurrent-users",
 					properties.get("maxConcurrentUsers"));
 			}
@@ -527,7 +514,7 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 			String maxUsers = properties.get("maxUsers");
 
 			if (Validator.isNotNull(maxUsers)) {
-				DocUtil.add(
+				_addElement(
 					rootElement, "max-users", properties.get("maxUsers"));
 			}
 		}
@@ -535,22 +522,30 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String instanceSize = properties.get("instanceSize");
 
 		if (Validator.isNotNull(instanceSize)) {
-			DocUtil.add(rootElement, "instance-size", instanceSize);
+			_addElement(rootElement, "instance-size", instanceSize);
 		}
 
 		if (!aggregate) {
-			if (licenseEntryType.equals(LicenseType.CLUSTER) ||
-				licenseEntryType.equals(LicenseType.LIMITED) ||
-				licenseEntryType.equals(LicenseType.PER_USER) ||
-				licenseEntryType.equals(LicenseType.PRODUCTION)) {
+			if (licenseEntryType.equals(LicenseConstants.TYPE_CLUSTER) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_LIMITED) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_PER_USER) ||
+				licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
 				exportServerToXML(rootElement, properties);
 			}
 
-			DocUtil.add(rootElement, "key", key);
+			_addElement(rootElement, "key", key);
 		}
 
 		return document;
+	}
+
+	private void _addElement(Element parentElement, String name, String value) {
+		Element childElement = parentElement.addElement(name);
+
+		if (value != null) {
+			childElement.addText(value);
+		}
 	}
 
 	private Map<String, String> _getProperties(
@@ -563,12 +558,13 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 		String serverIds, Date startDate, Date expirationDate,
 		Date createDate) {
 
-		Map<String, String> properties = _keyGenerator.getProperties(
-			accountName, licenseEntryName, licenseType, licenseVersion,
-			productName, productId, productVersion, owner, maxClusterNodes,
-			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
-			description, domains, hostNames, ipAddresses, macAddresses,
-			new String[] {serverIds}, startDate, expirationDate);
+		Map<String, String> properties = KeyGenerator.getProperties(
+			accountName, description, StringUtil.split(domains), expirationDate,
+			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
+			licenseEntryName, licenseType, String.valueOf(licenseVersion),
+			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
+			maxHttpSessions, maxServers, maxUsers, owner, productName,
+			productId, productVersion, new String[] {serverIds}, startDate);
 
 		// See LRDCOM-2568
 
@@ -588,8 +584,5 @@ public class LicenseKeyExporterImpl implements LicenseKeyExporter {
 
 		return properties;
 	}
-
-	@Reference
-	private KeyGenerator _keyGenerator;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -1,0 +1,595 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.provisioning.license.exporter.internal;
+
+import com.liferay.osb.provisioning.license.exporter.LicenseKeyExporter;
+import com.liferay.osb.provisioning.license.generator.KeyGenerator;
+import com.liferay.osb.provisioning.license.helper.constants.LicenseType;
+import com.liferay.osb.provisioning.license.helper.constants.ProductVersion;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.xml.DocUtil;
+import com.liferay.portal.kernel.io.Base64OutputStream;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PropertiesUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import java.text.DateFormat;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Amos Fong
+ */
+@Component(immediate = true, service = LicenseKeyExporter.class)
+public class LicenseKeyExporterImpl implements LicenseKeyExporter {
+
+	public String aggregateXMLs(String[] xmls) throws Exception {
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("licenses");
+
+		for (String xml : xmls) {
+			Document curDocument = SAXReaderUtil.read(xml);
+
+			rootElement.add(curDocument.getRootElement());
+		}
+
+		return document.formattedString();
+	}
+
+	public String getFileName(
+		String productName, String productVersion, String licenseKeyName) {
+
+		StringBundler sb = new StringBundler(6);
+
+		productName = StringUtil.extractChars(productName);
+
+		sb.append("activation-key-");
+		sb.append(productName);
+		sb.append(StringPool.DASH);
+		sb.append(productVersion);
+		sb.append(StringPool.DASH);
+		sb.append(licenseKeyName);
+
+		return formatFileName(sb.toString());
+	}
+
+	public String getFileName(String[] productNames, String[] licenseKeyNames) {
+		StringBundler sb = new StringBundler(
+			1 + (2 * productNames.length) + (2 * licenseKeyNames.length));
+
+		sb.append("activation-key");
+
+		for (String productName : productNames) {
+			sb.append(StringPool.DASH);
+			sb.append(StringUtil.extractChars(productName));
+		}
+
+		for (String licenseKeyName : licenseKeyNames) {
+			sb.append(StringPool.DASH);
+			sb.append(licenseKeyName);
+		}
+
+		return formatFileName(sb.toString());
+	}
+
+	public String toEncodedLicenseFile(String serverId, String key) {
+		Properties licenseProperties = new Properties();
+
+		licenseProperties.setProperty("serverId", serverId);
+		licenseProperties.setProperty("licenseKey", key);
+
+		String licenseFileDecoded = PropertiesUtil.toString(licenseProperties);
+
+		return Base64.objectToString(licenseFileDecoded);
+	}
+
+	public String toLI(
+			String key, String accountName, String licenseEntryName,
+			String licenseType, int licenseVersion, String productName,
+			String productId, String productVersion, String owner,
+			int maxClusterNodes, int maxServers, int maxHttpSessions,
+			long maxConcurrentUsers, long maxUsers, String sizing,
+			String description, String domains, String hostName,
+			String ipAddresses, String macAddresses, String serverId,
+			Date startDate, Date expirationDate)
+		throws IOException {
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+		ObjectOutputStream objectOutputStream = null;
+
+		try {
+			objectOutputStream = new ObjectOutputStream(
+				new Base64OutputStream(unsyncByteArrayOutputStream));
+
+			objectOutputStream.writeInt(4);
+			objectOutputStream.writeUTF(GetterUtil.getString(accountName));
+			objectOutputStream.writeUTF(GetterUtil.getString(description));
+			objectOutputStream.writeObject(StringUtil.split(domains));
+			objectOutputStream.writeObject(expirationDate);
+
+			String[] hostNames = null;
+
+			if (Validator.isNotNull(hostName)) {
+				hostNames = new String[] {hostName};
+			}
+			else {
+				hostNames = new String[0];
+			}
+
+			objectOutputStream.writeObject(hostNames);
+
+			objectOutputStream.writeObject(StringUtil.split(ipAddresses));
+			objectOutputStream.writeUTF(GetterUtil.getString(key));
+			objectOutputStream.writeLong(System.currentTimeMillis());
+			objectOutputStream.writeUTF(GetterUtil.getString(licenseEntryName));
+			objectOutputStream.writeUTF(GetterUtil.getString(licenseType));
+			objectOutputStream.writeUTF(String.valueOf(licenseVersion));
+			objectOutputStream.writeObject(StringUtil.split(macAddresses));
+
+			if (Objects.equals(LicenseType.VIRTUAL_CLUSTER, licenseType)) {
+				objectOutputStream.writeInt(maxClusterNodes);
+			}
+
+			objectOutputStream.writeInt(maxHttpSessions);
+			objectOutputStream.writeInt(maxServers);
+			objectOutputStream.writeLong(maxConcurrentUsers);
+			objectOutputStream.writeLong(maxUsers);
+			objectOutputStream.writeUTF(sizing);
+			objectOutputStream.writeUTF(GetterUtil.getString(owner));
+			objectOutputStream.writeUTF(GetterUtil.getString(productName));
+			objectOutputStream.writeUTF(GetterUtil.getString(productId));
+			objectOutputStream.writeUTF(productVersion);
+
+			String[] serverIds = null;
+
+			if (Validator.isNotNull(serverId)) {
+				serverIds = new String[] {serverId};
+			}
+			else {
+				serverIds = new String[0];
+			}
+
+			objectOutputStream.writeObject(serverIds);
+
+			objectOutputStream.writeObject(startDate);
+
+			objectOutputStream.flush();
+
+			return new String(unsyncByteArrayOutputStream.toByteArray());
+		}
+		finally {
+			if (objectOutputStream != null) {
+				objectOutputStream.close();
+			}
+
+			if (unsyncByteArrayOutputStream != null) {
+				unsyncByteArrayOutputStream.close();
+			}
+		}
+	}
+
+	public String toXML(
+			String accountName, String licenseEntryName, String licenseType,
+			int licenseVersion, String productName, String productId,
+			String productVersion, String owner, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String description, String domains,
+			String[] hostNames, String[] ipAddresses, String[] macAddresses,
+			String[] serverIds, Date startDate, Date expirationDate,
+			Date createDate)
+		throws Exception {
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames[0], ipAddresses[0], macAddresses[0],
+			serverIds[0], startDate, expirationDate, createDate);
+
+		if ((licenseVersion >= 4) &&
+			licenseType.equals(LicenseType.PRODUCTION)) {
+
+			properties.put("maxServers", String.valueOf(serverIds.length));
+		}
+
+		Document document = toXMLVersion3_4(properties, StringPool.BLANK, true);
+
+		Element rootElement = document.getRootElement();
+
+		List<String> allHostNames = new ArrayList<>();
+		List<String> allIpAddresses = new ArrayList<>();
+		List<String> allMacAddresses = new ArrayList<>();
+
+		Element serversElement = rootElement.addElement("servers");
+
+		for (int i = 0; i < serverIds.length; i++) {
+			Map<String, String> curProperties = _getProperties(
+				accountName, licenseEntryName, licenseType, licenseVersion,
+				productName, productId, productVersion, owner, maxClusterNodes,
+				maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers,
+				sizing, description, domains, hostNames[i], ipAddresses[i],
+				macAddresses[i], serverIds[i], startDate, expirationDate,
+				createDate);
+
+			Element serverElement = serversElement.addElement("server");
+
+			exportServerToXML(serverElement, curProperties);
+
+			String curHostName = curProperties.get("hostNames");
+
+			if (Validator.isNotNull(curHostName)) {
+				allHostNames.add(curHostName);
+			}
+
+			List<String> curIpAddresses = ListUtil.fromArray(
+				StringUtil.split(curProperties.get("ipAddresses")));
+
+			allIpAddresses.addAll(curIpAddresses);
+
+			List<String> curMacAddresses = ListUtil.fromArray(
+				StringUtil.split(curProperties.get("macAddresses")));
+
+			allMacAddresses.addAll(curMacAddresses);
+		}
+
+		properties.put("hostNames", StringUtil.merge(allHostNames));
+		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
+		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
+
+		String key = _keyGenerator.generate(properties);
+
+		DocUtil.add(rootElement, "key", key);
+
+		return document.formattedString();
+	}
+
+	public String toXML(
+			String key, String accountName, String licenseEntryName,
+			String licenseType, int licenseVersion, String productName,
+			String productId, String productVersion, String owner,
+			int maxClusterNodes, int maxServers, int maxHttpSessions,
+			long maxConcurrentUsers, long maxUsers, String sizing,
+			String description, String domains, String hostNames,
+			String ipAddresses, String macAddresses, String serverIds,
+			Date startDate, Date expirationDate, Date createDate)
+		throws Exception {
+
+		Document document = null;
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			serverIds, startDate, expirationDate, createDate);
+
+		if (licenseVersion >= 3) {
+			document = toXMLVersion3_4(properties, key, false);
+		}
+		else {
+			document = toXMLVersion2(properties, key);
+		}
+
+		return document.formattedString();
+	}
+
+	protected void exportServerToXML(
+		Element element, Map<String, String> properties) {
+
+		Element hostNamesElement = element.addElement("host-names");
+
+		String[] hostNames = StringUtil.split(properties.get("hostNames"));
+
+		for (String hostName : hostNames) {
+			DocUtil.add(hostNamesElement, "host-name", hostName);
+		}
+
+		Element ipAddressesElement = element.addElement("ip-addresses");
+
+		String[] ipAddresses = StringUtil.split(properties.get("ipAddresses"));
+
+		for (String ipAddress : ipAddresses) {
+			DocUtil.add(ipAddressesElement, "ip-address", ipAddress);
+		}
+
+		Element macAddressesElement = element.addElement("mac-addresses");
+
+		String[] macAddresses = StringUtil.split(
+			properties.get("macAddresses"));
+
+		for (String macAddress : macAddresses) {
+			DocUtil.add(macAddressesElement, "mac-address", macAddress);
+		}
+
+		String[] serverIds = StringUtil.split(properties.get("serverIds"));
+
+		if (serverIds.length > 0) {
+			Element serverIdElement = element.addElement("server-ids");
+
+			for (String serverId : serverIds) {
+				DocUtil.add(serverIdElement, "server-id", serverId);
+			}
+		}
+	}
+
+	protected String formatFileName(String fileName) {
+		fileName = StringUtil.replace(
+			fileName, CharPool.SPACE, StringPool.BLANK);
+		fileName = StringUtil.toLowerCase(fileName);
+		fileName = fileName.substring(0, Math.min(fileName.length(), 251));
+
+		return fileName.concat(".xml");
+	}
+
+	protected Document toXMLVersion2(Map<String, String> properties, String key)
+		throws Exception {
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("license");
+
+		String licenseEntryType = properties.get("type");
+		String licenseVersion = properties.get("version");
+
+		DocUtil.add(
+			rootElement, "account-name", properties.get("accountEntryName"));
+		DocUtil.add(rootElement, "owner", properties.get("owner"));
+		DocUtil.add(rootElement, "description", properties.get("description"));
+		DocUtil.add(
+			rootElement, "product-name", properties.get("productEntryName"));
+		DocUtil.add(
+			rootElement, "product-version", properties.get("productVersion"));
+		DocUtil.add(
+			rootElement, "license-name", properties.get("licenseEntryName"));
+		DocUtil.add(rootElement, "license-type", licenseEntryType);
+		DocUtil.add(rootElement, "license-version", licenseVersion);
+
+		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
+			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
+
+		longDateFormatDateTime.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+		Date startDate = new Date(
+			GetterUtil.getLong(properties.get("startDate")));
+
+		DocUtil.add(
+			rootElement, "start-date",
+			longDateFormatDateTime.format(startDate));
+
+		Date expirationDate = new Date(
+			GetterUtil.getLong(properties.get("expirationDate")));
+
+		DocUtil.add(
+			rootElement, "expiration-date",
+			longDateFormatDateTime.format(expirationDate));
+
+		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-servers", properties.get("maxServers"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-http-sessions",
+				properties.get("maxHttpSessions"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.PRODUCTION)) {
+			Element serverIdElement = rootElement.addElement("server-ids");
+
+			String[] serverIds = StringUtil.split(properties.get("serverIds"));
+
+			for (String serverId : serverIds) {
+				DocUtil.add(serverIdElement, "server-id", serverId);
+			}
+		}
+
+		DocUtil.add(rootElement, "key", key);
+
+		return document;
+	}
+
+	protected Document toXMLVersion3_4(
+			Map<String, String> properties, String key, boolean aggregate)
+		throws Exception {
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("license");
+
+		String productId = properties.get("productId");
+		String licenseEntryType = properties.get("type");
+		long licenseVersion = GetterUtil.getLong(properties.get("version"));
+
+		if (Validator.isNull(productId)) {
+			DocUtil.add(
+				rootElement, "account-name",
+				properties.get("accountEntryName"));
+		}
+
+		DocUtil.add(rootElement, "owner", properties.get("owner"));
+		DocUtil.add(rootElement, "description", properties.get("description"));
+		DocUtil.add(
+			rootElement, "product-name", properties.get("productEntryName"));
+
+		if (Validator.isNotNull(productId)) {
+			DocUtil.add(rootElement, "product-id", productId);
+		}
+
+		DocUtil.add(
+			rootElement, "product-version", properties.get("productVersion"));
+
+		if (Validator.isNull(productId)) {
+			DocUtil.add(
+				rootElement, "license-name",
+				properties.get("licenseEntryName"));
+		}
+
+		DocUtil.add(rootElement, "license-type", licenseEntryType);
+		DocUtil.add(
+			rootElement, "license-version", String.valueOf(licenseVersion));
+
+		DateFormat longDateFormatDateTime = DateFormat.getDateTimeInstance(
+			DateFormat.FULL, DateFormat.FULL, LocaleUtil.US);
+
+		longDateFormatDateTime.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+		Date startDate = new Date(
+			GetterUtil.getLong(properties.get("startDate")));
+
+		DocUtil.add(
+			rootElement, "start-date",
+			longDateFormatDateTime.format(startDate));
+
+		Date expirationDate = new Date(
+			GetterUtil.getLong(properties.get("expirationDate")));
+
+		DocUtil.add(
+			rootElement, "expiration-date",
+			longDateFormatDateTime.format(expirationDate));
+
+		if (licenseEntryType.equals(LicenseType.FREE) ||
+			licenseEntryType.equals(LicenseType.VIRTUAL_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-cluster-nodes",
+				properties.get("max-cluster-nodes"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+			((licenseVersion >= 4) &&
+			 (licenseEntryType.equals(LicenseType.LIMITED) ||
+			  licenseEntryType.equals(LicenseType.PRODUCTION)))) {
+
+			DocUtil.add(
+				rootElement, "max-servers", properties.get("maxServers"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.DEVELOPER) ||
+			licenseEntryType.equals(LicenseType.DEVELOPER_CLUSTER)) {
+
+			DocUtil.add(
+				rootElement, "max-http-sessions",
+				properties.get("maxHttpSessions"));
+		}
+
+		if (licenseEntryType.equals(LicenseType.FREE)) {
+			Element domainsElement = rootElement.addElement("domains");
+
+			String[] domains = StringUtil.split(properties.get("domains"));
+
+			for (String domain : domains) {
+				DocUtil.add(domainsElement, "domain", domain);
+			}
+		}
+
+		if (licenseEntryType.equals(LicenseType.PER_USER)) {
+			String maxConcurrentUsers = properties.get("maxConcurrentUsers");
+
+			if (Validator.isNotNull(maxConcurrentUsers)) {
+				DocUtil.add(
+					rootElement, "max-concurrent-users",
+					properties.get("maxConcurrentUsers"));
+			}
+
+			String maxUsers = properties.get("maxUsers");
+
+			if (Validator.isNotNull(maxUsers)) {
+				DocUtil.add(
+					rootElement, "max-users", properties.get("maxUsers"));
+			}
+		}
+
+		String instanceSize = properties.get("instanceSize");
+
+		if (Validator.isNotNull(instanceSize)) {
+			DocUtil.add(rootElement, "instance-size", instanceSize);
+		}
+
+		if (!aggregate) {
+			if (licenseEntryType.equals(LicenseType.CLUSTER) ||
+				licenseEntryType.equals(LicenseType.LIMITED) ||
+				licenseEntryType.equals(LicenseType.PER_USER) ||
+				licenseEntryType.equals(LicenseType.PRODUCTION)) {
+
+				exportServerToXML(rootElement, properties);
+			}
+
+			DocUtil.add(rootElement, "key", key);
+		}
+
+		return document;
+	}
+
+	private Map<String, String> _getProperties(
+		String accountName, String licenseEntryName, String licenseType,
+		int licenseVersion, String productName, String productId,
+		String productVersion, String owner, int maxClusterNodes,
+		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+		long maxUsers, String sizing, String description, String domains,
+		String hostNames, String ipAddresses, String macAddresses,
+		String serverIds, Date startDate, Date expirationDate,
+		Date createDate) {
+
+		Map<String, String> properties = _keyGenerator.getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			new String[] {serverIds}, startDate, expirationDate);
+
+		// See LRDCOM-2568
+
+		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
+			productVersion.equals("6.1 GA 1")) {
+
+			Calendar cal = Calendar.getInstance();
+
+			cal.set(Calendar.DAY_OF_MONTH, 31);
+			cal.set(Calendar.MONTH, 6);
+			cal.set(Calendar.YEAR, 2012);
+
+			if (createDate.before(cal.getTime())) {
+				properties.put("productVersion", "6.1");
+			}
+		}
+
+		return properties;
+	}
+
+	@Reference
+	private KeyGenerator _keyGenerator;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -65,7 +65,7 @@ public class LicenseKeyExporter {
 		sb.append(StringPool.DASH);
 		sb.append(licenseKeyName);
 
-		return formatFileName(sb.toString());
+		return _formatFileName(sb.toString());
 	}
 
 	public String getFileName(String[] productNames, String[] licenseKeyNames) {
@@ -84,7 +84,37 @@ public class LicenseKeyExporter {
 			sb.append(licenseKeyName);
 		}
 
-		return formatFileName(sb.toString());
+		return _formatFileName(sb.toString());
+	}
+
+	public String toXML(
+			String accountName, String licenseEntryName, String licenseType,
+			int licenseVersion, String productName, String productId,
+			String productVersion, String owner, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String description, String domains,
+			String hostNames, String ipAddresses, String macAddresses,
+			String serverIds, Date startDate, Date expirationDate,
+			Date createDate, String key)
+		throws Exception {
+
+		Document document = null;
+
+		Map<String, String> properties = _getProperties(
+			accountName, licenseEntryName, licenseType, licenseVersion,
+			productName, productId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostNames, ipAddresses, macAddresses,
+			serverIds, startDate, expirationDate, createDate);
+
+		if (licenseVersion >= 3) {
+			document = _toXMLVersion3_4(properties, false, key);
+		}
+		else {
+			document = _toXMLVersion2(properties, key);
+		}
+
+		return document.formattedString();
 	}
 
 	public String toXML(
@@ -111,7 +141,8 @@ public class LicenseKeyExporter {
 			properties.put("maxServers", String.valueOf(serverIds.length));
 		}
 
-		Document document = toXMLVersion3_4(properties, StringPool.BLANK, true);
+		Document document = _toXMLVersion3_4(
+			properties, true, StringPool.BLANK);
 
 		Element rootElement = document.getRootElement();
 
@@ -132,7 +163,7 @@ public class LicenseKeyExporter {
 
 			Element serverElement = serversElement.addElement("server");
 
-			exportServerToXML(serverElement, curProperties);
+			_exportServerToXML(serverElement, curProperties);
 
 			String curHostName = curProperties.get("hostNames");
 
@@ -155,44 +186,20 @@ public class LicenseKeyExporter {
 		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
 		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
 
-		String key = KeyGenerator.encrypt(properties);
-
-		_addElement(rootElement, "key", key);
+		_addElement(rootElement, "key", KeyGenerator.encrypt(properties));
 
 		return document.formattedString();
 	}
 
-	public String toXML(
-			String key, String accountName, String licenseEntryName,
-			String licenseType, int licenseVersion, String productName,
-			String productId, String productVersion, String owner,
-			int maxClusterNodes, int maxServers, int maxHttpSessions,
-			long maxConcurrentUsers, long maxUsers, String sizing,
-			String description, String domains, String hostNames,
-			String ipAddresses, String macAddresses, String serverIds,
-			Date startDate, Date expirationDate, Date createDate)
-		throws Exception {
+	private void _addElement(Element parentElement, String name, String value) {
+		Element childElement = parentElement.addElement(name);
 
-		Document document = null;
-
-		Map<String, String> properties = _getProperties(
-			accountName, licenseEntryName, licenseType, licenseVersion,
-			productName, productId, productVersion, owner, maxClusterNodes,
-			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
-			description, domains, hostNames, ipAddresses, macAddresses,
-			serverIds, startDate, expirationDate, createDate);
-
-		if (licenseVersion >= 3) {
-			document = toXMLVersion3_4(properties, key, false);
+		if (value != null) {
+			childElement.addText(value);
 		}
-		else {
-			document = toXMLVersion2(properties, key);
-		}
-
-		return document.formattedString();
 	}
 
-	protected void exportServerToXML(
+	private void _exportServerToXML(
 		Element element, Map<String, String> properties) {
 
 		Element hostNamesElement = element.addElement("host-names");
@@ -231,7 +238,7 @@ public class LicenseKeyExporter {
 		}
 	}
 
-	protected String formatFileName(String fileName) {
+	private String _formatFileName(String fileName) {
 		fileName = StringUtil.replace(
 			fileName, CharPool.SPACE, StringPool.BLANK);
 		fileName = StringUtil.toLowerCase(fileName);
@@ -240,7 +247,44 @@ public class LicenseKeyExporter {
 		return fileName.concat(".xml");
 	}
 
-	protected Document toXMLVersion2(Map<String, String> properties, String key)
+	private Map<String, String> _getProperties(
+		String accountName, String licenseEntryName, String licenseType,
+		int licenseVersion, String productName, String productId,
+		String productVersion, String owner, int maxClusterNodes,
+		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+		long maxUsers, String sizing, String description, String domains,
+		String hostNames, String ipAddresses, String macAddresses,
+		String serverIds, Date startDate, Date expirationDate,
+		Date createDate) {
+
+		Map<String, String> properties = KeyGenerator.getProperties(
+			accountName, description, StringUtil.split(domains), expirationDate,
+			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
+			licenseEntryName, licenseType, String.valueOf(licenseVersion),
+			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
+			maxHttpSessions, maxServers, maxUsers, owner, productName,
+			productId, productVersion, new String[] {serverIds}, startDate);
+
+		// See LRDCOM-2568
+
+		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
+			productVersion.equals("6.1 GA 1")) {
+
+			Calendar cal = Calendar.getInstance();
+
+			cal.set(Calendar.DAY_OF_MONTH, 31);
+			cal.set(Calendar.MONTH, 6);
+			cal.set(Calendar.YEAR, 2012);
+
+			if (createDate.before(cal.getTime())) {
+				properties.put("productVersion", "6.1");
+			}
+		}
+
+		return properties;
+	}
+
+	private Document _toXMLVersion2(Map<String, String> properties, String key)
 		throws Exception {
 
 		Document document = SAXReaderUtil.createDocument();
@@ -318,8 +362,8 @@ public class LicenseKeyExporter {
 		return document;
 	}
 
-	protected Document toXMLVersion3_4(
-			Map<String, String> properties, String key, boolean aggregate)
+	private Document _toXMLVersion3_4(
+			Map<String, String> properties, boolean aggregate, String key)
 		throws Exception {
 
 		Document document = SAXReaderUtil.createDocument();
@@ -444,58 +488,13 @@ public class LicenseKeyExporter {
 				licenseEntryType.equals(LicenseConstants.TYPE_PER_USER) ||
 				licenseEntryType.equals(LicenseConstants.TYPE_PRODUCTION)) {
 
-				exportServerToXML(rootElement, properties);
+				_exportServerToXML(rootElement, properties);
 			}
 
 			_addElement(rootElement, "key", key);
 		}
 
 		return document;
-	}
-
-	private void _addElement(Element parentElement, String name, String value) {
-		Element childElement = parentElement.addElement(name);
-
-		if (value != null) {
-			childElement.addText(value);
-		}
-	}
-
-	private Map<String, String> _getProperties(
-		String accountName, String licenseEntryName, String licenseType,
-		int licenseVersion, String productName, String productId,
-		String productVersion, String owner, int maxClusterNodes,
-		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
-		long maxUsers, String sizing, String description, String domains,
-		String hostNames, String ipAddresses, String macAddresses,
-		String serverIds, Date startDate, Date expirationDate,
-		Date createDate) {
-
-		Map<String, String> properties = KeyGenerator.getProperties(
-			accountName, description, StringUtil.split(domains), expirationDate,
-			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
-			licenseEntryName, licenseType, String.valueOf(licenseVersion),
-			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
-			maxHttpSessions, maxServers, maxUsers, owner, productName,
-			productId, productVersion, new String[] {serverIds}, startDate);
-
-		// See LRDCOM-2568
-
-		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
-			productVersion.equals("6.1 GA 1")) {
-
-			Calendar cal = Calendar.getInstance();
-
-			cal.set(Calendar.DAY_OF_MONTH, 31);
-			cal.set(Calendar.MONTH, 6);
-			cal.set(Calendar.YEAR, 2012);
-
-			if (createDate.before(cal.getTime())) {
-				properties.put("productVersion", "6.1");
-			}
-		}
-
-		return properties;
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89421

## What Is Being Fixed

The liferay-one Spring Boot client extension had no way to generate Liferay license keys. The key generation logic lived only in liferay-release-tool-ee and was not consumable from the client extension.

## How It Is Being Fixed

This adds a LicenseKeyExporter (ported from 7.2.x) and a ProductVersion constants class to the liferay-one-etc-spring-boot client extension. Rather than duplicating the key generation code, the build clones the ext/shared sources from liferay-release-tool-ee via a sparse, blobless checkout and adds ext-impl/src to the main source set, so LicenseKeyExporter can call KeyGenerator directly. The cloned directory is gitignored and excluded from source formatting, and the clone runs only when the directory is absent. The petra.io dependency is added to support the exporter.

## Why Are There No Tests?

The client extension is verified manually by exporting a license key against a running bundle; no automated coverage is added.

## PR Check

**pr-check: PASS** — tested on `ad706bb5ca4c8ac111f5c6554a9ead5cdd8c7e4a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "ad706bb5ca4c8ac111f5c6554a9ead5cdd8c7e4a"} -->