### PR TITLE
LPD-93972 Update Liferay Worker Roles

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/roles.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/roles.json
@@ -75,21 +75,6 @@
 		"type": 6
 	},
 	{
-		"externalReferenceCode": "ROLE_LIFERAY_ADVOCACY_SPECIALIST",
-		"name": "Liferay Advocacy Specialist",
-		"type": 6
-	},
-	{
-		"externalReferenceCode": "ROLE_LIFERAY_CUSTOMER_SUCCESS",
-		"name": "Liferay Customer Success",
-		"type": 6
-	},
-	{
-		"externalReferenceCode": "ROLE_LIFERAY_MANAGED_SERVICES",
-		"name": "Liferay Managed Services",
-		"type": 6
-	},
-	{
 		"externalReferenceCode": "ROLE_LIFERAY_SALES",
 		"name": "Liferay Sales",
 		"type": 6


### PR DESCRIPTION
[LPD-93972](https://liferay.atlassian.net/browse/LPD-93972)

## What is being fixed

  The liferay-one site initializer seeded every Liferay worker role,
  including three that are out of scope for the migration: Liferay
  Advocacy Specialist, Liferay Customer Success, and Liferay Managed
  Services. Per LPD-89038, only Liferay Sales, Primary, and Secondary
  worker roles are being migrated.
  
  ## How it is being fixed
  
  Removed the three non-migrating worker role definitions from
  roles.json in the liferay-one site initializer, keeping Liferay Sales
  along with the Primary Contact and Secondary Contact roles.
  resource-permissions.json referenced none of the removed roles, so no
  permission cleanup was required.


[LPD-93972]: https://liferay.atlassian.net/browse/LPD-93972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ