### PR TITLE
LPD-93972 Update Liferay Worker Roles

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/11-role.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/11-role.batch-engine-data.json
@@ -86,21 +86,6 @@
 			"roleType": "account"
 		},
 		{
-			"externalReferenceCode": "ROLE_LIFERAY_ADVOCACY_SPECIALIST",
-			"name": "Liferay Advocacy Specialist",
-			"roleType": "account"
-		},
-		{
-			"externalReferenceCode": "ROLE_LIFERAY_CUSTOMER_SUCCESS",
-			"name": "Liferay Customer Success",
-			"roleType": "account"
-		},
-		{
-			"externalReferenceCode": "ROLE_LIFERAY_MANAGED_SERVICES",
-			"name": "Liferay Managed Services",
-			"roleType": "account"
-		},
-		{
 			"externalReferenceCode": "ROLE_LIFERAY_SALES",
 			"name": "Liferay Sales",
 			"roleType": "account"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93972

## What is being fixed

The liferay-one batch client extension seeded every Liferay worker
role, including three that are out of scope for the migration: Liferay
Advocacy Specialist, Liferay Customer Success, and Liferay Managed
Services. Per LPD-89038, only Liferay Sales, Primary Contact, and
Secondary Contact worker roles are being migrated.

## How it is being fixed

The worker roles were recently moved from the site initializer
roles.json into the batch client extension (LPD-92498) so they deploy
across environments. This change re-applies the removal of the three
non-migrating roles in that new location,
11-role.batch-engine-data.json, keeping Liferay Sales along with the
Primary Contact and Secondary Contact roles.
