### PR TITLE
LPD-90604 Add 7-day SaaS Trial provisioning backend

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	implementation group: "com.google.cloud", name: "google-cloud-storage", version: "2.27.0"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
+	implementation group: "com.liferay", name: "com.liferay.headless.portal.instances.client", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.notification.rest.client", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
@@ -15,6 +15,7 @@ liferay-one-etc-spring-boot-oahs:
         -   c_licensekey.everything.read
         -   c_subscriptionentry.everything
         -   c_ticketattachment.everything
+        -   c_trialextensionrequest.everything
     type: oAuthApplicationHeadlessServer
 liferay-one-etc-spring-boot-oaua:
     .serviceAddress: localhost:58081

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -1,0 +1,668 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
+import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.pagination.Page;
+import com.liferay.headless.portal.instances.client.resource.v1_0.PortalInstanceResource;
+import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.ConsoleService;
+import com.liferay.one.service.NotificationQueueEntryService;
+import com.liferay.one.service.NotificationTemplateService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.net.URI;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Keven Leone
+ */
+@RequestMapping("/trial")
+@RestController
+public class TrialRestController extends BaseRestController {
+
+	@DeleteMapping("{orderId}")
+	public void deleteTrial(@PathVariable long orderId) throws Exception {
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(order);
+
+		_consoleService.deleteProject(
+			trialProvisioningContextJSONObject.getString("projectId"));
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		_deletePortalInstance(
+			orderId, trialProvisioningContextJSONObject,
+			customFields.get("trial-virtual-host"));
+	}
+
+	@GetMapping("availability")
+	public String getAvailability(
+			@RequestParam(defaultValue = "SOLUTIONS7", required = false) String
+				orderTypeExternalReferenceCode)
+		throws Exception {
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			_getTrialProvisioningContextJSONObject(
+				_getOrder(orderTypeExternalReferenceCode)));
+
+		return new JSONObject(
+		).put(
+			"active", _trialMaxInstances > portalInstancesPage.getTotalCount()
+		).put(
+			"available",
+			_trialMaxInstances - portalInstancesPage.getTotalCount()
+		).put(
+			"max", _trialMaxInstances
+		).toString();
+	}
+
+	@GetMapping("domain-availability/{projectPrefix}")
+	public ResponseEntity<Void> getDomainAvailability(
+			@PathVariable String projectPrefix,
+			@RequestParam(defaultValue = "SSA_SAAS", required = false) String
+				orderTypeExternalReferenceCode)
+		throws Exception {
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(
+				_getOrder(orderTypeExternalReferenceCode));
+
+		String virtualHost =
+			projectPrefix + "." +
+				trialProvisioningContextJSONObject.getString("domain");
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			trialProvisioningContextJSONObject);
+
+		for (PortalInstance portalInstance : portalInstancesPage.getItems()) {
+			if (Objects.equals(virtualHost, portalInstance.getVirtualHost())) {
+				return ResponseEntity.status(
+					HttpStatus.CONFLICT
+				).build();
+			}
+		}
+
+		return ResponseEntity.status(
+			HttpStatus.OK
+		).build();
+	}
+
+	@PostMapping("expire/{orderId}")
+	public void postExpire(@PathVariable long orderId) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Expired trial " + orderId);
+		}
+
+		_commerceOrderService.completeOrder(
+			orderId, CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
+
+		deleteTrial(orderId);
+	}
+
+	@PostMapping("extend/{id}")
+	public void postExtend(@PathVariable long id) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Extend trial " + id);
+		}
+
+		JSONObject trialExtensionRequestJSONObject = new JSONObject(
+			get(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					"liferay-one-etc-spring-boot-oahs"),
+				UriComponentsBuilder.fromPath(
+					"/o/c/trialextensionrequests/" + id
+				).build(
+				).toUri()));
+
+		JSONObject dueStatusJSONObject =
+			trialExtensionRequestJSONObject.getJSONObject("dueStatus");
+
+		if (!(Objects.equals(
+				dueStatusJSONObject.getString("key"), "Approved") ||
+			  Objects.equals(
+				  dueStatusJSONObject.getString("key"), "AutoApproved"))) {
+
+			return;
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(
+			trialExtensionRequestJSONObject.getLong(
+				"r_orderToTrialExtensionRequest_commerceOrderId"));
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		if (Objects.equals(dueStatusJSONObject.getString("key"), "Pending")) {
+			patch(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					"liferay-one-etc-spring-boot-oahs"),
+				new JSONObject(
+				).put(
+					"dueStatus", "Approved"
+				).toString(),
+				UriComponentsBuilder.fromPath(
+					"/o/c/trialextensionrequests/" + id
+				).build(
+				).toUri());
+		}
+
+		customFields.put(
+			"trial-end-date",
+			ZonedDateTime.parse(
+				customFields.get("trial-end-date")
+			).plusDays(
+				trialExtensionRequestJSONObject.getInt("duration")
+			).format(
+				DateTimeFormatter.ISO_INSTANT
+			));
+
+		_commerceOrderService.updateOrder(
+			customFields, order.getId(), order.getOrderStatus());
+	}
+
+	@PostMapping("notify-end/{orderId}")
+	public void postNotifyEnd(@PathVariable long orderId) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Notify end " + orderId);
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		UserAccount userAccount =
+			_userAccountService.getUserAccountByEmailAddress(
+				order.getCreatorEmailAddress());
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		_postNotification(
+			order.getCreatorEmailAddress(), "TRIAL-EXPIRING-ORDER",
+			HashMapBuilder.put(
+				"TRIAL_CREATOR_FIRST_NAME", userAccount.getGivenName()
+			).put(
+				"TRIAL_END_DATE",
+				ZonedDateTime.parse(
+					customFields.get("trial-end-date")
+				).format(
+					DateTimeFormatter.ofPattern("MMMM d, yyyy")
+				)
+			).build());
+
+		customFields.put(
+			"trial-notify-end-date",
+			ZonedDateTime.now(
+			).format(
+				DateTimeFormatter.ISO_INSTANT
+			));
+
+		_commerceOrderService.updateOrder(
+			customFields, orderId, order.getOrderStatus());
+	}
+
+	@PostMapping("provisioning")
+	public void postProvisioning(
+			@AuthenticationPrincipal Jwt jwt, @RequestBody String json)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(json);
+
+		postProvisioningOrder(jwt, jsonObject.getLong("classPK"));
+	}
+
+	@PostMapping("provisioning/{orderId}")
+	public void postProvisioningOrder(
+			@AuthenticationPrincipal Jwt jwt, @PathVariable long orderId)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Provisioning order " + orderId);
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(order);
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			trialProvisioningContextJSONObject);
+
+		if (portalInstancesPage.getTotalCount() == _trialMaxInstances) {
+			_log.error("Order is on hold");
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_ON_HOLD);
+
+			return;
+		}
+
+		if (order.getOrderStatus() ==
+				CommerceOrderConstants.ORDER_STATUS_OPEN) {
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_PENDING);
+		}
+
+		_commerceOrderService.updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		UserAccount userAccount =
+			_userAccountService.getUserAccountByEmailAddress(
+				order.getCreatorEmailAddress());
+
+		JSONObject trialSettingsJSONObject = _getTrialSettingsJSONObject(order);
+
+		boolean sendNotificationEmail = trialSettingsJSONObject.optBoolean(
+			"sendNotificationEmail", true);
+
+		if (sendNotificationEmail) {
+			_postNotification(
+				order.getCreatorEmailAddress(), "TRIAL-PROCESSING-ORDER",
+				HashMapBuilder.put(
+					"COMMERCEORDER_AUTHOR_FIRST_NAME",
+					userAccount.getGivenName()
+				).put(
+					"COMMERCEORDER_ID", String.valueOf(orderId)
+				).build());
+		}
+
+		PortalInstance portalInstance = null;
+
+		try {
+			portalInstance = _postPortalInstance(
+				jwt, order.getCreatorEmailAddress(),
+				trialSettingsJSONObject.optString(
+					"projectId", String.valueOf(orderId)),
+				trialSettingsJSONObject.optString("siteInitializerKey", null),
+				trialProvisioningContextJSONObject);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to provision portal instance for order " + orderId,
+				exception);
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_CANCELLED);
+
+			throw exception;
+		}
+
+		try {
+			_consoleService.setUpProject(
+				trialProvisioningContextJSONObject.getString("cluster"),
+				trialProvisioningContextJSONObject.getBoolean("deployable"),
+				trialProvisioningContextJSONObject.getString("dxpProjectUid"),
+				portalInstance.getVirtualHost(),
+				_toStringArray(
+					trialSettingsJSONObject.optJSONArray(
+						"consoleInviteEmailAddresses", new JSONArray())),
+				orderId,
+				trialProvisioningContextJSONObject.getString("projectId"));
+
+			_commerceOrderService.updateOrder(
+				HashMapBuilder.put(
+					"trial-end-date",
+					ZonedDateTime.now(
+					).plusDays(
+						trialSettingsJSONObject.optInt("duration", 7)
+					).format(
+						DateTimeFormatter.ISO_INSTANT
+					)
+				).put(
+					"trial-start-date",
+					ZonedDateTime.now(
+					).format(
+						DateTimeFormatter.ISO_INSTANT
+					)
+				).put(
+					"trial-virtual-host", portalInstance.getVirtualHost()
+				).build(),
+				orderId, CommerceOrderConstants.ORDER_STATUS_IN_PROGRESS);
+
+			if (sendNotificationEmail) {
+				_postNotification(
+					order.getCreatorEmailAddress(), "TRIAL-COMPLETED-ORDER",
+					HashMapBuilder.put(
+						"EMAIL", order.getCreatorEmailAddress()
+					).put(
+						"NAME", userAccount.getGivenName()
+					).put(
+						"URL", portalInstance.getVirtualHost()
+					).build());
+			}
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_rollBackTrial(
+				webClientResponseException.getResponseBodyAsString(), orderId,
+				portalInstance, trialProvisioningContextJSONObject);
+		}
+		catch (Exception exception) {
+			_rollBackTrial(
+				exception.getMessage(), orderId, portalInstance,
+				trialProvisioningContextJSONObject);
+		}
+	}
+
+	private void _deletePortalInstance(
+			long orderId, JSONObject trialProvisioningContextJSONObject,
+			String virtualHost)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		Page<PortalInstance> portalInstancesPage =
+			portalInstanceResource.getPortalInstancesPage(true);
+
+		for (PortalInstance portalInstance : portalInstancesPage.getItems()) {
+			if (Objects.equals(portalInstance.getVirtualHost(), virtualHost)) {
+				portalInstanceResource.deletePortalInstance(
+					portalInstance.getPortalInstanceId());
+
+				break;
+			}
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Portal instance deleted for order " + orderId);
+		}
+	}
+
+	private Order _getOrder(String orderTypeExternalReferenceCode) {
+		return new Order() {
+			{
+				setCustomFields(() -> new HashMap<>());
+				setOrderTypeExternalReferenceCode(
+					() -> orderTypeExternalReferenceCode);
+			}
+		};
+	}
+
+	private PortalInstanceResource _getPortalInstanceResource(
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		return PortalInstanceResource.builder(
+		).endpoint(
+			new URI(
+				trialProvisioningContextJSONObject.getString("trialHomePageURL")
+			).toURL()
+		).header(
+			HttpHeaders.AUTHORIZATION,
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				trialProvisioningContextJSONObject.getString(
+					"trialAuthorizationERC"))
+		).build();
+	}
+
+	private Page<PortalInstance> _getPortalInstancesPage(
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		return portalInstanceResource.getPortalInstancesPage(true);
+	}
+
+	private JSONObject _getTrialProvisioningContextJSONObject(Order order) {
+		JSONObject trialSettingsJSONObject = _getTrialSettingsJSONObject(order);
+
+		String projectId = trialSettingsJSONObject.optString(
+			"projectId", String.valueOf(order.getId()));
+
+		if (Objects.equals(
+				order.getOrderTypeExternalReferenceCode(), "SOLUTIONS7")) {
+
+			return new JSONObject(
+			).put(
+				"cluster", _consoleTrialCluster
+			).put(
+				"deployable", true
+			).put(
+				"domain", _trialDXPDomain
+			).put(
+				"dxpProjectUid", _consoleTrialProjectUid
+			).put(
+				"projectId", _consoleTrialProjectPrefix + "-ext" + projectId
+			).put(
+				"trialAuthorizationERC", "external-trial"
+			).put(
+				"trialHomePageURL", _externalTrialHomePageURL
+			);
+		}
+
+		if (Objects.equals(
+				order.getOrderTypeExternalReferenceCode(), "SSA_SAAS")) {
+
+			return new JSONObject(
+			).put(
+				"cluster", _consoleSSACluster
+			).put(
+				"deployable", false
+			).put(
+				"domain", _trialSSADXPDomain
+			).put(
+				"dxpProjectUid", _consoleSSAProjectUid
+			).put(
+				"projectId", _consoleSSAProjectPrefix + "-ext" + projectId
+			).put(
+				"trialAuthorizationERC", "external-ssa"
+			).put(
+				"trialHomePageURL", _externalSSAHomePageURL
+			);
+		}
+
+		throw new IllegalArgumentException(
+			"Unsupported order type: " +
+				order.getOrderTypeExternalReferenceCode());
+	}
+
+	private JSONObject _getTrialSettingsJSONObject(Order order) {
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		return new JSONObject(
+			customFields.getOrDefault("trial-settings", "{}"));
+	}
+
+	private void _postNotification(
+			String toEmailAddress, String externalReferenceCode,
+			Map<String, String> placeholders)
+		throws Exception {
+
+		JSONObject processedTemplateJSONObject =
+			_notificationTemplateService.getAndProcessTemplateJSONObject(
+				externalReferenceCode, "en_US", placeholders);
+
+		_notificationQueueEntryService.addNotificationQueueEntry(
+			"customer-service@liferay.com", "Liferay Support", toEmailAddress,
+			processedTemplateJSONObject.getString("subject"),
+			processedTemplateJSONObject.getString("body"));
+	}
+
+	private PortalInstance _postPortalInstance(
+			Jwt jwt, String emailAddress, String projectId,
+			String siteInitializerKey,
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		PortalInstance portalInstance = new PortalInstance();
+
+		Admin admin = new Admin();
+
+		admin.setEmailAddress(() -> emailAddress);
+		admin.setFamilyName(
+			() -> jwt.getClaim(
+				"username"
+			).toString());
+		admin.setGivenName(
+			() -> jwt.getClaim(
+				"username"
+			).toString());
+
+		portalInstance.setAdmin(() -> admin);
+
+		portalInstance.setDomain(() -> "lxc.app");
+		portalInstance.setSiteInitializerKey(() -> siteInitializerKey);
+
+		String domain =
+			projectId + "." +
+				trialProvisioningContextJSONObject.getString("domain");
+
+		portalInstance.setPortalInstanceId(() -> domain);
+		portalInstance.setVirtualHost(() -> domain);
+
+		portalInstance = portalInstanceResource.postPortalInstance(
+			portalInstance);
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Created portal instance " + portalInstance);
+		}
+
+		return portalInstance;
+	}
+
+	private void _rollBackTrial(
+			String errorMessage, long orderId, PortalInstance portalInstance,
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		_log.error(
+			StringBundler.concat(
+				"Unable to set up project for order ", orderId, ": \n",
+				errorMessage));
+
+		_deletePortalInstance(
+			orderId, trialProvisioningContextJSONObject,
+			portalInstance.getVirtualHost());
+
+		_commerceOrderService.updateOrder(
+			HashMapBuilder.put(
+				"trial-error", errorMessage
+			).put(
+				"trial-error-date",
+				ZonedDateTime.now(
+				).format(
+					DateTimeFormatter.ISO_INSTANT
+				)
+			).put(
+				"trial-virtual-host", portalInstance.getVirtualHost()
+			).build(),
+			orderId, CommerceOrderConstants.ORDER_STATUS_CANCELLED);
+	}
+
+	private String[] _toStringArray(JSONArray jsonArray) {
+		List<String> list = new ArrayList<>();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			list.add(jsonArray.getString(i));
+		}
+
+		return list.toArray(new String[0]);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		TrialRestController.class);
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private ConsoleService _consoleService;
+
+	@Value("${liferay.one.console.ssa.cluster}")
+	private String _consoleSSACluster;
+
+	@Value("${liferay.one.console.ssa.project.prefix}")
+	private String _consoleSSAProjectPrefix;
+
+	@Value("${liferay.one.console.ssa.project.uid}")
+	private String _consoleSSAProjectUid;
+
+	@Value("${liferay.one.console.cluster}")
+	private String _consoleTrialCluster;
+
+	@Value("${liferay.one.console.project.prefix}")
+	private String _consoleTrialProjectPrefix;
+
+	@Value("${liferay.one.console.project.uid}")
+	private String _consoleTrialProjectUid;
+
+	@Value("${external.ssa.oauth2.headless.server.home.page.url:}")
+	private String _externalSSAHomePageURL;
+
+	@Value("${external.trial.oauth2.headless.server.home.page.url:}")
+	private String _externalTrialHomePageURL;
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	@Autowired
+	private NotificationQueueEntryService _notificationQueueEntryService;
+
+	@Autowired
+	private NotificationTemplateService _notificationTemplateService;
+
+	@Value("${liferay.one.trial.dxp.domain}")
+	private String _trialDXPDomain;
+
+	@Value("${liferay.one.trial.max.instances}")
+	private int _trialMaxInstances;
+
+	@Value("${liferay.one.trial.ssa.dxp.domain}")
+	private String _trialSSADXPDomain;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Keven Leone
+ */
+public class CommerceOrderConstants {
+
+	public static final int ORDER_PAYMENT_STATUS_NOT_REQUIRED = 23;
+
+	public static final int ORDER_STATUS_CANCELLED = 8;
+
+	public static final int ORDER_STATUS_COMPLETED = 0;
+
+	public static final int ORDER_STATUS_IN_PROGRESS = 6;
+
+	public static final int ORDER_STATUS_ON_HOLD = 20;
+
+	public static final int ORDER_STATUS_OPEN = 2;
+
+	public static final int ORDER_STATUS_PENDING = 1;
+
+	public static final int ORDER_STATUS_PROCESSING = 10;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -14,6 +14,7 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.headless.commerce.admin.order.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
+import com.liferay.one.constants.CommerceOrderConstants;
 
 import java.math.BigDecimal;
 
@@ -84,6 +85,27 @@ public class CommerceOrderService extends OneBaseService {
 		}
 	}
 
+	public void completeOrder(long orderId, int paymentStatus)
+		throws Exception {
+
+		completeOrder(null, orderId, paymentStatus);
+	}
+
+	public void completeOrder(
+			Map<String, ?> customFields, long orderId, int paymentStatus)
+		throws Exception {
+
+		updateOrder(
+			customFields, orderId, CommerceOrderConstants.ORDER_STATUS_PENDING);
+
+		updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_COMPLETED,
+			paymentStatus);
+	}
+
 	public Order fetchCommerceOrder(long commerceOrderId) throws Exception {
 		OrderResource orderResource = _buildOrderResource();
 
@@ -99,6 +121,40 @@ public class CommerceOrderService extends OneBaseService {
 
 			throw problemException;
 		}
+	}
+
+	public void updateOrder(
+			Map<String, ?> customFields, long orderId, int orderStatus)
+		throws Exception {
+
+		OrderResource orderResource = _buildOrderResource();
+
+		orderResource.patchOrder(
+			orderId,
+			new Order() {
+				{
+					setCustomFields(() -> customFields);
+					setOrderStatus(() -> orderStatus);
+				}
+			});
+	}
+
+	public void updateOrder(
+			Map<String, ?> customFields, long orderId, int orderStatus,
+			int paymentStatus)
+		throws Exception {
+
+		OrderResource orderResource = _buildOrderResource();
+
+		orderResource.patchOrder(
+			orderId,
+			new Order() {
+				{
+					setCustomFields(() -> customFields);
+					setOrderStatus(() -> orderStatus);
+					setPaymentStatus(() -> paymentStatus);
+				}
+			});
 	}
 
 	private CurrencyResource _buildCurrencyResource() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ConsoleService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ConsoleService.java
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+
+import java.time.Duration;
+
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import reactor.util.retry.Retry;
+
+/**
+ * @author Keven Leone
+ */
+@Component
+public class ConsoleService extends BaseService {
+
+	public void deleteProject(String projectId) throws Exception {
+		delete(
+			getAuthorization(), "",
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/projects/" + projectId
+			).build(
+			).toUri());
+	}
+
+	public JSONObject deployApp(
+			String emailAddress, String orderId, String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+			post(
+				getAuthorization(),
+				new JSONObject(
+				).put(
+					"orderId", orderId
+				).put(
+					"userEmail", emailAddress
+				).toString(),
+				UriComponentsBuilder.fromUriString(
+					_consoleAuthURL
+				).path(
+					"/admin/projects/" + projectId + "/apps"
+				).build(
+				).toUri()));
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Deployed app for project " + projectId);
+		}
+
+		return jsonObject;
+	}
+
+	public String getAuthorization() throws Exception {
+		if ((_authorization != null) &&
+			(System.currentTimeMillis() < (_tokenExpirationMillis - 30000))) {
+
+			return _authorization;
+		}
+
+		String json = post(
+			null,
+			new JSONObject(
+			).put(
+				"email", _consoleAuthEmailAddress
+			).put(
+				"password", _consoleAuthPassword
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/login"
+			).build(
+			).toUri());
+
+		if (json == null) {
+			throw new Exception("Unable to get authorization");
+		}
+
+		String token = new JSONObject(
+			json
+		).getString(
+			"token"
+		);
+
+		_authorization = "Bearer " + token;
+
+		_tokenExpirationMillis = System.currentTimeMillis() + 900000;
+
+		return _authorization;
+	}
+
+	public void setUpProject(
+			String cluster, boolean deployable, String dxpProjectUid,
+			String dxpVirtualInstanceId, String[] emailAddresses, long orderId,
+			String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = _postProject(cluster, projectId);
+
+		for (String emailAddress : emailAddresses) {
+			_inviteProject(emailAddress, projectId);
+		}
+
+		_linkDXPWithProject(
+			dxpProjectUid, dxpVirtualInstanceId, jsonObject.getString("id"));
+
+		if (deployable) {
+			deployApp(
+				_consoleAuthEmailAddress, String.valueOf(orderId), projectId);
+		}
+	}
+
+	@Override
+	protected ExchangeFilterFunction getWebClientExchangeFilterFunction() {
+		return (clientRequest, exchangeFunction) -> exchangeFunction.exchange(
+			clientRequest
+		).retryWhen(
+			Retry.fixedDelay(
+				3, Duration.ofSeconds(5)
+			).doBeforeRetry(
+				retrySignal -> {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Retrying ", clientRequest.url(),
+								retrySignal.totalRetries() + 1));
+					}
+				}
+			)
+		);
+	}
+
+	private void _inviteProject(String emailAddress, String projectId)
+		throws Exception {
+
+		if (Objects.equals(emailAddress, _consoleAuthEmailAddress)) {
+			return;
+		}
+
+		post(
+			getAuthorization(),
+			new JSONObject(
+			).put(
+				"email", emailAddress
+			).put(
+				"role", "admin"
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/projects/" + projectId + "/invite"
+			).build(
+			).toUri());
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Invited ", emailAddress, " to project ", projectId));
+		}
+	}
+
+	private void _linkDXPWithProject(
+			String dxpProjectUid, String dxpVirtualInstanceId,
+			String extensionProjectUid)
+		throws Exception {
+
+		post(
+			getAuthorization(),
+			new JSONObject(
+			).put(
+				"dxpProjectUid", dxpProjectUid
+			).put(
+				"dxpVirtualInstanceId", dxpVirtualInstanceId
+			).put(
+				"extensionProjectUid", extensionProjectUid
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/lxc-extension-links"
+			).build(
+			).toUri());
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Linked Liferay virtual instance ", dxpVirtualInstanceId,
+					" with project ", extensionProjectUid));
+		}
+	}
+
+	private JSONObject _postProject(String cluster, String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+			post(
+				getAuthorization(),
+				new JSONObject(
+				).put(
+					"cluster", cluster
+				).put(
+					"environment", true
+				).put(
+					"metadata",
+					new JSONObject(
+					).put(
+						"skipCloudProviderIamConfiguration", true
+					)
+				).put(
+					"projectId", projectId
+				).toString(),
+				UriComponentsBuilder.fromUriString(
+					_consoleAuthURL
+				).path(
+					"/projects"
+				).build(
+				).toUri()));
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Created project " + jsonObject);
+		}
+
+		return jsonObject;
+	}
+
+	private static final Log _log = LogFactory.getLog(ConsoleService.class);
+
+	private String _authorization;
+
+	@Value("${liferay.one.console.auth.email.address}")
+	private String _consoleAuthEmailAddress;
+
+	@Value("${liferay.one.console.auth.password}")
+	private String _consoleAuthPassword;
+
+	@Value("${liferay.one.console.auth.url}")
+	private String _consoleAuthURL;
+
+	private long _tokenExpirationMillis;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -40,4 +40,17 @@ public class UserAccountService extends OneBaseService {
 		return userAccountResource.getUserAccount(userId);
 	}
 
+	public UserAccount getUserAccountByEmailAddress(String emailAddress)
+		throws Exception {
+
+		UserAccountResource userAccountResource = UserAccountResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+
+		return userAccountResource.getUserAccountByEmailAddress(emailAddress);
+	}
+
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -2,6 +2,15 @@
 # Application
 #
 
+liferay.one.console.auth.email.address=${LIFERAY_ONE_CONSOLE_AUTH_EMAIL_ADDRESS}
+liferay.one.console.auth.password=${LIFERAY_ONE_CONSOLE_AUTH_PASSWORD}
+liferay.one.console.auth.url=${LIFERAY_ONE_CONSOLE_AUTH_URL}
+liferay.one.console.cluster=${LIFERAY_ONE_CONSOLE_CLUSTER}
+liferay.one.console.project.prefix=${LIFERAY_ONE_CONSOLE_PROJECT_PREFIX}
+liferay.one.console.project.uid=${LIFERAY_ONE_CONSOLE_PROJECT_UID}
+liferay.one.console.ssa.cluster=${LIFERAY_ONE_CONSOLE_SSA_CLUSTER}
+liferay.one.console.ssa.project.prefix=${LIFERAY_ONE_CONSOLE_SSA_PROJECT_PREFIX}
+liferay.one.console.ssa.project.uid=${LIFERAY_ONE_CONSOLE_SSA_PROJECT_UID}
 liferay.one.gcs.bucket.name=${LIFERAY_ONE_GCS_BUCKET_NAME}
 liferay.one.gcs.service.account.key=${LIFERAY_ONE_GCS_SERVICE_ACCOUNT_KEY}
 liferay.one.jira.api.email.address=${LIFERAY_ONE_JIRA_API_EMAIL_ADDRESS}
@@ -16,6 +25,9 @@ liferay.one.jira.support.hc.project=${LIFERAY_ONE_JIRA_SUPPORT_HC_PROJECT}
 liferay.one.jira.url=${LIFERAY_ONE_JIRA_URL}
 liferay.one.jira.workspace.id=${LIFERAY_ONE_JIRA_WORKSPACE_ID}
 liferay.one.portal.url=${LIFERAY_ONE_PORTAL_URL}
+liferay.one.trial.dxp.domain=${LIFERAY_ONE_TRIAL_DXP_DOMAIN}
+liferay.one.trial.max.instances=${LIFERAY_ONE_TRIAL_MAX_INSTANCES:50}
+liferay.one.trial.ssa.dxp.domain=${LIFERAY_ONE_TRIAL_SSA_DXP_DOMAIN}
 
 #
 # Email Address Validator
@@ -30,6 +42,8 @@ liferay.one.email.address.validator.liferay.domains=bp.liferay.com,connect.lifer
 liferay-one-etc-spring-boot-oahs.oauth2.headless.server.client.secret=${LIFERAY_ONE_ETC_SPRING_BOOT_OAHS_CLIENT_SECRET:myfancypassword}
 
 liferay.oauth.application.external.reference.codes=\
+    external-ssa,\
+    external-trial,\
     liferay-one-etc-spring-boot-oahs,\
     liferay-one-etc-spring-boot-oaua
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90604

## What is being fixed

The 7-day SaaS Trial (`SOLUTIONS7`) provisioning backend lived only in the old Marketplace Spring Boot client extension. The trials frontend has already been migrated to liferay-one and calls `liferay-one-etc-spring-boot` at `POST /trial/provisioning/{orderId}`, but that client extension had no `TrialRestController`, so the call would 404.

## How it is being fixed

Lifts-and-shifts the trial provisioning backend into `liferay-one-etc-spring-boot`, aligned with the workspace's existing generated commerce-order-client approach. Adds `TrialRestController` covering the full trial lifecycle (provisioning, availability, domain availability, expire, extend, notify end, delete) for both the `SOLUTIONS7` and `SSA_SAAS` order types, and the `ConsoleService` Liferay Cloud integration. Trial order reads and writes (`updateOrder`, `completeOrder`) are added to the existing `CommerceOrderService` through the headless commerce order client, and a by-email lookup is added to the existing `UserAccountService`. Notification emails are sent through the existing `NotificationTemplateService` by external reference code; the trial templates themselves are migrated by a separate ticket. The expiry cron is delivered in a separate, stacked pull request.
