### PR TITLE
LRSD-12377 Hide PaaS User role from Team Members selection

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/utils/constants/roleTypes.ts
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/utils/constants/roleTypes.ts
@@ -5,7 +5,13 @@
 
 import i18n from '~/utils/I18n';
 
-export const ROLE_TYPES = {
+interface IRoleType {
+	key: string;
+	name: string;
+	raysourceName?: string;
+}
+
+export const ROLE_TYPES: Record<string, IRoleType> = {
 	admin: {
 		key: 'Administrator',
 		name: i18n.translate('administrator'),
@@ -19,7 +25,6 @@ export const ROLE_TYPES = {
 	paasUser: {
 		key: 'PaaS User',
 		name: i18n.translate('paas-user'),
-		raysourceName: 'PaaS User',
 	},
 	partnerManager: {
 		key: 'Partner Manager',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12377

## What Is Being Fixed

The PaaS User role was surfacing in the Team Members role selection. The `paasUser` entry in the `ROLE_TYPES` constants carried a `raysourceName` mapping, which made the role eligible to appear alongside the assignable team roles where it should not be offered.

## How It Is Being Fixed

The `raysourceName` property is removed from the `paasUser` entry so the role no longer appears in the selection. To keep the shape of the map explicit now that one entry omits `raysourceName`, an `IRoleType` interface (with `raysourceName` optional) is introduced and `ROLE_TYPES` is typed as `Record<string, IRoleType>`.

## Why Are There No Tests?

This is a TypeScript constants-only change in the `liferay-customer-custom-element` client extension — it removes the `raysourceName` mapping from a constants map and adds a type. There is no unit test infrastructure for this client extension's constants, so the change is verified by the workspace build and source format checks.

## PR Check

**pr-check: PASS** — tested on `817023782f1e5cdd9e4f6bcadf2ec552999b90c7`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "817023782f1e5cdd9e4f6bcadf2ec552999b90c7"} -->
