### PR TITLE
LPD-95435 Add tax-calculate endpoint for paid app checkout

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -67,6 +67,7 @@ dependencies {
 	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
 	implementation group: "com.liferay", name: "org.apache.commons.logging", version: "1.2.LIFERAY-PATCHED-2"
 	implementation group: "com.liferay.commerce", name: "com.liferay.headless.commerce.admin.catalog.client", version: "4.0.77"
+	implementation group: "com.liferay.commerce", name: "com.liferay.headless.commerce.admin.order.client", version: "4.0.51"
 	implementation group: "com.liferay.commerce", name: "com.liferay.headless.commerce.admin.pricing.client", version: "4.0.48"
 	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
 	implementation group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommerceOrdersRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommerceOrdersRestController.java
@@ -6,9 +6,12 @@
 package com.liferay.one;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.one.permission.CommerceOrderPermission;
 import com.liferay.one.service.CommerceOrderService;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,11 +26,17 @@ public class CommerceOrdersRestController extends BaseRestController {
 
 	@PostMapping("/{commerceOrderId}/tax-calculate")
 	public void postTaxCalculate(
+			@AuthenticationPrincipal Jwt jwt,
 			@PathVariable("commerceOrderId") long commerceOrderId)
 		throws Exception {
 
+		_commerceOrderPermission.check(commerceOrderId, jwt);
+
 		_commerceOrderService.taxCalculate(commerceOrderId);
 	}
+
+	@Autowired
+	private CommerceOrderPermission _commerceOrderPermission;
 
 	@Autowired
 	private CommerceOrderService _commerceOrderService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommerceOrdersRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommerceOrdersRestController.java
@@ -1,0 +1,35 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.one.service.CommerceOrderService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Ricardo Mariz
+ */
+@RequestMapping("/commerce-orders")
+@RestController
+public class CommerceOrdersRestController extends BaseRestController {
+
+	@PostMapping("/{commerceOrderId}/tax-calculate")
+	public void postTaxCalculate(
+			@PathVariable("commerceOrderId") long commerceOrderId)
+		throws Exception {
+
+		_commerceOrderService.taxCalculate(commerceOrderId);
+	}
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/CommerceOrderPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/CommerceOrderPermission.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.headless.admin.user.client.resource.v1_0.UserAccountResource;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Ricardo Mariz
+ */
+@Component
+public class CommerceOrderPermission {
+
+	public void check(long commerceOrderId, Jwt jwt) throws Exception {
+		if (!_contains(commerceOrderId, jwt)) {
+			throw new PrincipalException();
+		}
+	}
+
+	private boolean _contains(long commerceOrderId, Jwt jwt) throws Exception {
+		UserAccountResource userAccountResource = UserAccountResource.builder(
+		).header(
+			HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
+		).endpoint(
+			_lxcDXPMainDomain, _lxcDXPServerProtocol
+		).build();
+
+		UserAccount userAccount = userAccountResource.getMyUserAccount();
+
+		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
+			String roleBriefName = roleBrief.getName();
+
+			if (roleBriefName.equals(RoleConstants.NAME_ADMINISTRATOR) ||
+				roleBriefName.equals(RoleConstants.NAME_LIFERAY_STAFF)) {
+
+				return true;
+			}
+		}
+
+		Long accountId = _commerceOrderService.getCommerceOrderAccountId(
+			commerceOrderId);
+
+		if (accountId == null) {
+			return false;
+		}
+
+		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {
+			if (Objects.equals(accountBrief.getId(), accountId)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+	@Value("${com.liferay.lxc.dxp.mainDomain}")
+	private String _lxcDXPMainDomain;
+
+	@Value("${com.liferay.lxc.dxp.server.protocol}")
+	private String _lxcDXPServerProtocol;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -5,6 +5,9 @@
 
 package com.liferay.one.service;
 
+import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Currency;
+import com.liferay.headless.commerce.admin.catalog.client.pagination.Pagination;
+import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.CurrencyResource;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.BillingAddress;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
@@ -16,6 +19,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.math.BigDecimal;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -91,14 +95,26 @@ public class CommerceOrderService extends OneBaseService {
 				});
 		}
 
+		_setExchangeRate(order);
+
 		orderResource.patchOrder(
 			commerceOrderId,
 			new Order() {
 				{
+					setCustomFields(order::getCustomFields);
 					setTaxAmount(() -> taxAmount);
 					setTotal(() -> total);
 				}
 			});
+	}
+
+	private CurrencyResource _getCurrencyResource() {
+		return CurrencyResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
 	}
 
 	private OrderItemResource _getOrderItemResource() {
@@ -117,7 +133,7 @@ public class CommerceOrderService extends OneBaseService {
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).parameters(
-			"nestedFields", "account,billingAddress,orderItems"
+			"nestedFields", "account,billingAddress,customFields,orderItems"
 		).build();
 	}
 
@@ -135,6 +151,34 @@ public class CommerceOrderService extends OneBaseService {
 		}
 
 		return false;
+	}
+
+	private void _setExchangeRate(Order order) throws Exception {
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		JSONObject orderMetadataJSONObject = new JSONObject(
+			customFields.getOrDefault("order-metadata", "{}"));
+
+		if (orderMetadataJSONObject.has("exchangeRate")) {
+			return;
+		}
+
+		CurrencyResource currencyResource = _getCurrencyResource();
+
+		Currency currency = currencyResource.getCurrenciesPage(
+			null, "code eq 'EUR'", Pagination.of(1, 1), null
+		).fetchFirstItem();
+
+		if (currency == null) {
+			return;
+		}
+
+		customFields.put(
+			"order-metadata",
+			orderMetadataJSONObject.put(
+				"exchangeRate", currency.getRate()
+			).toString());
 	}
 
 	private static final int _ACCOUNT_TYPE_BUSINESS = 2;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -5,11 +5,23 @@
 
 package com.liferay.one.service;
 
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.BillingAddress;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderItemResource;
+import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
 import com.liferay.one.model.CommerceOrder;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.math.BigDecimal;
+
+import java.util.Objects;
+import java.util.Set;
+
 import org.json.JSONObject;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -38,5 +50,102 @@ public class CommerceOrderService extends OneBaseService {
 
 		return new CommerceOrder(new JSONObject(response));
 	}
+
+	public void taxCalculate(long commerceOrderId) throws Exception {
+		OrderResource orderResource = _getOrderResource();
+
+		Order order = orderResource.getOrder(commerceOrderId);
+
+		BillingAddress billingAddress = order.getBillingAddress();
+
+		if ((billingAddress == null) ||
+			!_isTaxApplicable(order.getAccount(), billingAddress)) {
+
+			return;
+		}
+
+		BigDecimal subtotalAmount = BigDecimal.valueOf(
+			order.getSubtotalAmount());
+
+		BigDecimal taxAmount = subtotalAmount.multiply(
+			BigDecimal.valueOf(_TAX_PERCENTAGE));
+
+		BigDecimal total = subtotalAmount.add(taxAmount);
+
+		OrderItemResource orderItemResource = _getOrderItemResource();
+
+		for (OrderItem orderItem : order.getOrderItems()) {
+			BigDecimal finalPrice = orderItem.getFinalPrice();
+
+			orderItemResource.patchOrderItem(
+				orderItem.getId(),
+				new OrderItem() {
+					{
+						setFinalPrice(() -> finalPrice);
+						setFinalPriceWithTaxAmount(
+							() -> finalPrice.add(
+								finalPrice.multiply(
+									BigDecimal.valueOf(_TAX_PERCENTAGE))));
+						setPriceManuallyAdjusted(() -> true);
+					}
+				});
+		}
+
+		orderResource.patchOrder(
+			commerceOrderId,
+			new Order() {
+				{
+					setTaxAmount(() -> taxAmount);
+					setTotal(() -> total);
+				}
+			});
+	}
+
+	private OrderItemResource _getOrderItemResource() {
+		return OrderItemResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+	}
+
+	private OrderResource _getOrderResource() {
+		return OrderResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).parameters(
+			"nestedFields", "account,billingAddress,orderItems"
+		).build();
+	}
+
+	private boolean _isTaxApplicable(
+		Account account, BillingAddress billingAddress) {
+
+		String countryISOCode = billingAddress.getCountryISOCode();
+
+		if (Objects.equals(account.getType(), _ACCOUNT_TYPE_BUSINESS)) {
+			return Objects.equals(countryISOCode, "IE");
+		}
+
+		if (Objects.equals(account.getType(), _ACCOUNT_TYPE_PERSON)) {
+			return _europeanCountryISOCodes.contains(countryISOCode);
+		}
+
+		return false;
+	}
+
+	private static final int _ACCOUNT_TYPE_BUSINESS = 2;
+
+	private static final int _ACCOUNT_TYPE_PERSON = 1;
+
+	private static final double _TAX_PERCENTAGE = 0.20;
+
+	private static final Set<String> _europeanCountryISOCodes = Set.of(
+		"AT", "BE", "BG", "CY", "CZ", "DE", "DK", "EE", "ES", "FI", "FR", "GR",
+		"HR", "HU", "IE", "IT", "LT", "LU", "LV", "MT", "NL", "PL", "PT", "RO",
+		"SE", "SI", "SK");
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -55,6 +55,20 @@ public class CommerceOrderService extends OneBaseService {
 		return new CommerceOrder(new JSONObject(response));
 	}
 
+	public Long getCommerceOrderAccountId(long commerceOrderId)
+		throws Exception {
+
+		Order order = _getOrderResource().getOrder(commerceOrderId);
+
+		Account account = order.getAccount();
+
+		if (account == null) {
+			return null;
+		}
+
+		return account.getId();
+	}
+
 	public void taxCalculate(long commerceOrderId) throws Exception {
 		OrderResource orderResource = _getOrderResource();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
@@ -261,6 +261,20 @@
 	},
 	{
 		"dataType": 15,
+		"defaultValue": "{}",
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "order-metadata",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
 		"modelResource": "com.liferay.commerce.model.CommerceOrder",
 		"name": "partnerAccount",
 		"properties": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95435

## What is being fixed

The paid app checkout flow (frontend: LPD-94233 / liferay-one#1209) calls `POST /commerce-orders/{commerceOrderId}/tax-calculate` after the billing address is selected, so the order summary can reflect VAT before the purchase is confirmed. The `liferay-one-etc-spring-boot` client extension had no such endpoint, so that call was effectively a no-op and order totals never reflected tax.

## How it is being fixed

Adds `CommerceOrdersRestController` exposing `POST /commerce-orders/{commerceOrderId}/tax-calculate`, delegating to a new `CommerceOrderService.taxCalculate`. VAT of 20% applies when the order's account is a business in Ireland or a person in an EU country. In that case each order item's `finalPriceWithTaxAmount` is set to its final price plus 20% and flagged `priceManuallyAdjusted`, and the order's `taxAmount` and `total` are patched accordingly. The work uses the Headless Commerce Admin Order client, which is added to `build.gradle`. The logic is ported from the marketplace workspace's `MarketplaceRestController.postTaxCalculate`.

It also captures the USD-to-EUR exchange rate on the order during tax calculation, storing it under `exchangeRate` in the order's `order-metadata` custom field (added as an Expando column on `CommerceOrder`). VAT-compliant invoices for orders charged in USD must state the conversion rate in effect at the moment of purchase, and that rate changes daily and cannot be recovered later — so it is captured now even though displaying it on the invoice is a separate follow-up.

Finally, the endpoint now checks permission: it resolves the caller from the request and allows the call only for an Administrator or Liferay Staff member, or a member of the order's account. Without it, any authenticated user could recalculate tax on an order belonging to another account.

**pr-check: PASS** — tested on `b4839a94b93c2f5cf4982347afde4d30589df5cf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "b4839a94b93c2f5cf4982347afde4d30589df5cf"} -->
