### PR TITLE
LPD-91432 Inline LicenseEntry table as a static lookup service

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductVersion.java
@@ -9,6 +9,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,6 +30,11 @@ public class ProductVersion {
 	public static final String DXP_VERSION_7_3 = "7.3";
 
 	public static final String DXP_VERSION_7_4 = "7.4";
+
+	public static final String[] DXP_VERSIONS = {
+		DXP_VERSION_7_0, DXP_VERSION_7_1, DXP_VERSION_7_2, DXP_VERSION_7_3,
+		DXP_VERSION_7_4
+	};
 
 	public static final String PORTAL_VERSION_5_1_3 = "5.1";
 
@@ -67,6 +74,21 @@ public class ProductVersion {
 
 	public static final String PORTAL_VERSION_6_2_10 = "6.2 EE";
 
+	public static final String[] PORTAL_VERSIONS = {
+		PORTAL_VERSION_5_1_3, PORTAL_VERSION_5_1_4, PORTAL_VERSION_5_1_5,
+		PORTAL_VERSION_5_1_6, PORTAL_VERSION_5_1_7, PORTAL_VERSION_5_1_8,
+		PORTAL_VERSION_5_2_4, PORTAL_VERSION_5_2_5, PORTAL_VERSION_5_2_6,
+		PORTAL_VERSION_5_2_7, PORTAL_VERSION_5_2_8, PORTAL_VERSION_5_2_9,
+		PORTAL_VERSION_6_0_10, PORTAL_VERSION_6_0_11, PORTAL_VERSION_6_0_12,
+		PORTAL_VERSION_6_1_10, PORTAL_VERSION_6_1_20, PORTAL_VERSION_6_1_30,
+		PORTAL_VERSION_6_2_10
+	};
+
+	public static final String[] SUPPORTED_PORTAL_VERSIONS = {
+		PORTAL_VERSION_6_1_10, PORTAL_VERSION_6_1_20, PORTAL_VERSION_6_1_30,
+		PORTAL_VERSION_6_2_10
+	};
+
 	public static String extractQuarterlyRelease(String version) {
 		if (Validator.isNotNull(version)) {
 			Matcher matcher = getQuarterlyReleaseMatcher(version);
@@ -79,10 +101,50 @@ public class ProductVersion {
 		return StringPool.BLANK;
 	}
 
+	// Ported from osb-provisioning ProductVersion.getOrder (LPD-89423).
+
+	public static int getOrder(
+		String productName, String productVersion, boolean supportedVersions) {
+
+		if (_isDXP(productName)) {
+			return _orderedDXPVersions.indexOf(productVersion);
+		}
+		else if (_isPortal(productName)) {
+			if (supportedVersions) {
+				return _orderedSupportedPortalVersions.indexOf(productVersion);
+			}
+
+			return _orderedPortalVersions.indexOf(productVersion);
+		}
+
+		return -1;
+	}
+
 	public static Matcher getQuarterlyReleaseMatcher(String version) {
 		return _quarterlyReleaseVersionPattern.matcher(version);
 	}
 
+	private static boolean _isDXP(String productName) {
+		return productName.startsWith("DXP");
+	}
+
+	private static boolean _isPortal(String productName) {
+		if ((productName.contains("Portal") &&
+			 !productName.contains("Early Access Program")) ||
+			productName.startsWith("TCAT Portal")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final List<String> _orderedDXPVersions = Arrays.asList(
+		DXP_VERSIONS);
+	private static final List<String> _orderedPortalVersions = Arrays.asList(
+		PORTAL_VERSIONS);
+	private static final List<String> _orderedSupportedPortalVersions =
+		Arrays.asList(SUPPORTED_PORTAL_VERSIONS);
 	private static final Pattern _quarterlyReleaseVersionPattern =
 		Pattern.compile("(\\d{4})\\.Q([1-4])", Pattern.CASE_INSENSITIVE);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/LicenseEntry.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/LicenseEntry.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.model;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseEntry {
+
+	public LicenseEntry(
+		String productKey, String name, String type, String versionMin,
+		String versionMax) {
+
+		_productKey = productKey;
+		_name = name;
+		_type = type;
+		_versionMin = versionMin;
+		_versionMax = versionMax;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getProductKey() {
+		return _productKey;
+	}
+
+	public String getType() {
+		return _type;
+	}
+
+	public String getVersionMax() {
+		return _versionMax;
+	}
+
+	public String getVersionMin() {
+		return _versionMin;
+	}
+
+	private final String _name;
+	private final String _productKey;
+	private final String _type;
+	private final String _versionMax;
+	private final String _versionMin;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseEntryService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseEntryService.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.constants.ProductVersion;
+import com.liferay.one.model.LicenseEntry;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class LicenseEntryService {
+
+	public List<LicenseEntry> getLicenseEntries(String productKey) {
+		List<LicenseEntry> licenseEntries = new ArrayList<>();
+
+		for (LicenseEntry licenseEntry : _licenseEntries) {
+			if (Objects.equals(licenseEntry.getProductKey(), productKey)) {
+				licenseEntries.add(licenseEntry);
+			}
+		}
+
+		return licenseEntries;
+	}
+
+	public List<LicenseEntry> getLicenseEntriesByNameVersion(
+		String name, String version, boolean supportedVersions) {
+
+		List<LicenseEntry> licenseEntries = new ArrayList<>();
+
+		for (LicenseEntry licenseEntry : _licenseEntries) {
+			String licenseEntryName = licenseEntry.getName();
+
+			if ((licenseEntryName != null) && licenseEntryName.contains(name)) {
+				licenseEntries.add(licenseEntry);
+			}
+		}
+
+		return _filterByVersion(
+			licenseEntries, name, version, supportedVersions);
+	}
+
+	public List<LicenseEntry> getLicenseEntriesByType(String type) {
+		List<LicenseEntry> licenseEntries = new ArrayList<>();
+
+		for (LicenseEntry licenseEntry : _licenseEntries) {
+			if (Objects.equals(licenseEntry.getType(), type)) {
+				licenseEntries.add(licenseEntry);
+			}
+		}
+
+		return licenseEntries;
+	}
+
+	public List<LicenseEntry> getLicenseEntriesByVersion(
+		String productKey, String version, boolean supportedVersions) {
+
+		// TODO Resolve product name via CommerceProductService and apply
+		// _filterByVersion (getOrder needs the name, not the productKey).
+
+		return getLicenseEntries(productKey);
+	}
+
+	public LicenseEntry getLicenseEntry(String productKey, String type) {
+		for (LicenseEntry licenseEntry : _licenseEntries) {
+			if (Objects.equals(licenseEntry.getProductKey(), productKey) &&
+				Objects.equals(licenseEntry.getType(), type)) {
+
+				return licenseEntry;
+			}
+		}
+
+		return null;
+	}
+
+	// Ported from LicenseEntryLocalServiceImpl.filterByVersion (LPD-89423).
+
+	private List<LicenseEntry> _filterByVersion(
+		List<LicenseEntry> licenseEntries, String name, String version,
+		boolean supportedVersions) {
+
+		List<LicenseEntry> curLicenseEntries = new ArrayList<>();
+
+		for (LicenseEntry licenseEntry : licenseEntries) {
+			int productVersionMinOrder = ProductVersion.getOrder(
+				name, licenseEntry.getVersionMin(), supportedVersions);
+			int productVersionMaxOrder = ProductVersion.getOrder(
+				name, licenseEntry.getVersionMax(), supportedVersions);
+
+			if ((Validator.isNull(licenseEntry.getVersionMin()) ||
+				 (productVersionMinOrder <= ProductVersion.getOrder(
+					 name, version, supportedVersions))) &&
+				(Validator.isNull(licenseEntry.getVersionMax()) ||
+				 (ProductVersion.getOrder(name, version, supportedVersions) <=
+					 productVersionMaxOrder))) {
+
+				curLicenseEntries.add(licenseEntry);
+			}
+		}
+
+		return curLicenseEntries;
+	}
+
+	// TODO Inline production Provisioning_LicenseEntry rows (LPD-89423).
+
+	private final List<LicenseEntry> _licenseEntries = Arrays.asList();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91432

## What is being fixed

Scoped slice of the LicenseKey port (LPD-89423): the legacy
osb-provisioning LicenseEntryLocalService has no equivalent in the One
Liferay Spring Boot client extension, and the workspace ProductVersion
class lacks the version-ordering logic the lookup's range filter needs.

## How it is being fixed

Inlines the LicenseEntry table as code. Adds a LicenseEntry model and a
LicenseEntryService @Component reproducing the five legacy read methods
over an in-memory list, and ports ProductVersion.getOrder and the
filterByVersion version-range logic. The legacy add/update methods are
intentionally dropped since the table is now static code.

This PR is intentionally limited to the LicenseEntry lookup. Follow-up in
the same area: inline the production Provisioning_LicenseEntry rows,
resolve the product name in getLicenseEntriesByVersion via
CommerceProductService, and add a version-range equivalence test. The
remaining LicenseKey port work (LicenseKeyLocalServiceImpl, validators,
model listener, Free Tier, detached-license mapping) stays under
LPD-89423.
