### PR TITLE
LPD-89029 Fix Spring Boot redeploy and add a .env.local override

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/skills/one-deploy/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-deploy/SKILL.md
@@ -20,7 +20,7 @@ Stop and report if either step fails. Do not deploy a failing build.
 
 ## 2. Resolve Target
 
-Valid targets: `liferay-one-custom-element`, `liferay-one-global-css`, `liferay-one-instance-settings`, `liferay-one-site-initializer`, `all`.
+Valid targets: `liferay-one-custom-element`, `liferay-one-etc-spring-boot`, `liferay-one-global-css`, `liferay-one-instance-settings`, `liferay-one-site-initializer`, `all`.
 
 Check `git diff --name-only` and pick every touched `client-extensions/liferay-one-*` directory. When multiple are touched, confirm with the user before proceeding.
 
@@ -36,10 +36,13 @@ Check `git diff --name-only` and pick every touched `client-extensions/liferay-o
     -Ddeploy.docker.container.id=$(docker ps --filter "name=^liferay$" --quiet)
 ```
 
-Deploy also rebuilds the `liferay-one-etc-spring-boot:latest` image and recreates the `liferay-one-etc-spring-boot` container, so the deployed `liferay-one-etc-spring-boot` client extension picks up code changes. `buildDockerImage` regenerates `build/local.env` as it builds; if a previous `gradlew clean` removed it, regenerate it before recreating the container:
+`deploy` only builds each client extension's zip and copies it into the running `liferay` container. The other client extensions hot-deploy from there, but `liferay-one-etc-spring-boot` runs as its own Compose service off the `liferay-one-etc-spring-boot:latest` image — `deploy` does not rebuild that image or restart its container, so the running app keeps serving old code. When `liferay-one-etc-spring-boot` is among the deployed targets, rebuild the image and recreate the container so the running app picks up the new code:
 
 ```bash
-[ -f client-extensions/liferay-one-etc-spring-boot/build/local.env ] || ./gradlew :client-extensions:liferay-one-etc-spring-boot:buildDockerImage --rerun-tasks
+./gradlew :client-extensions:liferay-one-etc-spring-boot:buildDockerImage
+docker compose up --detach --force-recreate liferay-one-etc-spring-boot
 ```
+
+`buildDockerImage` also regenerates `build/local.env` — every `${...}` placeholder in `application-default.properties` becomes `VAR=unused` — so the same step repairs a `build/local.env` that a prior `gradlew clean` removed. To supply real integration values or toggle a feature (for example, enabling the Salesforce object subscriber) so they survive rebuilds, set those overrides in the gitignored root `.env.local` (read after `build/local.env`, so it wins) rather than editing `build/local.env` directly, then recreate the container.
 
 Report: what was deployed, Gradle result, and log evidence of pickup.

--- a/workspaces/liferay-one-workspace/.gitignore
+++ b/workspaces/liferay-one-workspace/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+/.env.local
 /.idea
 /bundles
 /client-extensions/liferay-one-etc-spring-boot/liferay-release-tool-ee

--- a/workspaces/liferay-one-workspace/docker-compose.yaml
+++ b/workspaces/liferay-one-workspace/docker-compose.yaml
@@ -58,6 +58,8 @@ services:
                 condition: service_healthy
         env_file:
             -   ./client-extensions/liferay-one-etc-spring-boot/build/local.env
+            -   path: ./.env.local
+                required: false
         environment:
             LIFERAY_JAR_RUNNER_JAVA_OPTS: --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED
             LIFERAY_ROUTES_CLIENT_EXTENSION: /opt/liferay/routes/default/liferay-one-etc-spring-boot


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89029

## What is being fixed

Two local-development pain points for the `liferay-one-etc-spring-boot` client extension. First, the `/one-deploy` skill claimed `gradlew deploy` rebuilds the Spring Boot image and recreates its container, but `deploy` only copies the client-extension zip into the portal container — the Spring Boot app runs as its own Compose service, so following the skill left the running app on stale code. Second, there was no clean way to set local environment values: `buildDockerImage` regenerates `build/local.env` as `KEY=unused` on every build, wiping any hand-edited values.

## How it is being fixed

The `/one-deploy` skill now documents the real redeploy path — after `gradlew deploy`, run `buildDockerImage` and `docker compose up --force-recreate liferay-one-etc-spring-boot` — and adds `liferay-one-etc-spring-boot` to the valid deploy targets. The Spring Boot Compose service now also reads an optional, gitignored root `.env.local` as a second `env_file`, listed after the generated `build/local.env` so its values win. Developers set their overrides there once; they survive every rebuild (env vars outrank Spring config files, so the values reach the app) and are never committed.
