### PR TITLE
LRSD-12388 Add Liferay DXP Academic products to Customer Portal

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
@@ -113,5 +113,10 @@
 		"externalReferenceCode": "ERC-023",
 		"name": "AI Hub Test Account",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "ERC-024",
+		"name": "Liferay DXP Academic Test Account",
+		"type": "business"
 	}
 ]

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
@@ -307,6 +307,17 @@
 			"name": "Liferay Cloud",
 			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-023",
 			"tabOrder": 2
+		},
+		{
+			"accountKey": "ERC-024",
+			"activationProductName": "DXP",
+			"activationStatus": "Active",
+			"externalReferenceCode": "ERC-024_self-hosted",
+			"hasActivation": true,
+			"menuOrder": 1,
+			"name": "Self-Hosted",
+			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-024",
+			"tabOrder": 2
 		}
 	],
 	"objectDefinitionName": "AccountSubscriptionGroup"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -587,6 +587,30 @@
 			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-023",
 			"startDate": "2023-01-01T00:00:00Z",
 			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-024",
+			"accountSubscriptionGroupERC": "ERC-024_self-hosted",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-024_self-hosted_academic-production",
+			"instanceSize": "1",
+			"name": "Academic Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-024",
+			"accountSubscriptionGroupERC": "ERC-024_self-hosted",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-024_self-hosted_academic-non-production",
+			"instanceSize": "1",
+			"name": "Academic Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
 		}
 	],
 	"objectDefinitionName": "AccountSubscription"

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
@@ -370,6 +370,19 @@
 			"slaCurrent": "Platinum Subscription",
 			"slaCurrentEndDate": "2026-12-31 00:00:00.0",
 			"slaCurrentStartDate": "2023-01-01 00:00:00.0"
+		},
+		{
+			"accountKey": "ERC-024",
+			"code": "TESTACCOUNT24",
+			"dxpVersion": "7.4",
+			"externalReferenceCode": "ERC-024",
+			"liferayContactEmailAddress": "customer-service@liferay.com",
+			"liferayContactName": "Liferay Support",
+			"maxRequestors": -1,
+			"name": "Liferay DXP Academic Test Account",
+			"partner": false,
+			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-024",
+			"region": "United States"
 		}
 	],
 	"objectDefinitionName": "KoroneikiAccount"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRSD-12388

## What Is Being Fixed

Sales is launching the Liferay DXP Academic MVP for SM Universities customers migrating from the Community Edition. The three Liferay DXP Academic products (Bundle, Production, and Non-Production - Self-Support) must be represented in the Customer Portal so that an academic customer's self-hosted DXP subscriptions render correctly.

## How It Is Being Fixed

Adds a test account to the customer site initializer that exercises the academic products: an account entry, its Koroneiki account profile (self-support, so no SLA), a Self-Hosted / DXP subscription group, and the Academic Production and Academic Non-Production subscriptions. This mirrors the AI Hub work (LRSD-12365) but uses the Self-Hosted / DXP structure, since these are self-hosted instance-based DXP products rather than cloud products. The product registration itself (Koroneiki Products, 1:1 with the Salesforce products) and the entitlement behavior are runtime configuration captured in the ticket's Release Notes, not code.

## Why Are There No Tests?

The change is site-initializer seed data (JSON) with no testable logic — it adds a demo/test account that mirrors the existing accounts. This matches the merged AI Hub change (LRSD-12365), which added the analogous seed data without tests.

## PR Check

**pr-check: PASS** — tested on `567e203`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "567e203aea86b1949d1b3c82130eca9f4300948f"} -->
