### PR TITLE
LPD-95435 Point the checkout at the renamed calculate-tax endpoint

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PaymentMethod/PaymentMethod.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PaymentMethod/PaymentMethod.tsx
@@ -46,7 +46,7 @@ const PaymentMethod = () => {
 					shippingAddress: payment.billingAddress,
 				});
 
-				await CommerceOrders.taxCalculate(cartId).catch(console.error);
+				await CommerceOrders.calculateTax(cartId).catch(console.error);
 
 				productPurchaseCart.setCart(
 					await HeadlessCommerceDeliveryCart.getCart(cartId)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/CommerceOrders.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/CommerceOrders.ts
@@ -6,8 +6,8 @@
 import {OneSpringBootOAuth2} from './OAuth2Client';
 
 class CommerceOrdersOAuth2 extends OneSpringBootOAuth2 {
-	async taxCalculate(orderId: number | string) {
-		await this.post(`/${orderId}/tax-calculate`);
+	async calculateTax(orderId: number | string) {
+		await this.post(`/${orderId}/calculate-tax`);
 	}
 }
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95435

## What is being fixed

The tax calculation endpoint was renamed from `tax-calculate` to `calculate-tax` on the `liferay-one-etc-spring-boot` client extension (LPD-95435), but the custom element was not updated and still posted to `/commerce-orders/{id}/tax-calculate`. The checkout swallows that call with `.catch(console.error)`, so the request failed silently with a 404 and the order kept its pre-tax total — paid checkout applied no VAT.

## How it is being fixed

Updates the frontend to target the renamed endpoint: `CommerceOrders` now exposes `calculateTax` posting to `/commerce-orders/{id}/calculate-tax`, and the Payment Method step calls it. This realigns the custom element with the backend so VAT is applied again during checkout.

**pr-check: PASS** — tested on `41ab4e840ee64b81543c0b1b1e3cb19f026e289c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "41ab4e840ee64b81543c0b1b1e3cb19f026e289c"} -->
