### PR TITLE
LPD-94251 Grant order write scope for tax calculation

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
@@ -7,7 +7,7 @@ liferay-one-etc-spring-boot-oahs:
     scopes:
         -   Liferay.Headless.Admin.User.everything.read
         -   Liferay.Headless.Commerce.Admin.Catalog.everything
-        -   Liferay.Headless.Commerce.Admin.Order.everything.read
+        -   Liferay.Headless.Commerce.Admin.Order.everything
         -   Liferay.Headless.Commerce.Admin.Pricing.everything
         -   Liferay.Notification.REST.everything
         -   c_entitlement.everything


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94251

## What is being fixed

The paid app checkout flow calculates VAT and writes it back to the commerce order and its order items through the tax calculation endpoint, but the Spring Boot client extension only held read access to the Headless Commerce Admin Order API. As a result, the order patch performed during tax calculation fails with an insufficient scope error.

## How it is being fixed

Broaden the OAuth scope granted to the liferay-one-etc-spring-boot headless server application from Liferay.Headless.Commerce.Admin.Order.everything.read to Liferay.Headless.Commerce.Admin.Order.everything, giving the tax calculation endpoint the write access it needs to persist the tax amount on the order.
