### PR TITLE
LPD-94233 Add paid app Marketplace checkout flow

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/RadioCard/RadioCard.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/RadioCard/RadioCard.tsx
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayRadio} from '@clayui/form';
+import classNames from 'classnames';
+import {ReactNode} from 'react';
+
+type RadioCardProps = {
+	className?: string;
+	content?: ReactNode;
+	description?: string;
+	onChange: () => void;
+	selected: boolean;
+	title?: string;
+};
+
+const RadioCard = ({
+	className,
+	content,
+	description,
+	onChange,
+	selected,
+	title,
+}: RadioCardProps) => (
+	<div
+		className={classNames(
+			'border p-3 product-purchase-radio-card rounded',
+			{selected},
+			className
+		)}
+		onClick={onChange}
+		role="button"
+		tabIndex={0}
+	>
+		<div className="align-items-center d-flex">
+			<ClayRadio
+				checked={selected}
+				className="mr-2"
+				onChange={onChange}
+				value=""
+			/>
+
+			{content || (
+				<div>
+					<strong className="d-block">{title}</strong>
+
+					{description && (
+						<small className="text-muted">{description}</small>
+					)}
+				</div>
+			)}
+		</div>
+	</div>
+);
+
+export default RadioCard;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Section/Section.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/components/Section/Section.tsx
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import classNames from 'classnames';
+import {ReactNode} from 'react';
+
+type SectionProps = {
+	children: ReactNode;
+	className?: string;
+	label: string;
+	required?: boolean;
+};
+
+const Section = ({children, className, label, required}: SectionProps) => (
+	<div className={classNames('mb-4', className)}>
+		<label className="d-block font-weight-semi-bold mb-2">
+			{label}
+
+			{required && <span className="ml-1 text-danger">*</span>}
+		</label>
+
+		{children}
+	</div>
+);
+
+export default Section;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -35,6 +35,7 @@ export default {
 	'active': 'Active',
 	'activity-history': 'Activity History',
 	'actual-event-date': 'Actual Event Date',
+	'add': 'Add',
 	'add-a-description-of-the-file-related-to-this-ticket':
 		'Add a description of the file related to this ticket.',
 	'add-currency': 'Add Currency',
@@ -662,6 +663,7 @@ export default {
 	'no-further-edits-can-be-made-when-tickets-are-closed-please-open-a-new-support-ticket-if-assistance-is-needed':
 		'No further edits can be made when tickets are closed. Please open a new support ticket if assistance is needed.',
 	'no-history-of-activity-was-found': 'No history of activity was found.',
+	'no-licenses-available': 'No licenses available',
 	'no-licenses-yet': 'No Licenses Yet',
 	'no-orders-yet': 'No Orders Yet',
 	'no-products-yet': 'No Products Yet',
@@ -921,6 +923,8 @@ export default {
 	'select-tags': 'Select Tags',
 	'select-the-account-and-ticket-you-want-to-attach-a-file-to':
 		'Select the account and ticket you want to attach a file to.',
+	'select-the-license-type-and-the-number-of-licenses-you-want-to-purchase':
+		'Select the license type and the number of licenses you want to purchase.',
 	'select-the-offering-of-liferay-your-app-is-compatible-with-the-compatibility-selections-will-determine-on-what-platforms-your-app-is-tested':
 		'Select the offering of Liferay your app is compatible with. The compatibility selections will determine on what platforms your app is tested.',
 	'select-the-option': 'Select the Option',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -190,6 +190,7 @@ export default {
 	'choose-currency': 'Choose Currency',
 	'choose-the-marketplace-category-that-most-accurately-describes-what-your-solution-does-users-looking-for-specific-types-of-solutions-will-often-browse-categories-by-searching-for-a-specific-category-name-on-the-main-marketplace-home-page-having-your-solution-listed-under-the-appropriate-category-will-help-them-find-it':
 		'Choose the Marketplace category that most accurately describes what your solution does. Users looking for specific types of solutions will often browse categories by searching for a specific category name on the main Marketplace home page. Having your solution listed under the appropriate category will help them find it.',
+	'city': 'City',
 	'clear': 'Clear',
 	'clear-all-filters': 'Clear All Filters',
 	'click-on-browse-catalog-to-start': "Click on 'Browse Catalog' to start.",
@@ -699,6 +700,7 @@ export default {
 	'once-canceled-no-further-edits-can-be-made-to-this-event':
 		'Once canceled, no further edits can be made to this event.',
 	'one-time-purchases': 'One-Time Purchases',
+	'online-payments-with-paypal': 'Online payments with PayPal',
 	'only-gif-jpg-jpeg-png-are-allowed-max-file-size-is-5mb':
 		'Only GIF, JPG, JPEG, and PNG are allowed. Max file size is 5MB.',
 	'only-jar-war-files-are-allowed-max-file-size-is-500mb':
@@ -709,6 +711,7 @@ export default {
 		'Only ZIP files are allowed. Max file size is 500MB.',
 	'oops-something-went-wrong': 'Oops! Something went wrong.',
 	'open': 'Open',
+	'order-confirmation': 'Order Confirmation',
 	'order-date': 'Order Date',
 	'order-details': 'Order Details',
 	'order-form': 'Order Form',
@@ -967,6 +970,7 @@ export default {
 	'start-date': 'Start Date',
 	'start-date-exp-date': 'Start Date - Exp. Date',
 	'start-trial': 'Start Trial',
+	'state': 'State',
 	'status': 'Status',
 	'storefront': 'Storefront',
 	'submit': 'Submit',
@@ -1243,6 +1247,7 @@ export default {
 		'You need Administrator or Requester role on this project to upload a file.',
 	'you-will-receive-an-invoice-via-email-with-all-the-details-needed-to-complete-your-payment-after-you-complete-the-payment-you-can-activate-your-license-from-the-customer-dashboard':
 		'You will receive an invoice via email with all the details needed to complete your payment. After you complete the payment, you can activate your license from the customer dashboard.',
+	'you-will-receive-an-invoice-via-email-with-the-instructions-to-complete-your-bank-transfer-payment': 'You will receive an invoice via email with the instructions to complete your bank transfer payment.',
 	'your-attachment-is-uploaded-however-we-encountered-a-problem-posting-your-comment-the-system-is-automatically-retrying-to-send-it':
 		'Your attachment is uploaded, however we encountered a problem posting your comment. The system is automatically retrying to send it.',
 	'your-current-liferay-version': 'Your Current Liferay Version',
@@ -1253,6 +1258,7 @@ export default {
 		'Your purchase has been successfully processed. To continue, please click the button below to download or install the app.',
 	'your-request-completed-successfully':
 		'Your request completed successfully',
+	'zip-area-code': 'Zip/Area Code',
 	'zip-files-must-be-in-universal-file-format-archive-luffa-the-specially-structured-zip-encoded-archive-used-to-package-client-extension-project-outputs-this-format-must-support-the-following-use-cases-deliver-batch-engine-data-files-compatible-with-all-deployment-targets-deliver-dxp-configuration-resource-compatible-with-all-deployment-targets-deliver-static-resources-compatible-with-all-deployment-targets-deliver-the-infrastructure-metadata-necessary-to-deploy-to-lxc-sm-for-more-information-see':
 		'ZIP Files must be in universal file format archive (LUFFA) - the specially structured, ZIP encoded archive used to package client extension project outputs This format must support the following use cases: deliver batch engine data files compatible with all deployment targets deliver DXP configuration resource compatible with all deployment targets deliver static resources compatible with all deployment targets deliver the infrastructure metadata necessary to deploy to Liferay PaaS for more information see: ',
 } as const;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseOutlet.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseOutlet.tsx
@@ -15,9 +15,11 @@ import AccountAvatar from '../../components/AccountAvatar';
 import Loading from '../../components/Loading';
 import i18n from '../../i18n';
 import {Liferay} from '../../liferay/liferay';
+import {getProductPriceModel} from '../../utils/productUtils';
 import ProductPurchaseHeader from './components/ProductPurchaseHeader';
 import ProductPurchaseSteps from './components/ProductPurchaseSteps';
 import useAccounts from './hooks/useAccounts';
+import useProductPurchaseCart from './hooks/useProductPurchaseCart';
 import {ProductPurchaseRoute} from './productPurchaseRoutes';
 import ProductPurchaseApp from './services/ProductPurchaseApp';
 
@@ -37,6 +39,7 @@ export type ProductPurchaseOutletContext = {
 	isSingleAccount: boolean;
 	isSubmitting: boolean;
 	product: DeliveryProduct;
+	productPurchaseCart: ReturnType<typeof useProductPurchaseCart>;
 	selectedAccount: Account;
 	setSelectedAccount: React.Dispatch<React.SetStateAction<Account>>;
 };
@@ -48,6 +51,21 @@ const ProductPurchaseOutlet = ({
 	const [isSubmitting, setSubmitting] = useState(false);
 	const {accounts, isLoading, selectedAccount, setSelectedAccount} =
 		useAccounts();
+
+	const productPurchaseCart = useProductPurchaseCart(
+		selectedAccount?.id,
+		product,
+		ProductPurchaseApp.getOrderTypeExternalReferenceCode(product)
+	);
+
+	const {isFreeApp} = getProductPriceModel(product);
+
+	const priceLabel = isFreeApp
+		? i18n.translate('free')
+		: productPurchaseCart.cart?.summary?.totalFormatted ||
+			product.skus?.find((sku) => sku?.price?.priceFormatted)?.price
+				?.priceFormatted ||
+			i18n.translate('free');
 
 	const {pathname} = useLocation();
 	const navigate = useNavigate();
@@ -110,6 +128,7 @@ const ProductPurchaseOutlet = ({
 		isSingleAccount: accounts.length === 1,
 		isSubmitting,
 		product,
+		productPurchaseCart,
 		selectedAccount,
 		setSelectedAccount,
 	};
@@ -133,7 +152,7 @@ const ProductPurchaseOutlet = ({
 						</small>
 
 						<span className="font-weight-semi-bold">
-							{i18n.translate('free')}
+							{priceLabel}
 						</span>
 					</div>
 				}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseOutlet.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseOutlet.tsx
@@ -15,6 +15,7 @@ import AccountAvatar from '../../components/AccountAvatar';
 import Loading from '../../components/Loading';
 import i18n from '../../i18n';
 import {Liferay} from '../../liferay/liferay';
+import HeadlessCommerceDeliveryCart from '../../services/rest/HeadlessCommerceDeliveryCart';
 import {getProductPriceModel} from '../../utils/productUtils';
 import ProductPurchaseHeader from './components/ProductPurchaseHeader';
 import ProductPurchaseSteps from './components/ProductPurchaseSteps';
@@ -22,6 +23,7 @@ import useAccounts from './hooks/useAccounts';
 import useProductPurchaseCart from './hooks/useProductPurchaseCart';
 import {ProductPurchaseRoute} from './productPurchaseRoutes';
 import ProductPurchaseApp from './services/ProductPurchaseApp';
+import {PaymentMethodType, ProductPurchasePayment} from './types';
 
 type ProductPurchaseOutletProps = {
 	product: DeliveryProduct;
@@ -38,9 +40,11 @@ export type ProductPurchaseOutletContext = {
 	isLoadingAccounts: boolean;
 	isSingleAccount: boolean;
 	isSubmitting: boolean;
+	payment: ProductPurchasePayment;
 	product: DeliveryProduct;
 	productPurchaseCart: ReturnType<typeof useProductPurchaseCart>;
 	selectedAccount: Account;
+	setPayment: React.Dispatch<React.SetStateAction<ProductPurchasePayment>>;
 	setSelectedAccount: React.Dispatch<React.SetStateAction<Account>>;
 };
 
@@ -49,6 +53,13 @@ const ProductPurchaseOutlet = ({
 	routes,
 }: ProductPurchaseOutletProps) => {
 	const [isSubmitting, setSubmitting] = useState(false);
+	const [payment, setPayment] = useState<ProductPurchasePayment>({
+		billingAddress: {} as BillingAddress,
+		invoice: {email: '', purchaseOrderNumber: ''},
+		taxId: '',
+		type: PaymentMethodType.PAY_NOW,
+	});
+
 	const {accounts, isLoading, selectedAccount, setSelectedAccount} =
 		useAccounts();
 
@@ -58,7 +69,7 @@ const ProductPurchaseOutlet = ({
 		ProductPurchaseApp.getOrderTypeExternalReferenceCode(product)
 	);
 
-	const {isFreeApp} = getProductPriceModel(product);
+	const {isFreeApp, isPaidApp} = getProductPriceModel(product);
 
 	const priceLabel = isFreeApp
 		? i18n.translate('free')
@@ -99,6 +110,37 @@ const ProductPurchaseOutlet = ({
 				product
 			);
 
+			if (isPaidApp) {
+				const cart = await productPurchase.createOrder({
+					...productPurchaseCart.cart,
+					billingAddress: payment.billingAddress,
+					cartItems: productPurchaseCart.cartItems,
+					paymentMethod:
+						payment.type === PaymentMethodType.PAY_NOW
+							? 'paypal-integration'
+							: 'money-order',
+					shippingAddress: payment.billingAddress,
+				});
+
+				if (payment.type === PaymentMethodType.PAY_NOW) {
+					window.location.href =
+						await HeadlessCommerceDeliveryCart.getPaymentMethodURL(
+							cart.id,
+							`${
+								window.location.href.split('#')[0]
+							}#/purchase-completed?orderId=${cart.id}`
+						);
+
+					return;
+				}
+
+				navigate(`/bank-transfer-completed?orderId=${cart.id}`, {
+					state: {account: selectedAccount},
+				});
+
+				return;
+			}
+
 			const order = await productPurchase.createOrder();
 
 			navigate(await productPurchase.getNextStepsLink(order), {
@@ -127,9 +169,11 @@ const ProductPurchaseOutlet = ({
 		isLoadingAccounts: isLoading,
 		isSingleAccount: accounts.length === 1,
 		isSubmitting,
+		payment,
 		product,
 		productPurchaseCart,
 		selectedAccount,
+		setPayment,
 		setSelectedAccount,
 	};
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
@@ -12,7 +12,6 @@ import {useDeliveryProduct} from '../../hooks/data/useProduct';
 import i18n from '../../i18n';
 import {Liferay} from '../../liferay/liferay';
 import {getProductPriceModel} from '../../utils/productUtils';
-import {getSiteURL} from '../../utils/site';
 import ProductPurchaseOutlet from './ProductPurchaseOutlet';
 import {getProductPurchaseRoutes} from './productPurchaseRoutes';
 
@@ -29,9 +28,7 @@ const ProductPurchaseRouter = () => {
 
 	const {data: product, isLoading} = useDeliveryProduct(productId);
 
-	const {isFreeApp, isPaidApp} = getProductPriceModel(
-		product as DeliveryProduct
-	);
+	const {isPaidApp} = getProductPriceModel(product as DeliveryProduct);
 
 	useEffect(() => {
 		if (!isSignedIn) {
@@ -43,17 +40,7 @@ const ProductPurchaseRouter = () => {
 		}
 	}, [isSignedIn]);
 
-	useEffect(() => {
-
-		// TODO LPD-94233: route paid apps through the license and payment
-		// steps instead of bouncing back to the marketplace
-
-		if (product && !isFreeApp) {
-			Liferay.Util.navigate(`${getSiteURL()}/marketplace`);
-		}
-	}, [isFreeApp, product]);
-
-	if (!isSignedIn || (product && !isFreeApp)) {
+	if (!isSignedIn) {
 		return null;
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
@@ -17,6 +17,9 @@ import {getProductPurchaseRoutes} from './productPurchaseRoutes';
 
 import './product_purchase.scss';
 
+const BankTransferCompleted = lazy(
+	() => import('./pages/BankTransferCompleted')
+);
 const PurchaseCompleted = lazy(() => import('./pages/PurchaseCompleted'));
 
 const ProductPurchaseRouter = () => {
@@ -95,6 +98,13 @@ const ProductPurchaseRouter = () => {
 								)
 							)}
 						</Route>
+
+						<Route
+							element={
+								<BankTransferCompleted product={product} />
+							}
+							path="bank-transfer-completed"
+						/>
 
 						<Route
 							element={<PurchaseCompleted product={product} />}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useAccountAddresses.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useAccountAddresses.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+import HeadlessAdminUser from '../../../services/rest/HeadlessAdminUser';
+
+const useAccountAddresses = (accountId?: number) =>
+	useSWR(
+		accountId ? `/account-postal-addresses/${accountId}` : null,
+		() => HeadlessAdminUser.getAccountPostalAddresses(accountId as number)
+	);
+
+export default useAccountAddresses;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useCommerceRegions.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useCommerceRegions.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+
+import HeadlessAdminAddress from '../../../services/rest/HeadlessAdminAddress';
+
+const useCommerceRegions = () =>
+	useSWR('/admin-address-countries', () =>
+		HeadlessAdminAddress.getCountries()
+	);
+
+export default useCommerceRegions;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useProductPurchaseCart.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/hooks/useProductPurchaseCart.ts
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useCallback, useEffect, useState} from 'react';
+
+import {Liferay} from '../../../liferay/liferay';
+import HeadlessCommerceDeliveryCart from '../../../services/rest/HeadlessCommerceDeliveryCart';
+
+const useProductPurchaseCart = (
+	accountId?: number,
+	product?: DeliveryProduct,
+	orderTypeExternalReferenceCode?: string
+) => {
+	const channelId = Liferay.CommerceContext.commerceChannelId;
+
+	const [cart, setCart] = useState<Cart>({} as Cart);
+	const [cartItems, setCartItems] = useState<CartItem[]>([]);
+
+	const cartId = cart?.id;
+
+	const syncCartItems = useCallback(
+		async (id: number, items: CartItem[]) => {
+			const updatedCart = await HeadlessCommerceDeliveryCart.updateCart(
+				id,
+				{cartItems: items}
+			);
+
+			setCart(updatedCart);
+		},
+		[]
+	);
+
+	const addCart = async (productId: number, skuId: number) => {
+		let currentCart = cart;
+
+		if (!cartId) {
+			currentCart = await HeadlessCommerceDeliveryCart.createCart(
+				channelId,
+				{
+					accountId,
+					currencyCode: Liferay.CommerceContext.currency.currencyCode,
+					orderTypeExternalReferenceCode,
+				}
+			);
+
+			setCart(currentCart);
+		}
+
+		const existingItem = cartItems.find((item) => item.skuId === skuId);
+
+		const newCartItems = existingItem
+			? cartItems.map((item) =>
+					item.skuId === skuId
+						? {...item, quantity: item.quantity + 1}
+						: item
+				)
+			: [...cartItems, {productId, quantity: 1, skuId} as CartItem];
+
+		setCartItems(newCartItems);
+
+		await syncCartItems(currentCart.id, newCartItems);
+	};
+
+	const removeFromCart = async (skuId: number) => {
+		const newCartItems = cartItems
+			.map((item) =>
+				item.skuId === skuId
+					? {...item, quantity: item.quantity - 1}
+					: item
+			)
+			.filter((item) => item.quantity > 0);
+
+		setCartItems(newCartItems);
+
+		if (cartId) {
+			await syncCartItems(cartId, newCartItems);
+		}
+	};
+
+	const removeCart = useCallback(
+		(id: number) =>
+			HeadlessCommerceDeliveryCart.deleteCart(id)
+				.then(() => {
+					setCart({} as Cart);
+					setCartItems([]);
+				})
+				.catch(console.error),
+		[]
+	);
+
+	useEffect(() => {
+		(async () => {
+			if (!accountId || !product) {
+				return;
+			}
+
+			const {items: carts} =
+				await HeadlessCommerceDeliveryCart.getAccountCarts(
+					accountId,
+					channelId
+				);
+
+			const [openCart] = carts ?? [];
+
+			if (openCart?.orderStatusInfo?.label !== 'open') {
+				return;
+			}
+
+			const {items: openCartItems} =
+				await HeadlessCommerceDeliveryCart.getCartItems(openCart.id);
+
+			const hasProduct = openCartItems.some(
+				(cartItem) => cartItem.productId === product.productId
+			);
+
+			if (!hasProduct) {
+				return removeCart(openCart.id);
+			}
+
+			setCart(openCart);
+			setCartItems(openCartItems);
+		})();
+	}, [accountId, channelId, product, removeCart]);
+
+	return {
+		addCart,
+		cart,
+		cartItems,
+		removeCart,
+		removeFromCart,
+		setCart,
+		updateCart: HeadlessCommerceDeliveryCart.updateCart.bind(
+			HeadlessCommerceDeliveryCart
+		),
+	};
+};
+
+export default useProductPurchaseCart;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/AccountSelection.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/AccountSelection.tsx
@@ -19,6 +19,7 @@ import {Liferay} from '../../../liferay/liferay';
 import {
 	getLicenseTagText,
 	getProductImageFallback,
+	getProductPriceModel,
 	getProductSpecificationValue,
 } from '../../../utils/productUtils';
 import {normalizeURLProtocol} from '../../../utils/string';
@@ -30,6 +31,7 @@ const HELP_CENTER_URL = 'https://help.liferay.com';
 const AccountSelection = () => {
 	const {
 		accounts,
+		actions: {nextStep},
 		isLoadingAccounts,
 		isSingleAccount,
 		product,
@@ -39,13 +41,15 @@ const AccountSelection = () => {
 
 	const navigate = useNavigate();
 
+	const {isPaidApp} = getProductPriceModel(product);
+
 	useEffect(() => {
 		if (isSingleAccount) {
 			setSelectedAccount(accounts[0]);
 
-			navigate('/summary', {replace: true});
+			navigate(isPaidApp ? '/license' : '/summary', {replace: true});
 		}
-	}, [accounts, isSingleAccount, navigate, setSelectedAccount]);
+	}, [accounts, isPaidApp, isSingleAccount, navigate, setSelectedAccount]);
 
 	if (isLoadingAccounts || isSingleAccount) {
 		return (
@@ -66,7 +70,7 @@ const AccountSelection = () => {
 				backButtonProps: {className: 'd-none'},
 				continueButtonProps: {
 					disabled: !selectedAccount?.id,
-					onClick: () => navigate('/summary'),
+					onClick: () => nextStep(),
 				},
 			}}
 			title={i18n.translate('account-selection')}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/BankTransferCompleted.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/BankTransferCompleted.tsx
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import {useLocation} from 'react-router-dom';
+
+import EmptyState from '../../../components/EmptyState';
+import i18n from '../../../i18n';
+import {Liferay} from '../../../liferay/liferay';
+import {getSiteURL} from '../../../utils/site';
+import ProductPurchaseHeaderCards from '../components/ProductPurchaseHeaderCards';
+
+type BankTransferCompletedProps = {
+	product: DeliveryProduct;
+};
+
+const BankTransferCompleted = ({product}: BankTransferCompletedProps) => {
+	const {search, state} = useLocation();
+
+	const urlSearchParams = new URLSearchParams(
+		search || window.location.search
+	);
+
+	const orderId = urlSearchParams.get('orderId') ?? '';
+
+	const account = (state as {account?: Account} | null)?.account;
+
+	if (!orderId) {
+		return (
+			<EmptyState
+				title={i18n.translate('no-results-found')}
+				type="NOT_FOUND"
+			/>
+		);
+	}
+
+	return (
+		<div className="product-purchase-completed">
+			<ProductPurchaseHeaderCards account={account} product={product} />
+
+			<h1 className="mt-5 product-purchase-shell-title text-center">
+				{i18n.translate('order-confirmation')}
+			</h1>
+
+			<p className="mt-3 text-center text-muted">
+				{i18n.translate(
+					'you-will-receive-an-invoice-via-email-with-the-instructions-to-complete-your-bank-transfer-payment'
+				)}
+			</p>
+
+			<p className="mt-4 text-center">
+				{i18n.translate('your-order-id-is')}{' '}
+				<strong className="text-primary">{orderId}</strong>
+			</p>
+
+			<hr className="my-4" />
+
+			<div className="d-flex justify-content-center">
+				<ClayButton
+					displayType="secondary"
+					onClick={() =>
+						Liferay.Util.navigate(
+							`${getSiteURL()}/my-account#/project/applications`
+						)
+					}
+				>
+					{i18n.translate('go-to-my-apps')}
+				</ClayButton>
+
+				<ClayButton
+					className="ml-3"
+					onClick={() =>
+						Liferay.Util.navigate(`${getSiteURL()}/marketplace`)
+					}
+				>
+					{i18n.translate('go-to-the-catalog')}
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default BankTransferCompleted;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/LicenseCard.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/LicenseCard.tsx
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayButtonWithIcon} from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+
+import {ProductLicense} from '../../../../enums/Product';
+import i18n from '../../../../i18n';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+import LicenseTier from './LicenseTier';
+
+const MAX_QUANTITY = 99;
+const MIN_QUANTITY = 0;
+
+const licenseTypeDescriptions: Record<string, string> = {
+	developer:
+		'Limited to 5 unique addresses and should not be used for full scale production deployments.',
+	standard:
+		'Covers the following DXP environments: production, non-production (UAT) and backup (DR) for both standalone and virtual cluster servers.',
+};
+
+type LicenseCardProps = {
+	sku: DeliverySKU;
+};
+
+const LicenseCard = ({sku}: LicenseCardProps) => {
+	const {product, productPurchaseCart} = useProductPurchaseOutletContext();
+
+	const {addCart, cartItems, removeFromCart} = productPurchaseCart;
+
+	const quantity =
+		cartItems.find((item) => item.skuId === sku.id)?.quantity ||
+		MIN_QUANTITY;
+
+	const skuOption = sku.skuOptions.find((skuOption) =>
+		[
+			ProductLicense.BASE,
+			ProductLicense.CLOUD,
+			ProductLicense.DXP,
+		].includes(skuOption.skuOptionKey as ProductLicense)
+	);
+
+	const licenseType = skuOption?.skuOptionValueKey?.toLocaleLowerCase() ?? '';
+
+	const licenseDescription = licenseTypeDescriptions[licenseType];
+
+	return (
+		<div className="border mb-4 p-4 product-purchase-license-card rounded">
+			<div className="align-items-start d-flex justify-content-between">
+				<div className="mr-4">
+					<span className="font-weight-bold text-capitalize">
+						{`${licenseType} ${i18n.translate('license')}`}
+
+						<ClayIcon
+							className="ml-2 product-purchase-license-card-icon"
+							symbol="code"
+						/>
+					</span>
+
+					{licenseDescription && (
+						<p className="mb-0 mt-2 text-muted">
+							{licenseDescription}
+						</p>
+					)}
+				</div>
+
+				<div className="align-items-center border d-flex justify-content-between p-1 product-purchase-license-card-stepper rounded-pill">
+					<ClayButtonWithIcon
+						aria-label={i18n.translate('remove')}
+						disabled={quantity === MIN_QUANTITY}
+						displayType="primary"
+						onClick={() => removeFromCart(sku.id)}
+						size="sm"
+						symbol="hr"
+					/>
+
+					<span className="px-3">{quantity}</span>
+
+					<ClayButtonWithIcon
+						aria-label={i18n.translate('add')}
+						disabled={quantity === MAX_QUANTITY}
+						displayType="primary"
+						onClick={() =>
+							addCart(Number(product.productId), sku.id)
+						}
+						size="sm"
+						symbol="plus"
+					/>
+				</div>
+			</div>
+
+			<div className="d-flex flex-column mt-4 p-4 product-purchase-license-card-tier rounded">
+				<span className="font-weight-bold mb-1">
+					{i18n.translate('license-prices')}
+				</span>
+
+				<LicenseTier sku={sku} />
+			</div>
+		</div>
+	);
+};
+
+export default LicenseCard;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/LicenseTier.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/LicenseTier.tsx
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import i18n from '../../../../i18n';
+
+const getTierPriceText = (
+	tierPrices: TierPrice[],
+	tierPrice: TierPrice,
+	index: number
+): string => {
+	const {priceFormatted, quantity} = tierPrice;
+
+	const isLastTier = index === tierPrices.length - 1;
+	const maxQuantity = tierPrices[index + 1]?.quantity - 1;
+
+	let quantityRange = `${quantity}`;
+
+	if (isLastTier) {
+		quantityRange = `${quantity}+`;
+	}
+	else if (maxQuantity !== quantity) {
+		quantityRange = `${quantity}-${maxQuantity}`;
+	}
+
+	const licensesText = i18n.translate(
+		quantity === 1 ? 'license' : 'licenses'
+	);
+
+	return `${quantityRange} ${licensesText}: ${priceFormatted} ${i18n.translate(
+		'each'
+	)}`;
+};
+
+type LicenseTierProps = {
+	sku: DeliverySKU;
+};
+
+const LicenseTier = ({sku}: LicenseTierProps) => {
+	const tierPrices = sku.tierPrices ?? [];
+
+	if (tierPrices.length <= 1) {
+		return (
+			<span className="product-purchase-license-tier-text">
+				{`1 ${i18n.translate('license')}: ${sku?.price?.priceFormatted}`}
+			</span>
+		);
+	}
+
+	return (
+		<>
+			{tierPrices.map((tierPrice, index) => (
+				<span
+					className="product-purchase-license-tier-text"
+					key={index}
+				>
+					{getTierPriceText(tierPrices, tierPrice, index)}
+				</span>
+			))}
+		</>
+	);
+};
+
+export default LicenseTier;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/License/index.tsx
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Navigate} from 'react-router-dom';
+
+import i18n from '../../../../i18n';
+import {isTrialSKU} from '../../../../utils/productUtils';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+import ProductPurchaseShell from '../../components/ProductPurchaseShell';
+import LicenseCard from './LicenseCard';
+
+const License = () => {
+	const {
+		actions: {nextStep, previousStep},
+		isSingleAccount,
+		product,
+		productPurchaseCart,
+		selectedAccount,
+	} = useProductPurchaseOutletContext();
+
+	if (!selectedAccount?.id) {
+		return <Navigate replace to="/" />;
+	}
+
+	const purchasableSkus = (product.skus || []).filter(
+		(sku) =>
+			sku?.price?.price &&
+			sku.purchasable &&
+			!isTrialSKU(sku as unknown as SKU)
+	);
+
+	const hasCartItems = productPurchaseCart.cartItems.some(
+		(cartItem) => cartItem.quantity > 0
+	);
+
+	return (
+		<ProductPurchaseShell
+			footerProps={{
+				backButtonProps: {
+					className: isSingleAccount ? 'd-none' : undefined,
+					onClick: () => previousStep(),
+				},
+				continueButtonProps: {
+					disabled: !hasCartItems,
+					onClick: () => nextStep(),
+				},
+			}}
+			title={i18n.translate('license-selection')}
+		>
+			<p className="text-muted">
+				{i18n.translate(
+					'select-the-license-type-and-the-number-of-licenses-you-want-to-purchase'
+				)}
+			</p>
+
+			{purchasableSkus.length ? (
+				purchasableSkus.map((sku) => (
+					<LicenseCard key={sku.id} sku={sku} />
+				))
+			) : (
+				<p className="font-weight-bold my-5">
+					{i18n.translate('no-licenses-available')}
+				</p>
+			)}
+		</ProductPurchaseShell>
+	);
+};
+
+export default License;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/BillingAddress.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/BillingAddress.tsx
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useState} from 'react';
+
+import RadioCard from '../../../../components/RadioCard/RadioCard';
+import Section from '../../../../components/Section/Section';
+import i18n from '../../../../i18n';
+import HeadlessAdminUser from '../../../../services/rest/HeadlessAdminUser';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+import useAccountAddresses from '../../hooks/useAccountAddresses';
+import useCommerceRegions from '../../hooks/useCommerceRegions';
+import BillingAddressForm from './BillingAddressForm';
+import getPostalAddressDescription from './getPostalAddressDescription';
+
+const BillingAddress = () => {
+	const {payment, selectedAccount, setPayment} =
+		useProductPurchaseOutletContext();
+
+	const {data: addressesResponse, mutate} = useAccountAddresses(
+		selectedAccount?.id
+	);
+	const {data: countriesResponse} = useCommerceRegions();
+
+	const [selectedAddress, setSelectedAddress] = useState(
+		payment.billingAddress?.name || ''
+	);
+	const [showNewAddressForm, setShowNewAddressForm] = useState(false);
+
+	const addresses = addressesResponse?.items ?? [];
+	const countries = countriesResponse?.items ?? [];
+
+	const setBillingAddress = (billingAddress: BillingAddress) =>
+		setPayment((previousPayment) => ({
+			...previousPayment,
+			billingAddress,
+		}));
+
+	const onSelectAddress = (address: AccountPostalAddresses) => {
+		setSelectedAddress(address.name);
+		setShowNewAddressForm(false);
+
+		const country = countries.find(
+			(commerceCountry) =>
+				(commerceCountry.title_i18n?.en_US || commerceCountry.name) ===
+				address.addressCountry
+		);
+
+		const region = country?.regions.find(
+			(commerceRegion) => commerceRegion.name === address.addressRegion
+		);
+
+		setBillingAddress({
+			city: address.addressLocality || '',
+			country: country?.a2 || address.addressCountry || '',
+			countryISOCode: country?.a2 || '',
+			name: address.name || '',
+			phoneNumber: address.phoneNumber || '',
+			regionISOCode: region?.regionCode || '',
+			street1: address.streetAddressLine1 || '',
+			street2: address.streetAddressLine2 || '',
+			zip: address.postalCode ? String(address.postalCode) : '',
+		});
+	};
+
+	const saveAddress = async (billingAddress: BillingAddress) => {
+		const country = countries.find(
+			(commerceCountry) => commerceCountry.a2 === billingAddress.country
+		);
+
+		const region = country?.regions.find(
+			(commerceRegion) =>
+				commerceRegion.regionCode === billingAddress.regionISOCode
+		);
+
+		await HeadlessAdminUser.postAddress(selectedAccount.id, {
+			addressCountry: country?.title_i18n?.en_US || country?.name,
+			addressLocality: billingAddress.city,
+			addressRegion: region?.name,
+			addressType: 'billing-and-shipping',
+			name: billingAddress.name,
+			phoneNumber: billingAddress.phoneNumber,
+			postalCode: billingAddress.zip,
+			primary: false,
+			streetAddressLine1: billingAddress.street1,
+			streetAddressLine2: billingAddress.street2,
+		});
+
+		await mutate();
+
+		setSelectedAddress(billingAddress.name || '');
+		setShowNewAddressForm(false);
+
+		setBillingAddress(billingAddress);
+	};
+
+	return (
+		<Section label={i18n.translate('billing-address')} required>
+			{addresses.map((address) => {
+				const {description, title} =
+					getPostalAddressDescription(address);
+
+				return (
+					<RadioCard
+						className="mb-3"
+						description={description}
+						key={address.id}
+						onChange={() => onSelectAddress(address)}
+						selected={selectedAddress === address.name}
+						title={title}
+					/>
+				);
+			})}
+
+			<BillingAddressForm
+				saveAddress={saveAddress}
+				setBillingAddress={setBillingAddress}
+				setSelectedAddress={setSelectedAddress}
+				setShowNewAddressForm={setShowNewAddressForm}
+				showNewAddressForm={showNewAddressForm}
+			/>
+		</Section>
+	);
+};
+
+export default BillingAddress;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/BillingAddressForm.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/BillingAddressForm.tsx
@@ -1,0 +1,208 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayIcon from '@clayui/icon';
+import {useForm} from 'react-hook-form';
+
+import FormInput from '../../../../components/Input/formInput';
+import Select from '../../../../components/Select/Select';
+import i18n from '../../../../i18n';
+import zodSchema, {zodResolver} from '../../../../schema/zod';
+import useCommerceRegions from '../../hooks/useCommerceRegions';
+
+const defaultBillingAddress: BillingAddress = {
+	city: '',
+	country: '',
+	countryISOCode: '',
+	name: '',
+	phoneNumber: '',
+	regionISOCode: '',
+	street1: '',
+	street2: '',
+	zip: '',
+};
+
+type BillingAddressFormProps = {
+	saveAddress: (billingAddress: BillingAddress) => void;
+	setBillingAddress: (billingAddress: BillingAddress) => void;
+	setSelectedAddress: (name: string) => void;
+	setShowNewAddressForm: (show: boolean) => void;
+	showNewAddressForm: boolean;
+};
+
+const BillingAddressForm = ({
+	saveAddress,
+	setBillingAddress,
+	setSelectedAddress,
+	setShowNewAddressForm,
+	showNewAddressForm,
+}: BillingAddressFormProps) => {
+	const {
+		formState: {errors, isValid},
+		handleSubmit,
+		register,
+		reset,
+		setValue,
+		watch,
+	} = useForm<BillingAddress>({
+		defaultValues: defaultBillingAddress,
+		mode: 'onChange',
+		resolver: zodResolver(zodSchema.billingAddress),
+	});
+
+	const {data: countriesResponse} = useCommerceRegions();
+
+	const countries = countriesResponse?.items ?? [];
+
+	const {country, regionISOCode} = watch();
+
+	const states =
+		countries.find((commerceCountry) => commerceCountry.a2 === country)
+			?.regions ?? [];
+
+	const inputProps = {
+		errors,
+		register,
+		required: true,
+	};
+
+	const onSubmit = (billingAddress: BillingAddress) => {
+		saveAddress(billingAddress);
+
+		reset();
+	};
+
+	if (!showNewAddressForm) {
+		return (
+			<button
+				className="align-items-center border d-flex justify-content-center mt-2 p-3 product-purchase-new-address rounded text-primary w-100"
+				onClick={() => {
+					setShowNewAddressForm(true);
+
+					setBillingAddress({
+						...defaultBillingAddress,
+						countryISOCode: countries[0]?.a2 ?? '',
+					});
+				}}
+			>
+				<ClayIcon className="mr-2" symbol="plus" />
+
+				{i18n.translate('new-address')}
+			</button>
+		);
+	}
+
+	return (
+		<div className="border mt-2 p-4 rounded">
+			<div className="align-items-center d-flex justify-content-between mb-3">
+				<strong>{i18n.translate('new-address')}</strong>
+
+				<ClayButton
+					displayType="secondary"
+					onClick={() => {
+						setShowNewAddressForm(false);
+						setSelectedAddress('');
+
+						setBillingAddress(defaultBillingAddress);
+					}}
+					size="sm"
+				>
+					{i18n.translate('cancel')}
+				</ClayButton>
+			</div>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('full-name')}
+				name="name"
+			/>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('address')}
+				name="street1"
+			/>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('address')}
+				name="street2"
+				required={false}
+			/>
+
+			<Select
+				boldLabel
+				label={i18n.translate('country')}
+				name="country"
+				onChange={({target: {value}}) => {
+					const countryStates =
+						countries.find(
+							(commerceCountry) => commerceCountry.a2 === value
+						)?.regions ?? [];
+
+					setValue('country', value);
+					setValue('countryISOCode', value);
+					setValue(
+						'regionISOCode',
+						countryStates[0]?.regionCode ?? ''
+					);
+				}}
+				options={countries.map((country) => ({
+					key: country.a2,
+					name: country.title_i18n?.en_US || country.name,
+				}))}
+				required
+				value={country}
+			/>
+
+			<Select
+				boldLabel
+				defaultOption={false}
+				disabled={!states.length}
+				label={i18n.translate('state')}
+				name="regionISOCode"
+				onChange={({target: {value}}) =>
+					setValue('regionISOCode', value)
+				}
+				options={states.map((state) => ({
+					key: state.regionCode,
+					name: state.name,
+				}))}
+				required={!!states.length}
+				value={regionISOCode}
+			/>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('city')}
+				name="city"
+			/>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('zip-area-code')}
+				name="zip"
+			/>
+
+			<FormInput
+				{...inputProps}
+				label={i18n.translate('phone')}
+				name="phoneNumber"
+			/>
+
+			<div className="d-flex justify-content-end">
+				<ClayButton
+					disabled={!isValid}
+					onClick={handleSubmit(onSubmit)}
+				>
+					{i18n.translate('save')}
+				</ClayButton>
+			</div>
+		</div>
+	);
+};
+
+export default BillingAddressForm;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/PaymentTypeSelector.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/PaymentTypeSelector.tsx
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayIcon from '@clayui/icon';
+
+import RadioCard from '../../../../components/RadioCard/RadioCard';
+import Section from '../../../../components/Section/Section';
+import {useOneContext} from '../../../../context/OneContext';
+import i18n from '../../../../i18n';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+import {PaymentMethodType} from '../../types';
+
+const PaymentTypeSelector = () => {
+	const {myUserAccount} = useOneContext();
+	const {payment, productPurchaseCart, setPayment} =
+		useProductPurchaseOutletContext();
+
+	const paymentModes = [
+		{
+			onSelect: () =>
+				setPayment((previousPayment) => ({
+					...previousPayment,
+					type: PaymentMethodType.PAY_NOW,
+				})),
+			subtitle: i18n.translate('online-payments-with-paypal'),
+			symbol: 'credit-card',
+			title: i18n.translate('pay-with-card'),
+			type: PaymentMethodType.PAY_NOW,
+		},
+		{
+			onSelect: () =>
+				setPayment((previousPayment) => ({
+					...previousPayment,
+					invoice: {
+						email: myUserAccount?.emailAddress || '',
+						purchaseOrderNumber: String(
+							productPurchaseCart.cart?.id || ''
+						),
+					},
+					type: PaymentMethodType.INVOICE,
+				})),
+			subtitle: i18n.translate('offline-payments-using-the-invoice'),
+			symbol: 'document-text',
+			title: i18n.translate('pay-with-bank-transfer'),
+			type: PaymentMethodType.INVOICE,
+		},
+	];
+
+	return (
+		<Section label={i18n.translate('payment-method')} required>
+			{paymentModes.map((paymentMode) => (
+				<RadioCard
+					className="mb-3"
+					content={
+						<div className="align-items-center d-flex">
+							<ClayIcon
+								className="mr-3 text-primary"
+								symbol={paymentMode.symbol}
+							/>
+
+							<div>
+								<p className="mb-0">{paymentMode.title}</p>
+
+								<small className="text-muted">
+									{paymentMode.subtitle}
+								</small>
+							</div>
+						</div>
+					}
+					key={paymentMode.type}
+					onChange={paymentMode.onSelect}
+					selected={payment.type === paymentMode.type}
+				/>
+			))}
+		</Section>
+	);
+};
+
+export default PaymentTypeSelector;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/TaxIdInput.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/TaxIdInput.tsx
@@ -1,0 +1,30 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import Section from '../../../../components/Section/Section';
+import {Input} from '../../../../components/Input/Input';
+import i18n from '../../../../i18n';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+
+const TaxIdInput = () => {
+	const {payment, setPayment} = useProductPurchaseOutletContext();
+
+	return (
+		<Section label={i18n.translate('tax-vat-id')}>
+			<Input
+				onChange={({target: {value}}) =>
+					setPayment((previousPayment) => ({
+						...previousPayment,
+						taxId: value,
+					}))
+				}
+				placeholder={i18n.translate('enter-your-vat-id')}
+				value={payment.taxId}
+			/>
+		</Section>
+	);
+};
+
+export default TaxIdInput;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/getPostalAddressDescription.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/getPostalAddressDescription.ts
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export default function getPostalAddressDescription(
+	address: AccountPostalAddresses
+) {
+	const streetAddressLine2 = address.streetAddressLine2
+		? `${address.streetAddressLine2}, `
+		: '';
+
+	return {
+		description: `${address.streetAddressLine1}, ${streetAddressLine2}${address.addressLocality}, ${address.addressRegion}, ${address.addressCountry} ${address.postalCode}`,
+		title: address.name,
+	};
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/index.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/PaymentMethod/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useState} from 'react';
+import {Navigate} from 'react-router-dom';
+
+import i18n from '../../../../i18n';
+import zodSchema from '../../../../schema/zod';
+import CommerceOrder from '../../../../services/oauth/CommerceOrder';
+import HeadlessCommerceDeliveryCart from '../../../../services/rest/HeadlessCommerceDeliveryCart';
+import {useProductPurchaseOutletContext} from '../../ProductPurchaseOutlet';
+import ProductPurchaseShell from '../../components/ProductPurchaseShell';
+import BillingAddress from './BillingAddress';
+import PaymentTypeSelector from './PaymentTypeSelector';
+import TaxIdInput from './TaxIdInput';
+
+const PaymentMethod = () => {
+	const [loading, setLoading] = useState(false);
+
+	const {
+		actions: {nextStep, previousStep},
+		payment,
+		productPurchaseCart,
+		selectedAccount,
+	} = useProductPurchaseOutletContext();
+
+	if (!selectedAccount?.id) {
+		return <Navigate replace to="/" />;
+	}
+
+	const isBillingAddressValid = zodSchema.billingAddress.safeParse(
+		payment.billingAddress
+	).success;
+
+	const onContinue = async () => {
+		setLoading(true);
+
+		try {
+			const cartId = productPurchaseCart.cart?.id;
+
+			if (cartId) {
+				await productPurchaseCart.updateCart(cartId, {
+					billingAddress: payment.billingAddress,
+					shippingAddress: payment.billingAddress,
+				});
+
+				await CommerceOrder.taxCalculate(cartId).catch(console.error);
+
+				productPurchaseCart.setCart(
+					await HeadlessCommerceDeliveryCart.getCart(cartId)
+				);
+			}
+
+			nextStep();
+		}
+		finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<ProductPurchaseShell
+			footerProps={{
+				backButtonProps: {onClick: () => previousStep()},
+				continueButtonProps: {
+					disabled: !isBillingAddressValid || loading,
+					onClick: onContinue,
+				},
+			}}
+			title={i18n.translate('payment-method')}
+		>
+			<BillingAddress />
+
+			<TaxIdInput />
+
+			<PaymentTypeSelector />
+		</ProductPurchaseShell>
+	);
+};
+
+export default PaymentMethod;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/Summary.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/pages/Summary.tsx
@@ -7,12 +7,15 @@ import classNames from 'classnames';
 import {useState} from 'react';
 import {Navigate} from 'react-router-dom';
 
+import Section from '../../../components/Section/Section';
 import i18n from '../../../i18n';
 import {Liferay} from '../../../liferay/liferay';
 import {formatCurrency} from '../../../utils/currencies';
+import {getProductPriceModel} from '../../../utils/productUtils';
 import {useProductPurchaseOutletContext} from '../ProductPurchaseOutlet';
 import LicenseTermsCheckbox from '../components/LicenseTermsCheckbox';
 import ProductPurchaseShell from '../components/ProductPurchaseShell';
+import {PaymentMethodType} from '../types';
 
 const Summary = () => {
 	const [eulaAgreement, setEulaAgreement] = useState(false);
@@ -22,7 +25,9 @@ const Summary = () => {
 		handlePurchase,
 		isSingleAccount,
 		isSubmitting,
+		payment,
 		product,
+		productPurchaseCart,
 		selectedAccount,
 	} = useProductPurchaseOutletContext();
 
@@ -30,32 +35,84 @@ const Summary = () => {
 		return <Navigate replace to="/" />;
 	}
 
+	const {isPaidApp} = getProductPriceModel(product);
+
 	const freePrice = formatCurrency(
 		0,
 		Liferay.CommerceContext.currency.currencyCode
 	);
 
+	const summary = productPurchaseCart.cart?.summary;
+
+	const billingAddress = payment.billingAddress;
+
 	const summaryRows = [
-		{label: i18n.translate('net-price'), value: freePrice},
-		{label: i18n.translate('vat'), value: freePrice},
-		{label: i18n.translate('total'), value: freePrice},
+		{
+			label: i18n.translate('net-price'),
+			value: (isPaidApp && summary?.subtotalFormatted) || freePrice,
+		},
+		{
+			label: i18n.translate('vat'),
+			value: (isPaidApp && summary?.taxValueFormatted) || freePrice,
+		},
+		{
+			label: i18n.translate('total'),
+			value: (isPaidApp && summary?.totalFormatted) || freePrice,
+		},
 	];
 
 	return (
 		<ProductPurchaseShell
 			footerProps={{
 				backButtonProps: {
-					className: classNames({'d-none': isSingleAccount}),
+					className: classNames({
+						'd-none': !isPaidApp && isSingleAccount,
+					}),
 					onClick: () => previousStep(),
 				},
 				continueButtonProps: {
-					children: i18n.translate('get-app'),
+					children: i18n.translate(
+						isPaidApp ? 'purchase-app' : 'get-app'
+					),
 					disabled: !eulaAgreement || isSubmitting,
 					onClick: () => handlePurchase(),
 				},
 			}}
 			title={i18n.translate('summary')}
 		>
+			{isPaidApp && (
+				<>
+					<Section label={i18n.translate('billing-address')}>
+						<div className="border p-3 rounded">
+							<strong className="d-block">
+								{billingAddress.name}
+							</strong>
+
+							<small className="text-muted">
+								{[
+									billingAddress.street1,
+									billingAddress.city,
+									billingAddress.regionISOCode,
+									billingAddress.country,
+								]
+									.filter(Boolean)
+									.join(', ')}
+							</small>
+						</div>
+					</Section>
+
+					<Section label={i18n.translate('payment-method')}>
+						<div className="border p-3 rounded">
+							{i18n.translate(
+								payment.type === PaymentMethodType.PAY_NOW
+									? 'pay-with-card'
+									: 'pay-with-bank-transfer'
+							)}
+						</div>
+					</Section>
+				</>
+			)}
+
 			<h5 className="mb-2">{i18n.translate('order-summary')}</h5>
 
 			<hr className="mt-0" />

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
@@ -9,6 +9,7 @@ import i18n from '../../i18n';
 
 const AccountSelection = lazy(() => import('./pages/AccountSelection'));
 const License = lazy(() => import('./pages/License'));
+const PaymentMethod = lazy(() => import('./pages/PaymentMethod'));
 const Summary = lazy(() => import('./pages/Summary'));
 
 export type ProductPurchaseRoute = {
@@ -31,6 +32,12 @@ export function getProductPurchaseRoutes(isPaidApp: boolean) {
 			isPaidOnly: true,
 			path: 'license',
 			title: i18n.translate('license-selection'),
+		},
+		{
+			element: <PaymentMethod />,
+			isPaidOnly: true,
+			path: 'payment-method',
+			title: i18n.translate('payment-method'),
 		},
 		{
 			element: <Summary />,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
@@ -8,6 +8,7 @@ import {ReactNode, lazy} from 'react';
 import i18n from '../../i18n';
 
 const AccountSelection = lazy(() => import('./pages/AccountSelection'));
+const License = lazy(() => import('./pages/License'));
 const Summary = lazy(() => import('./pages/Summary'));
 
 export type ProductPurchaseRoute = {
@@ -24,6 +25,12 @@ export function getProductPurchaseRoutes(isPaidApp: boolean) {
 			element: <AccountSelection />,
 			index: true,
 			title: i18n.translate('account'),
+		},
+		{
+			element: <License />,
+			isPaidOnly: true,
+			path: 'license',
+			title: i18n.translate('license-selection'),
 		},
 		{
 			element: <Summary />,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/product_purchase.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/product_purchase.scss
@@ -59,4 +59,33 @@
 	.product-purchase-summary-label {
 		min-width: 80px;
 	}
+
+	.product-purchase-license-card {
+		border-color: #e2e2e4;
+		border-radius: 10px;
+
+		.product-purchase-license-card-icon {
+			color: #377cff;
+		}
+	}
+
+	.product-purchase-license-card-stepper {
+		height: 40px;
+
+		span {
+			min-width: 32px;
+			text-align: center;
+		}
+	}
+
+	.product-purchase-license-card-tier {
+		background-color: #f7f7f8;
+		border-radius: 8px;
+
+		.product-purchase-license-tier-text {
+			color: #6c6c75;
+			font-size: 13px;
+			line-height: 16px;
+		}
+	}
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/product_purchase.scss
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/product_purchase.scss
@@ -88,4 +88,22 @@
 			line-height: 16px;
 		}
 	}
+
+	.product-purchase-radio-card {
+		cursor: pointer;
+
+		&.selected {
+			background-color: #e7f0ff;
+			border-color: #0b60ff !important;
+		}
+	}
+
+	.product-purchase-new-address {
+		background-color: #fff;
+		border-color: #0b60ff !important;
+
+		&:hover {
+			background-color: #e7f0ff;
+		}
+	}
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/types.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/types.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export enum PaymentMethodType {
+	INVOICE,
+	PAY_NOW,
+}
+
+export type ProductPurchaseInvoice = {
+	email: string;
+	purchaseOrderNumber: string;
+};
+
+export type ProductPurchasePayment = {
+	billingAddress: BillingAddress;
+	invoice: ProductPurchaseInvoice;
+	taxId: string;
+	type: PaymentMethodType;
+};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/CommerceOrder.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/oauth/CommerceOrder.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {OneSpringBootOAuth2} from './OAuth2Client';
+
+class CommerceOrderOAuth2 extends OneSpringBootOAuth2 {
+	async taxCalculate(orderId: number | string) {
+		await this.post(`/${orderId}/tax-calculate`);
+	}
+}
+
+const commerceOrderOAuth2 = new CommerceOrderOAuth2('/commerce-orders');
+
+export default commerceOrderOAuth2;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/GetAppInformation.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/GetAppInformation.ts
@@ -17,6 +17,6 @@ export default class GetAppInformation {
 	static async postGetAppInformation(
 		getAppInformation: GetAppInformationBody
 	) {
-		return fetcher.post('/o/c/getappinformations/', getAppInformation);
+		return fetcher.post('/o/c/getappinformations', getAppInformation);
 	}
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessAdminAddress.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessAdminAddress.ts
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '../fetcher';
+
+export type AddressCountryRegion = {
+	name: string;
+	regionCode: string;
+};
+
+export type AddressCountry = {
+	a2: string;
+	active: boolean;
+	name: string;
+	regions: AddressCountryRegion[];
+	title_i18n: {[key: string]: string};
+};
+
+export default class HeadlessAdminAddress {
+	static async getCountries(
+		searchParams = new URLSearchParams({
+			nestedFields: 'regions',
+			pageSize: '-1',
+		})
+	) {
+		return fetcher<APIResponse<AddressCountry>>(
+			`/o/headless-admin-address/v1.0/countries?${searchParams.toString()}`
+		);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceDeliveryCart.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/rest/HeadlessCommerceDeliveryCart.ts
@@ -49,7 +49,9 @@ export default class HeadlessCommerceDeliveryCart {
 
 	static async getPaymentMethodURL(cartId: number, callbackURL: string) {
 		const response = await Liferay.Util.fetch(
-			`/o/headless-commerce-delivery-cart/v1.0/carts/${cartId}/payment-url?callbackURL=${callbackURL}`
+			`/o/headless-commerce-delivery-cart/v1.0/carts/${cartId}/payment-url?callbackURL=${encodeURIComponent(
+				callbackURL
+			)}`
 		);
 
 		return response.text();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/accounts.d.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/accounts.d.ts
@@ -41,6 +41,7 @@ type AccountPostalAddresses = {
 	addressType: string;
 	id: number;
 	name: string;
+	phoneNumber: string;
 	postalCode: number;
 	primary: boolean;
 	streetAddressLine1: string;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94233

## What is being fixed

The paid Marketplace application checkout flow was not yet available in liferay-one. After the free-app checkout shell landed (LPD-94250), paid apps were bounced back to the marketplace instead of going through license selection and payment, so customers could not purchase a paid app.

## How it is being fixed

The paid flow is built on top of the shared ProductPurchase shell. It adds a license selection step with paid license tiers and quantity, a payment method step with billing address selection or creation, Tax/VAT ID, and a PayPal or bank transfer choice, a paid order summary with the real totals and a billing and payment review alongside the EULA agreement, and a bank transfer confirmation page. Account selection now advances to the next step, and the temporary redirect that sent paid apps back to the marketplace was removed so they flow through the new paid-only steps. PayPal checkout redirects through the commerce payment URL and returns to the purchase completed page, while bank transfer lands on its confirmation page. The billing address country and region list is sourced from headless-admin-address, and the tax calculation call is wired to the backend endpoint delivered separately in LPD-95435.
