### PR TITLE
LPD-94251 Open the activation tab for paid app purchases

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PurchaseCompleted/PurchaseCompleted.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PurchaseCompleted/PurchaseCompleted.tsx
@@ -10,6 +10,7 @@ import EmptyState from '~/components/EmptyState/EmptyState';
 import i18n from '~/i18n';
 import ProductPurchaseHeaderCards from '~/pages/ProductPurchase/components/ProductPurchaseHeaderCards/ProductPurchaseHeaderCards';
 import {Liferay} from '~/services/liferay/liferay';
+import {getProductPriceModel} from '~/utils/productUtils';
 import {getSiteURL} from '~/utils/siteUtils';
 
 import type {Account} from '~/types/accounts';
@@ -29,6 +30,10 @@ const PurchaseCompleted = ({product}: PurchaseCompletedProps) => {
 	const orderId = urlSearchParams.get('orderId') ?? '';
 
 	const account = (state as {account?: Account} | null)?.account;
+
+	const {isPaidApp} = getProductPriceModel(product);
+
+	const installTab = isPaidApp ? 'activation' : 'download';
 
 	if (!orderId) {
 		return (
@@ -87,7 +92,7 @@ const PurchaseCompleted = ({product}: PurchaseCompletedProps) => {
 					className="ml-3"
 					onClick={() =>
 						Liferay.Util.navigate(
-							`${getSiteURL()}/my-account#/project/applications/${orderId}?tab=download`
+							`${getSiteURL()}/my-account#/project/applications/${orderId}?tab=${installTab}`
 						)
 					}
 				>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94251

## What is being fixed

On the Purchase Completed page, the "Continue to Install" button always sent the user to the download tab of the project applications dashboard. For paid applications, the checkout acceptance criteria (LPD-94239) require landing on the Activation tab so the user can activate the purchased license. The download tab remains the correct destination for free applications, which is the behavior introduced with the free app checkout flow.

## How it is being fixed

Derive the destination tab from the product price model in PurchaseCompleted.tsx: paid apps navigate to ?tab=activation and free apps keep ?tab=download, instead of a single hardcoded tab.
