### PR TITLE
LPD-89433 Port Okta identity providers and utilities to Spring Boot

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/OktaConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/OktaConstants.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Karoline Silva
+ */
+public class OktaConstants {
+
+	public static final String GROUP_NAME_CUSTOMERS = "Customers";
+
+	public static final String GROUP_NAME_PARTNERS = "Partners";
+
+	public static final String TOPIC_OKTA_APP_USER_UPDATE =
+		"okta-app-user-update";
+
+	public static final String TOPIC_OKTA_USER_CREATE = "okta-user-create";
+
+	public static final String TOPIC_OKTA_USER_GROUP_UPDATE =
+		"okta-user-group-update";
+
+	public static final String TOPIC_OKTA_USER_UPDATE = "okta-user-update";
+
+	public static final String URL_API_REST_GROUPS = "/api/v1/groups/";
+
+	public static final String URL_API_REST_GROUPS_USERS = "/users";
+
+	public static final String URL_API_REST_USERS = "/api/v1/users/";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/OktaUser.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/OktaUser.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.model;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.json.JSONObject;
+
+/**
+ * @author Karoline Silva
+ */
+public class OktaUser {
+
+	public OktaUser(JSONObject jsonObject) {
+		JSONObject profileJSONObject = jsonObject.optJSONObject("profile");
+
+		if (profileJSONObject == null) {
+			profileJSONObject = new JSONObject();
+		}
+
+		_email = profileJSONObject.optString("email");
+		_emailAddressVerified = _statusesVerified.contains(
+			jsonObject.optString("status"));
+		_firstName = profileJSONObject.optString("firstName");
+		_lastName = profileJSONObject.optString("lastName");
+		_middleName = profileJSONObject.optString("middleName");
+		_uuid = profileJSONObject.optString("uuid");
+	}
+
+	public String getEmail() {
+		return _email;
+	}
+
+	public String getFirstName() {
+		return _firstName;
+	}
+
+	public String getLastName() {
+		return _lastName;
+	}
+
+	public String getMiddleName() {
+		return _middleName;
+	}
+
+	public String getUuid() {
+		return _uuid;
+	}
+
+	public boolean isEmailAddressVerified() {
+		return _emailAddressVerified;
+	}
+
+	private static final Set<String> _statusesVerified = new HashSet<>(
+		Arrays.asList(
+			"ACTIVE", "LOCKED_OUT", "PASSWORD_EXPIRED", "RECOVERY",
+			"SUSPENDED"));
+
+	private final String _email;
+	private final boolean _emailAddressVerified;
+	private final String _firstName;
+	private final String _lastName;
+	private final String _middleName;
+	private final String _uuid;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/OktaPubsubPublisher.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/pubsub/OktaPubsubPublisher.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.pubsub;
+
+import com.liferay.one.pubsub.publisher.BasePubsubPublisher;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Karoline Silva
+ */
+@Component
+public class OktaPubsubPublisher extends BasePubsubPublisher {
+
+	@Override
+	protected String getProjectId() {
+		return _projectId;
+	}
+
+	@Override
+	protected boolean isAutoCreateTopic() {
+		return false;
+	}
+
+	@Value("${liferay.one.okta.pubsub.publisher.project.id}")
+	private String _projectId;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EmailAddressValidatorService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EmailAddressValidatorService.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Karoline Silva
+ */
+@Component
+public class EmailAddressValidatorService {
+
+	public boolean isLiferayDomain(String emailAddress) {
+		String domain = emailAddress.substring(emailAddress.indexOf('@') + 1);
+
+		return _liferayDomains.contains(domain);
+	}
+
+	public void validateDomain(String emailAddress) {
+		if (isLiferayDomain(emailAddress)) {
+			throw new IllegalArgumentException(
+				"Email address uses a reserved Liferay domain");
+		}
+	}
+
+	@PostConstruct
+	protected void init() {
+		Collections.addAll(
+			_liferayDomains, StringUtil.split(_liferayDomainsString));
+	}
+
+	private final Set<String> _liferayDomains = new HashSet<>();
+
+	@Value("${liferay.one.email.address.validator.liferay.domains}")
+	private String _liferayDomainsString;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OktaIdentityService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OktaIdentityService.java
@@ -1,0 +1,378 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.constants.OktaConstants;
+import com.liferay.one.model.OktaUser;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.pubsub.OktaPubsubPublisher;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.annotation.PostConstruct;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * @author Karoline Silva
+ */
+@Component
+public class OktaIdentityService {
+
+	public void activateUser(String emailAddress) throws Exception {
+		_oktaPubsubPublisher.publish(
+			new Message(
+				null,
+				new JSONObject(
+				).put(
+					"action", "ACTIVATE"
+				).put(
+					"login", emailAddress
+				).toString(),
+				OktaConstants.TOPIC_OKTA_USER_UPDATE));
+	}
+
+	public void addMembership(String groupName, String emailAddress)
+		throws Exception {
+
+		_oktaPubsubPublisher.publish(
+			new Message(
+				null,
+				new JSONObject(
+				).put(
+					"action", "ADD"
+				).put(
+					"groupName", groupName
+				).put(
+					"login", emailAddress
+				).toString(),
+				OktaConstants.TOPIC_OKTA_USER_GROUP_UPDATE));
+	}
+
+	public void assignUserToApplication(String appId, String emailAddress)
+		throws Exception {
+
+		_oktaPubsubPublisher.publish(
+			new Message(
+				null,
+				new JSONObject(
+				).put(
+					"action", "ASSIGN"
+				).put(
+					"appId", appId
+				).put(
+					"emailAddress", emailAddress
+				).toString(),
+				OktaConstants.TOPIC_OKTA_APP_USER_UPDATE));
+	}
+
+	public OktaUser createContact(
+			String emailAddress, String firstName, String middleName,
+			String lastName)
+		throws Exception {
+
+		String response = _getOktaUser(emailAddress);
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		if (jsonObject.has("errorCode")) {
+			_oktaPubsubPublisher.publish(
+				new Message(
+					null,
+					new JSONObject(
+					).put(
+						"emailAddress", emailAddress
+					).put(
+						"firstName", firstName
+					).put(
+						"lastName", lastName
+					).put(
+						"uuid",
+						UUID.randomUUID(
+						).toString()
+					).toString(),
+					OktaConstants.TOPIC_OKTA_USER_CREATE));
+
+			return null;
+		}
+
+		return new OktaUser(jsonObject);
+	}
+
+	public OktaUser fetchContactByEmailAddress(String emailAddress)
+		throws Exception {
+
+		String response = _getOktaUser(emailAddress);
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		if (jsonObject.has("errorCode")) {
+			return null;
+		}
+
+		return new OktaUser(jsonObject);
+	}
+
+	public OktaUser fetchContactByUuid(String uuid) throws Exception {
+		ResponseEntity<String> responseEntity = _webClient.get(
+		).uri(
+			uriBuilder -> uriBuilder.path(
+				OktaConstants.URL_API_REST_USERS
+			).queryParam(
+				"search", "profile.uuid eq \"" + uuid + "\""
+			).build()
+		).retrieve(
+		).toEntity(
+			String.class
+		).block();
+
+		if ((responseEntity == null) ||
+			Validator.isNull(responseEntity.getBody())) {
+
+			return null;
+		}
+
+		JSONArray jsonArray = new JSONArray(responseEntity.getBody());
+
+		if (jsonArray.isEmpty()) {
+			return null;
+		}
+
+		return new OktaUser(jsonArray.getJSONObject(0));
+	}
+
+	public Integer fetchContactStatusByEmailAddress(String emailAddress)
+		throws Exception {
+
+		String response = _getOktaUser(emailAddress);
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		if (jsonObject.has("errorCode")) {
+			return null;
+		}
+
+		String status = jsonObject.optString("status");
+
+		if (_statusesDeactivated.contains(status)) {
+			return WorkflowConstants.STATUS_INACTIVE;
+		}
+
+		if (_statusesPending.contains(status)) {
+			return WorkflowConstants.STATUS_PENDING;
+		}
+
+		return WorkflowConstants.STATUS_APPROVED;
+	}
+
+	public List<OktaUser> getGroupContacts(String groupId) throws Exception {
+		return _getAllGroupMembers(groupId);
+	}
+
+	public void removeMembership(String groupName, String emailAddress)
+		throws Exception {
+
+		_oktaPubsubPublisher.publish(
+			new Message(
+				null,
+				new JSONObject(
+				).put(
+					"action", "REMOVE"
+				).put(
+					"groupName", groupName
+				).put(
+					"login", emailAddress
+				).toString(),
+				OktaConstants.TOPIC_OKTA_USER_GROUP_UPDATE));
+	}
+
+	public OktaUser syncContact(
+			String emailAddress, String firstName, String lastName, String uuid)
+		throws Exception {
+
+		String response = _getOktaUser(emailAddress);
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		if (jsonObject.has("errorCode")) {
+			_oktaPubsubPublisher.publish(
+				new Message(
+					null,
+					new JSONObject(
+					).put(
+						"emailAddress", emailAddress
+					).put(
+						"firstName", firstName
+					).put(
+						"lastName", lastName
+					).put(
+						"uuid", uuid
+					).toString(),
+					OktaConstants.TOPIC_OKTA_USER_CREATE));
+
+			return null;
+		}
+
+		return new OktaUser(jsonObject);
+	}
+
+	public void unassignUserFromApplication(String appId, String emailAddress)
+		throws Exception {
+
+		_oktaPubsubPublisher.publish(
+			new Message(
+				null,
+				new JSONObject(
+				).put(
+					"action", "UNASSIGN"
+				).put(
+					"appId", appId
+				).put(
+					"emailAddress", emailAddress
+				).toString(),
+				OktaConstants.TOPIC_OKTA_APP_USER_UPDATE));
+	}
+
+	@PostConstruct
+	protected void init() {
+		_webClient = _webClientBuilder.baseUrl(
+			"https://" + _host
+		).defaultHeader(
+			HttpHeaders.AUTHORIZATION, "SSWS " + _apiToken
+		).build();
+	}
+
+	private List<OktaUser> _getAllGroupMembers(String groupId) {
+		List<OktaUser> users = new ArrayList<>();
+
+		String url = StringBundler.concat(
+			OktaConstants.URL_API_REST_GROUPS, groupId,
+			OktaConstants.URL_API_REST_GROUPS_USERS, "?limit=200");
+
+		while (url != null) {
+			ResponseEntity<String> responseEntity = _webClient.get(
+			).uri(
+				url
+			).retrieve(
+			).toEntity(
+				String.class
+			).block();
+
+			if (responseEntity == null) {
+				break;
+			}
+
+			String body = responseEntity.getBody();
+
+			if (body == null) {
+				break;
+			}
+
+			JSONArray jsonArray = new JSONArray(body);
+
+			for (int i = 0; i < jsonArray.length(); i++) {
+				users.add(new OktaUser(jsonArray.getJSONObject(i)));
+			}
+
+			url = _getNextUrl(responseEntity.getHeaders());
+		}
+
+		return users;
+	}
+
+	private String _getNextUrl(HttpHeaders headers) {
+		List<String> links = headers.get("link");
+
+		if (links == null) {
+			return null;
+		}
+
+		for (String link : links) {
+			String[] parts = link.split(";");
+
+			if ((parts.length > 1) &&
+				Objects.equals(parts[1].trim(), "rel=\"next\"")) {
+
+				String urlPart = parts[0].trim();
+
+				return urlPart.substring(1, urlPart.length() - 1);
+			}
+		}
+
+		return null;
+	}
+
+	private String _getOktaUser(String login) {
+		try {
+			ResponseEntity<String> responseEntity = _webClient.get(
+			).uri(
+				OktaConstants.URL_API_REST_USERS + login
+			).retrieve(
+			).toEntity(
+				String.class
+			).block();
+
+			if ((responseEntity == null) ||
+				Validator.isNull(responseEntity.getBody())) {
+
+				return _RESPONSE_USER_NOT_FOUND;
+			}
+
+			return responseEntity.getBody();
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			String body = webClientResponseException.getResponseBodyAsString();
+
+			if (Validator.isNull(body)) {
+				return _RESPONSE_USER_NOT_FOUND;
+			}
+
+			return body;
+		}
+	}
+
+	private static final String _RESPONSE_USER_NOT_FOUND =
+		"{\"errorCode\": \"E0000095\"}";
+
+	private static final Set<String> _statusesDeactivated =
+		Collections.singleton("DEPROVISIONED");
+	private static final Set<String> _statusesPending = new HashSet<>(
+		Arrays.asList("PROVISIONED", "STAGED"));
+
+	@Value("${liferay.one.okta.api.token}")
+	private String _apiToken;
+
+	@Value("${liferay.one.okta.host}")
+	private String _host;
+
+	@Autowired
+	private OktaPubsubPublisher _oktaPubsubPublisher;
+
+	private WebClient _webClient;
+
+	@Autowired
+	private WebClient.Builder _webClientBuilder;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -37,6 +37,12 @@ liferay.one.jira.workspace.id=${LIFERAY_ONE_JIRA_WORKSPACE_ID}
 liferay.one.portal.url=${LIFERAY_ONE_PORTAL_URL}
 
 #
+# Email Address Validator
+#
+
+liferay.one.email.address.validator.liferay.domains=bp.liferay.com,connect.liferay.com,dev.liferay.com,gs.liferay.com,in.liferay.com,liferay.com,liferay.io,testray.io
+
+#
 # OAuth
 #
 
@@ -49,9 +55,17 @@ liferay.oauth.application.external.reference.codes=\
 liferay.oauth.urls.excludes=/ready
 
 #
+# Okta
+#
+
+liferay.one.okta.api.token=${LIFERAY_ONE_OKTA_API_TOKEN}
+liferay.one.okta.host=${LIFERAY_ONE_OKTA_HOST}
+
+#
 # Pub/Sub
 #
 
+liferay.one.okta.pubsub.publisher.project.id=${LIFERAY_ONE_OKTA_PUBSUB_PUBLISHER_PROJECT_ID}
 liferay.one.salesforce.object.pubsub.subscriber.enabled=${LIFERAY_ONE_SALESFORCE_OBJECT_PUBSUB_SUBSCRIBER_ENABLED}
 liferay.one.salesforce.object.pubsub.subscriber.project.id=${LIFERAY_ONE_SALESFORCE_OBJECT_PUBSUB_SUBSCRIBER_PROJECT_ID}
 liferay.one.salesforce.object.pubsub.subscriber.subscription=${LIFERAY_ONE_SALESFORCE_OBJECT_PUBSUB_SUBSCRIBER_SUBSCRIPTION}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89433

## What is being fixed

The Okta identity-management layer lives in the legacy OSGi osb-provisioning module (osb-provisioning-identity-management), which is being retired along with the rest of the OSGi/Koroneiki stack. The Spring Boot client extension that replaces it had no equivalent: no way to create or update customer contacts in Okta, sync group membership, or block reserved Liferay email domains. This story ports that layer so the new app has the identity services the Account Management UI and the downstream provisioning webhooks depend on.

## How it is being fixed

OktaIdentityService (a Spring `@Component`) takes over the Okta operations from the legacy ContactIdentityProvider. Mutations publish to the existing GCP Pub/Sub topics (okta-user-update, okta-user-group-update, okta-app-user-update, okta-user-create), keeping the payloads compatible with the Cloud Functions that consume them; reads call the Okta REST API over WebClient with the status mapping preserved. The Koroneiki ContactWebService coupling is dropped — reads return a lightweight OktaUser built from the Okta response, and the entitlement-to-group reconciliation moves to the LPD-89439 Object-action webhooks. EmailAddressValidatorService ports the reserved-Liferay-domain check (domains read from application properties), and the Okta host and API token are read via `@Value`.
