### PR TITLE
LPD-96601 Isolate JSM transport from other Jira operations

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -7,6 +7,7 @@ package com.liferay.one;
 
 import com.liferay.one.jira.service.JiraService;
 import com.liferay.one.permission.BusinessEventPermission;
+import com.liferay.one.service.AccountService;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.apache.commons.logging.Log;
@@ -40,7 +41,7 @@ public class AccountsRestController extends OneBaseRestController {
 				externalReferenceCode, ActionKeys.VIEW, jwt);
 
 			return new ResponseEntity<>(
-				_jiraService.getAccountObjectKey(externalReferenceCode),
+				_accountService.getAccountObjectKey(externalReferenceCode),
 				HttpStatus.OK);
 		}
 		catch (Exception exception) {
@@ -55,6 +56,9 @@ public class AccountsRestController extends OneBaseRestController {
 
 	private static final Log _log = LogFactory.getLog(
 		AccountsRestController.class);
+
+	@Autowired
+	private AccountService _accountService;
 
 	@Autowired
 	private BusinessEventPermission _businessEventPermission;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/BusinessEventsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/BusinessEventsRestController.java
@@ -1,0 +1,229 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.converter.BusinessEventConverter;
+import com.liferay.one.jira.model.AssetObject;
+import com.liferay.one.jira.model.AssetObjectFieldOption;
+import com.liferay.one.jira.model.BusinessEvent;
+import com.liferay.one.jira.model.BusinessEventVersion;
+import com.liferay.one.jira.service.BusinessEventService;
+import com.liferay.one.permission.BusinessEventPermission;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints for Business Events JSM Object operations
+ *
+ * @author Jenny Chen
+ * @author Drew Brokke
+ */
+@RequestMapping("/jira")
+@RestController
+public class BusinessEventsRestController extends OneBaseRestController {
+
+	@DeleteMapping("/accounts/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> deleteAccountsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id)
+		throws Exception {
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.UPDATE, jwt);
+
+		_businessEventService.deleteBusinessEvent(id);
+
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+
+	@GetMapping("/accounts/{externalReferenceCode}/business-events")
+	public ResponseEntity<String> getAccountsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.VIEW, jwt);
+
+		return _getResponseEntity(
+			_businessEventService.getBusinessEvents(externalReferenceCode),
+			BusinessEvent::toJSONObject);
+	}
+
+	@GetMapping("/accounts/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> getAccountsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id)
+		throws Exception {
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.VIEW, jwt);
+
+		BusinessEvent businessEvent = _businessEventService.getBusinessEvent(
+			id);
+
+		return new ResponseEntity<>(
+			businessEvent.toJSONObject(
+			).toString(),
+			HttpStatus.OK);
+	}
+
+	@GetMapping(
+		"/accounts/{externalReferenceCode}/business-events/{id}/versions"
+	)
+	public ResponseEntity<String> getAccountsBusinessEventsVersions(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id)
+		throws Exception {
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.VIEW, jwt);
+
+		return _getResponseEntity(
+			_businessEventService.getBusinessEventVersions(id),
+			BusinessEventVersion::toJSONObject);
+	}
+
+	@GetMapping("/business-events/fields/{fieldName}/options")
+	public ResponseEntity<String> getBusinessEventsFieldsOptions(
+			@PathVariable("fieldName") String fieldName)
+		throws Exception {
+
+		return _getResponseEntity(
+			_businessEventService.getFieldOptions(fieldName),
+			AssetObjectFieldOption::toJSONObject);
+	}
+
+	@GetMapping("/product-versions")
+	public ResponseEntity<String> getProductVersions() throws Exception {
+		return _getResponseEntity(
+			_businessEventService.getProductVersions(),
+			AssetObject::toJSONObject);
+	}
+
+	@PostMapping("/accounts/{externalReferenceCode}/business-events")
+	public ResponseEntity<String> postAccountsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@RequestBody String json)
+		throws Exception {
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.UPDATE, jwt);
+
+		UserAccount userAccount = _getMyUserAccount(jwt);
+
+		_businessEventService.createBusinessEvent(
+			_businessEventConverter.toBusinessEvent(
+				externalReferenceCode, json, userAccount.getEmailAddress()));
+
+		return _getResponseEntity(
+			_businessEventService.getBusinessEvents(externalReferenceCode),
+			BusinessEvent::toJSONObject);
+	}
+
+	@PutMapping("/accounts/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> putAccountsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id, @RequestBody String json)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("PUT business event " + id);
+		}
+
+		_businessEventPermission.check(
+			externalReferenceCode, ActionKeys.UPDATE, jwt);
+
+		UserAccount userAccount = _getMyUserAccount(jwt);
+
+		BusinessEvent businessEvent = _businessEventConverter.toBusinessEvent(
+			externalReferenceCode, json, userAccount.getEmailAddress());
+
+		businessEvent = _businessEventService.updateBusinessEvent(
+			businessEvent, id);
+
+		return new ResponseEntity<>(
+			businessEvent.toJSONObject(
+			).toString(),
+			HttpStatus.OK);
+	}
+
+	private UserAccount _getMyUserAccount(Jwt jwt) throws Exception {
+		try {
+			return _userAccountService.getMyUserAccount(jwt);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get user account", exception);
+			}
+
+			throw new PrincipalException();
+		}
+	}
+
+	private <T> ResponseEntity<String> _getResponseEntity(
+		List<T> items, Function<T, JSONObject> transformFunction) {
+
+		JSONObject responseJSONObject = new JSONObject();
+
+		JSONArray itemsJSONArray = new JSONArray();
+
+		for (T item : items) {
+			itemsJSONArray.put(transformFunction.apply(item));
+		}
+
+		responseJSONObject.put("items", itemsJSONArray);
+
+		return new ResponseEntity<>(
+			responseJSONObject.toString(), HttpStatus.OK);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		BusinessEventsRestController.class);
+
+	@Autowired
+	private BusinessEventConverter _businessEventConverter;
+
+	@Autowired
+	private BusinessEventPermission _businessEventPermission;
+
+	@Autowired
+	private BusinessEventService _businessEventService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
@@ -5,26 +5,14 @@
 
 package com.liferay.one;
 
-import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
-import com.liferay.one.jira.constants.BusinessEventConstants;
-import com.liferay.one.jira.converter.BusinessEventConverter;
-import com.liferay.one.jira.model.AssetObject;
-import com.liferay.one.jira.model.AssetObjectFieldOption;
-import com.liferay.one.jira.model.BusinessEvent;
-import com.liferay.one.jira.model.BusinessEventVersion;
 import com.liferay.one.jira.model.SupportIssue;
 import com.liferay.one.jira.service.JiraService;
 import com.liferay.one.permission.BusinessEventPermission;
-import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.util.List;
 import java.util.function.Function;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -34,12 +22,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,70 +34,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/jira")
 @RestController
 public class JiraRestController extends OneBaseRestController {
-
-	@DeleteMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> deleteAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
-
-		_jiraService.deleteBusinessEvent(id);
-
-		return new ResponseEntity<>(HttpStatus.OK);
-	}
-
-	@GetMapping("/accounts/{externalReferenceCode}/business-events")
-	public ResponseEntity<String> getAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		return _getResponseEntity(
-			_jiraService.getBusinessEvents(externalReferenceCode),
-			BusinessEvent::toJSONObject);
-	}
-
-	@GetMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> getAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		BusinessEvent businessEvent = _jiraService.getBusinessEvent(id);
-
-		return new ResponseEntity<>(
-			businessEvent.toJSONObject(
-			).toString(),
-			HttpStatus.OK);
-	}
-
-	@GetMapping(
-		"/accounts/{externalReferenceCode}/business-events/{id}/versions"
-	)
-	public ResponseEntity<String> getAccountsBusinessEventsVersions(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		return _getResponseEntity(
-			_jiraService.getBusinessEventVersions(id),
-			BusinessEventVersion::toJSONObject);
-	}
 
 	@GetMapping("/accounts/{externalReferenceCode}/tickets")
 	public ResponseEntity<String> getAccountsTickets(
@@ -129,87 +49,6 @@ public class JiraRestController extends OneBaseRestController {
 		return _getResponseEntity(
 			_jiraService.getSupportIssues(externalReferenceCode, ticketIds),
 			SupportIssue::toJSONObject);
-	}
-
-	@GetMapping("/business-events/fields/{fieldName}/options")
-	public ResponseEntity<String> getBusinessEventsFieldsOptions(
-			@PathVariable("fieldName") String fieldName)
-		throws Exception {
-
-		return _getResponseEntity(
-			_jiraService.getAssetObjectFieldOptions(
-				fieldName, _businessEventConverter.getObjectTypeId()),
-			AssetObjectFieldOption::toJSONObject);
-	}
-
-	@GetMapping("/product-versions")
-	public ResponseEntity<String> getProductVersions() throws Exception {
-		return _getResponseEntity(
-			_jiraService.getAssetObjects(
-				BusinessEventConstants.OBJECT_SCHEMA_BUSINESS_EVENTS,
-				BusinessEventConstants.OBJECT_TYPE_PRODUCT_VERSION),
-			AssetObject::toJSONObject);
-	}
-
-	@PostMapping("/accounts/{externalReferenceCode}/business-events")
-	public ResponseEntity<String> postAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@RequestBody String json)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
-
-		UserAccount userAccount = _getMyUserAccount(jwt);
-
-		_jiraService.createBusinessEvent(
-			_businessEventConverter.toBusinessEvent(
-				externalReferenceCode, json, userAccount.getEmailAddress()));
-
-		return _getResponseEntity(
-			_jiraService.getBusinessEvents(externalReferenceCode),
-			BusinessEvent::toJSONObject);
-	}
-
-	@PutMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> putAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id, @RequestBody String json)
-		throws Exception {
-
-		if (_log.isInfoEnabled()) {
-			_log.info("PUT business event " + id);
-		}
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
-
-		UserAccount userAccount = _getMyUserAccount(jwt);
-
-		BusinessEvent businessEvent = _businessEventConverter.toBusinessEvent(
-			externalReferenceCode, json, userAccount.getEmailAddress());
-
-		businessEvent = _jiraService.updateBusinessEvent(businessEvent, id);
-
-		return new ResponseEntity<>(
-			businessEvent.toJSONObject(
-			).toString(),
-			HttpStatus.OK);
-	}
-
-	private UserAccount _getMyUserAccount(Jwt jwt) throws Exception {
-		try {
-			return _userAccountService.getMyUserAccount(jwt);
-		}
-		catch (Exception exception) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to get user account", exception);
-			}
-
-			throw new PrincipalException();
-		}
 	}
 
 	private <T> ResponseEntity<String> _getResponseEntity(
@@ -228,11 +67,6 @@ public class JiraRestController extends OneBaseRestController {
 		return new ResponseEntity<>(
 			responseJSONObject.toString(), HttpStatus.OK);
 	}
-
-	private static final Log _log = LogFactory.getLog(JiraRestController.class);
-
-	@Autowired
-	private BusinessEventConverter _businessEventConverter;
 
 	@Autowired
 	private BusinessEventPermission _businessEventPermission;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
@@ -74,7 +74,4 @@ public class JiraRestController extends OneBaseRestController {
 	@Autowired
 	private JiraService _jiraService;
 
-	@Autowired
-	private UserAccountService _userAccountService;
-
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetObject.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetObject.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.client;
+
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetObject {
+
+	public JiraAssetObject(
+		JSONObject jsonObject, Map<String, String> attributeNameToIdsMap) {
+
+		_jsonObject = jsonObject;
+
+		_attributeIds = attributeNameToIdsMap;
+	}
+
+	public JiraAssetObject(Map<String, String> attributeNameToIdsMap) {
+		this(new JSONObject(), attributeNameToIdsMap);
+	}
+
+	/**
+	 * Attempts to get the named attribute's display value. Falls back to the
+	 * result of {@link #getAttributeValue(String)} if no display value is
+	 * found.
+	 */
+	public String getAttributeDisplayValue(String attributeName) {
+		JSONObject attributeValueJSONObject = _getAttributeValueJSONObject(
+			attributeName);
+
+		return attributeValueJSONObject.optString(
+			"displayValue", _getValue(attributeValueJSONObject));
+	}
+
+	/**
+	 * Gets the named attribute's value. If not found, will attempt to
+	 * return the id of the referenced object.
+	 */
+	public String getAttributeValue(String attributeName) {
+		String attributeId = _getAttributeId(attributeName);
+
+		if (_values.containsKey(attributeId)) {
+			return String.valueOf(_values.get(attributeId));
+		}
+
+		return _getValue(_getAttributeValueJSONObject(attributeName));
+	}
+
+	/**
+	 * The object's own id (top-level {@code id}), not an attribute value.
+	 */
+	public String getObjectId() {
+		return _jsonObject.optString("id");
+	}
+
+	/**
+	 * The object's own id (top-level {@code id}), not an attribute value.
+	 */
+	public String getObjectKey() {
+		return _jsonObject.optString("objectKey");
+	}
+
+	/**
+	 * The object's own id (top-level {@code id}), not an attribute value.
+	 */
+	public String getObjectName() {
+		return _jsonObject.optString("name");
+	}
+
+	public void setAttributeValue(String attributeName, Object value) {
+		String attributeId = _getAttributeId(attributeName);
+
+		if ((attributeId == null) || (value == null)) {
+			return;
+		}
+
+		_values.put(attributeId, value);
+	}
+
+	/**
+	 * Serializes this object into the JSM's {@code attributes} JSON shape.
+	 * This method is used by the {@link JiraAssetsClient}.
+	 */
+	public JSONArray toAttributesJSONArray() {
+		JSONArray attributesJSONArray = new JSONArray();
+
+		for (Map.Entry<String, Object> entry : _values.entrySet()) {
+			attributesJSONArray.put(
+				new JSONObject(
+				).put(
+					"objectAttributeValues",
+					new JSONArray(
+					).put(
+						new JSONObject(
+						).put(
+							"value", entry.getValue()
+						)
+					)
+				).put(
+					"objectTypeAttributeId", entry.getKey()
+				));
+		}
+
+		return attributesJSONArray;
+	}
+
+	private String _getAttributeId(String attributeName) {
+		String attributeId = _attributeIds.get(attributeName);
+
+		if (Validator.isNull(attributeId)) {
+			_log.error(
+				"No attribute id is mapped for attribute name \"" +
+					attributeName +
+						"\"; a constant likely no longer matches the schema");
+
+			return null;
+		}
+
+		return attributeId;
+	}
+
+	private JSONObject _getAttributeValueJSONObject(String attributeName) {
+		String attributeId = _getAttributeId(attributeName);
+
+		if (attributeId == null) {
+			return new JSONObject();
+		}
+
+		JSONArray attributesJSONArray = _jsonObject.optJSONArray("attributes");
+
+		if (attributesJSONArray == null) {
+			return new JSONObject();
+		}
+
+		for (int i = 0; i < attributesJSONArray.length(); i++) {
+			JSONObject attributeJSONObject = attributesJSONArray.getJSONObject(
+				i);
+
+			if (!attributeId.equals(
+					attributeJSONObject.optString("objectTypeAttributeId"))) {
+
+				continue;
+			}
+
+			JSONArray objectAttributeValuesJSONArray =
+				attributeJSONObject.optJSONArray("objectAttributeValues");
+
+			if ((objectAttributeValuesJSONArray == null) ||
+				objectAttributeValuesJSONArray.isEmpty()) {
+
+				break;
+			}
+
+			return objectAttributeValuesJSONArray.getJSONObject(0);
+		}
+
+		return new JSONObject();
+	}
+
+	private String _getValue(JSONObject attributeValueJSONObject) {
+		String value = attributeValueJSONObject.optString("value");
+
+		if (Validator.isNull(value)) {
+			JSONObject referencedObjectJSONObject =
+				attributeValueJSONObject.optJSONObject("referencedObject");
+
+			if (referencedObjectJSONObject != null) {
+				value = referencedObjectJSONObject.optString("id");
+			}
+		}
+
+		return value;
+	}
+
+	private static final Log _log = LogFactory.getLog(JiraAssetObject.class);
+
+	private final Map<String, String> _attributeIds;
+	private final JSONObject _jsonObject;
+	private final Map<String, Object> _values = new LinkedHashMap<>();
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetObject.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetObject.java
@@ -68,14 +68,15 @@ public class JiraAssetObject {
 	}
 
 	/**
-	 * The object's own id (top-level {@code id}), not an attribute value.
+	 * The object's own key (top-level {@code objectKey}), not an attribute
+	 * value.
 	 */
 	public String getObjectKey() {
 		return _jsonObject.optString("objectKey");
 	}
 
 	/**
-	 * The object's own id (top-level {@code id}), not an attribute value.
+	 * The object's own name (top-level {@code name}), not an attribute value.
 	 */
 	public String getObjectName() {
 		return _jsonObject.optString("name");

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetsClient.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetsClient.java
@@ -1,0 +1,247 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.client;
+
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.net.URI;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class JiraAssetsClient extends BaseService {
+
+	public void createObject(
+		String objectTypeId, JiraAssetObject jiraAssetObject) {
+
+		String response = post(
+			new JSONObject(
+			).put(
+				"attributes", jiraAssetObject.toAttributesJSONArray()
+			).put(
+				"objectTypeId", objectTypeId
+			).toString(),
+			_headers(), _objectURI("create"));
+
+		new JSONObject(response);
+	}
+
+	public void deleteObject(String objectId) {
+		delete(_getAuthorization(), StringPool.BLANK, _objectURI(objectId));
+	}
+
+	public JSONObject getObject(String objectId) {
+		return new JSONObject(get(_getAuthorization(), _objectURI(objectId)));
+	}
+
+	public JSONArray getObjectSchemas() {
+		JSONArray itemsJSONArray = new JSONArray();
+
+		boolean last = false;
+		int startAt = 0;
+
+		while (!last) {
+			JSONObject resultsJSONObject = _getObjectSchemasPageJSONObject(
+				startAt);
+
+			JSONArray valuesJSONArray = resultsJSONObject.optJSONArray(
+				"values");
+
+			if ((valuesJSONArray == null) || valuesJSONArray.isEmpty()) {
+				break;
+			}
+
+			itemsJSONArray.putAll(valuesJSONArray);
+
+			last = resultsJSONObject.optBoolean("isLast");
+
+			startAt += _MAX_RESULTS;
+		}
+
+		return itemsJSONArray;
+	}
+
+	public JSONArray getObjectTypeAttributes(String objectTypeId) {
+		return new JSONArray(
+			get(
+				_getAuthorization(),
+				_v1URI(
+					StringBundler.concat(
+						"objecttype/", objectTypeId, "/attributes"))));
+	}
+
+	public JSONArray getObjectTypes(String schemaId) {
+		return new JSONArray(
+			get(
+				_getAuthorization(),
+				_v1URI(
+					StringBundler.concat(
+						"objectschema/", schemaId, "/objecttypes"))));
+	}
+
+	public JSONArray searchObjects(String aql) {
+		JSONArray itemsJSONArray = new JSONArray();
+
+		boolean last = false;
+		int startAt = 0;
+
+		while (!last) {
+			JSONObject resultsJSONObject = _searchObjectsPage(aql, startAt);
+
+			JSONArray valuesJSONArray = resultsJSONObject.optJSONArray(
+				"values");
+
+			if ((valuesJSONArray == null) || valuesJSONArray.isEmpty()) {
+				break;
+			}
+
+			itemsJSONArray.putAll(valuesJSONArray);
+
+			last = resultsJSONObject.optBoolean("last");
+
+			startAt += _MAX_RESULTS;
+		}
+
+		return itemsJSONArray;
+	}
+
+	public <T> List<T> searchObjects(
+		String aql, Function<JSONObject, T> transformFunction) {
+
+		ArrayList<T> results = new ArrayList<>();
+
+		JSONArray jsonArray = searchObjects(aql);
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			results.add(transformFunction.apply(jsonArray.getJSONObject(0)));
+		}
+
+		return results;
+	}
+
+	public void updateObject(String objectId, JiraAssetObject jiraAssetObject) {
+		String response = put(
+			new JSONObject(
+			).put(
+				"attributes", jiraAssetObject.toAttributesJSONArray()
+			).toString(),
+			_headers(), _objectURI(objectId));
+
+		new JSONObject(response);
+	}
+
+	private String _getAuthorization() {
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String credentials =
+			_jiraAPIEmailAddress + StringPool.COLON + _jiraAPIToken;
+
+		String encodedString = encoder.encodeToString(
+			credentials.getBytes(StandardCharsets.UTF_8));
+
+		return "Basic " + encodedString;
+	}
+
+	private JSONObject _getObjectSchemasPageJSONObject(int startAt) {
+		String response = get(
+			_getAuthorization(),
+			UriComponentsBuilder.fromUri(
+				_v1URI("objectschema/list")
+			).queryParam(
+				"maxResults", _MAX_RESULTS
+			).queryParam(
+				"startAt", startAt
+			).build(
+			).toUri());
+
+		if (Validator.isNull(response)) {
+			return new JSONObject();
+		}
+
+		return new JSONObject(response);
+	}
+
+	private Map<String, String> _headers() {
+		return HashMapBuilder.put(
+			HttpHeaders.AUTHORIZATION, _getAuthorization()
+		).put(
+			HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
+		).build();
+	}
+
+	private URI _objectURI(String suffix) {
+		return _v1URI("object/" + suffix);
+	}
+
+	private JSONObject _searchObjectsPage(String aql, int startAt) {
+		String response = post(
+			new JSONObject(
+			).put(
+				"qlQuery", aql
+			).toString(),
+			_headers(),
+			UriComponentsBuilder.fromUri(
+				_v1URI("object/aql")
+			).queryParam(
+				"maxResults", _MAX_RESULTS
+			).queryParam(
+				"startAt", startAt
+			).build(
+			).toUri());
+
+		if (Validator.isNull(response)) {
+			return new JSONObject();
+		}
+
+		return new JSONObject(response);
+	}
+
+	private URI _v1URI(String path) {
+		return UriComponentsBuilder.fromUriString(
+			StringBundler.concat(
+				_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/", _jiraWorkspaceId,
+				"/v1/", path)
+		).build(
+		).toUri();
+	}
+
+	private static final String _JIRA_CLOUD_API_URL =
+		"https://api.atlassian.com";
+
+	private static final int _MAX_RESULTS = 100;
+
+	@Value("${liferay.one.jira.api.email.address}")
+	private String _jiraAPIEmailAddress;
+
+	@Value("${liferay.one.jira.api.token}")
+	private String _jiraAPIToken;
+
+	@Value("${liferay.one.jira.workspace.id}")
+	private String _jiraWorkspaceId;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetsClient.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/client/JiraAssetsClient.java
@@ -138,7 +138,7 @@ public class JiraAssetsClient extends BaseService {
 		JSONArray jsonArray = searchObjects(aql);
 
 		for (int i = 0; i < jsonArray.length(); i++) {
-			results.add(transformFunction.apply(jsonArray.getJSONObject(0)));
+			results.add(transformFunction.apply(jsonArray.getJSONObject(i)));
 		}
 
 		return results;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/AccountConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/AccountConstants.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface AccountConstants {
+
+	public static final String ATTRIBUTE_NAME_AI_PUBLIC_COMMENTS =
+		"AI Public Comments";
+
+	public static final String ATTRIBUTE_NAME_ARR = "ARR";
+
+	public static final String ATTRIBUTE_NAME_CODE = "Code";
+
+	public static final String ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS =
+		"Contact Email Address";
+
+	public static final String ATTRIBUTE_NAME_DATA_REGION = "Data Region";
+
+	public static final String ATTRIBUTE_NAME_DESCRIPTION = "Description";
+
+	public static final String ATTRIBUTE_NAME_DXP_VERSION_CONFIRMED_DATE =
+		"DXP Version Confirmed Date";
+
+	public static final String ATTRIBUTE_NAME_EXPIRED = "Expired";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_CREATED_AT =
+		"External Created At";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT =
+		"External Updated At";
+
+	public static final String ATTRIBUTE_NAME_FAX_NUMBER = "Fax Number";
+
+	public static final String ATTRIBUTE_NAME_GS_OPPORTUNITY = "GS Opportunity";
+
+	public static final String ATTRIBUTE_NAME_INTERNAL = "Internal";
+
+	public static final String ATTRIBUTE_NAME_LANGUAGE = "Language";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String ATTRIBUTE_NAME_ORGANIZATION = "Organization";
+
+	public static final String ATTRIBUTE_NAME_PHONE_NUMBER = "Phone Number";
+
+	public static final String ATTRIBUTE_NAME_PREMIUM_SERVICE =
+		"Premium Service";
+
+	public static final String ATTRIBUTE_NAME_PROFILE_EMAIL_ADDRESS =
+		"Profile Email Address";
+
+	public static final String ATTRIBUTE_NAME_STATUS = "Status";
+
+	public static final String ATTRIBUTE_NAME_SUBORGANIZATION =
+		"Sub-Organization";
+
+	public static final String ATTRIBUTE_NAME_SUBORGANIZATION_IMPORTED =
+		"Sub-Organization-Imported";
+
+	public static final String ATTRIBUTE_NAME_SUPPORT_REGION = "Support Region";
+
+	public static final String ATTRIBUTE_NAME_TIER = "Tier";
+
+	public static final String ATTRIBUTE_NAME_WEBSITE = "Website";
+
+	public static final String OBJECT_TYPE_NAME = "Account";
+
+	public static final String SCHEMA_NAME = "One Liferay";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
  * @author Drew Brokke
  */
 @Component
-public class AccountConverter extends AssetObjectConverter {
+public class AccountConverter extends BaseAssetObjectConverter {
 
 	@Override
 	protected String getObjectSchemaName() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.AccountConstants;
+import com.liferay.one.jira.model.JiraAssetSchemaNameProvider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class AccountConverter extends AssetObjectConverter {
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _jiraAssetSchemaNameProvider.getSchemaName();
+	}
+
+	@Override
+	protected String getObjectTypeName() {
+		return AccountConstants.OBJECT_TYPE_NAME;
+	}
+
+	@Autowired
+	private JiraAssetSchemaNameProvider _jiraAssetSchemaNameProvider;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
@@ -5,8 +5,22 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
+import com.liferay.one.jira.client.JiraAssetObject;
 import com.liferay.one.jira.constants.AccountConstants;
 import com.liferay.one.jira.model.JiraAssetSchemaNameProvider;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.TimeZone;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -17,6 +31,56 @@ import org.springframework.stereotype.Component;
 @Component
 public class AccountConverter extends BaseAssetObjectConverter {
 
+	public JiraAssetObject toAssetObject(Account account) throws Exception {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			getAttributeIds());
+
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_KEY,
+			account.getExternalReferenceCode());
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_NAME, account.getName());
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_DESCRIPTION,
+			account.getDescription());
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT,
+			_format(account.getDateCreated()));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT,
+			_format(account.getDateModified()));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_STATUS,
+			_status(account.getStatus()));
+
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_CODE,
+			_customFieldData(account, _CUSTOM_FIELD_NAME_ACCOUNT_CODE));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_TIER,
+			_customFieldData(account, _CUSTOM_FIELD_NAME_ACCOUNT_TIER));
+
+		AccountContactInformation accountContactInformation =
+			account.getAccountContactInformation();
+
+		if (accountContactInformation != null) {
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS,
+				_getEmailAddress(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_FAX_NUMBER,
+				_getFaxNumber(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_PHONE_NUMBER,
+				_getPhoneNumber(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_WEBSITE,
+				_getWebsite(accountContactInformation));
+		}
+
+		return jiraAssetObject;
+	}
+
 	@Override
 	protected String getObjectSchemaName() {
 		return _jiraAssetSchemaNameProvider.getSchemaName();
@@ -26,6 +90,151 @@ public class AccountConverter extends BaseAssetObjectConverter {
 	protected String getObjectTypeName() {
 		return AccountConstants.OBJECT_TYPE_NAME;
 	}
+
+	private Object _customFieldData(Account account, String name) {
+		CustomField[] customFields = account.getCustomFields();
+
+		if (customFields == null) {
+			return null;
+		}
+
+		for (CustomField customField : customFields) {
+			if (!name.equals(customField.getName())) {
+				continue;
+			}
+
+			CustomValue customValue = customField.getCustomValue();
+
+			if (customValue == null) {
+				return null;
+			}
+
+			return customValue.getData();
+		}
+
+		return null;
+	}
+
+	private String _format(Date date) {
+		if (date == null) {
+			return null;
+		}
+
+		SimpleDateFormat simpleDateFormat = _simpleDateFormat();
+
+		return simpleDateFormat.format(date);
+	}
+
+	private String _getEmailAddress(
+		AccountContactInformation accountContactInformation) {
+
+		EmailAddress[] emailAddresses =
+			accountContactInformation.getEmailAddresses();
+
+		if (ArrayUtil.isEmpty(emailAddresses)) {
+			return null;
+		}
+
+		for (EmailAddress emailAddress : emailAddresses) {
+			if (Boolean.TRUE.equals(emailAddress.getPrimary())) {
+				return emailAddress.getEmailAddress();
+			}
+		}
+
+		EmailAddress emailAddress = emailAddresses[0];
+
+		return emailAddress.getEmailAddress();
+	}
+
+	private String _getFaxNumber(
+		AccountContactInformation accountContactInformation) {
+
+		Phone[] telephones = accountContactInformation.getTelephones();
+
+		if (telephones == null) {
+			return null;
+		}
+
+		for (Phone telephone : telephones) {
+			if ("fax".equalsIgnoreCase(telephone.getPhoneType())) {
+				return telephone.getPhoneNumber();
+			}
+		}
+
+		return null;
+	}
+
+	private String _getPhoneNumber(
+		AccountContactInformation accountContactInformation) {
+
+		Phone[] telephones = accountContactInformation.getTelephones();
+
+		if (ArrayUtil.isEmpty(telephones)) {
+			return null;
+		}
+
+		for (Phone telephone : telephones) {
+			if ("fax".equalsIgnoreCase(telephone.getPhoneType())) {
+				continue;
+			}
+
+			if (Boolean.TRUE.equals(telephone.getPrimary())) {
+				return telephone.getPhoneNumber();
+			}
+		}
+
+		Phone telephone = telephones[0];
+
+		return telephone.getPhoneNumber();
+	}
+
+	private String _getWebsite(
+		AccountContactInformation accountContactInformation) {
+
+		WebUrl[] webUrls = accountContactInformation.getWebUrls();
+
+		if (ArrayUtil.isEmpty(webUrls)) {
+			return null;
+		}
+
+		for (WebUrl webUrl : webUrls) {
+			if (Boolean.TRUE.equals(webUrl.getPrimary())) {
+				return webUrl.getUrl();
+			}
+		}
+
+		WebUrl webUrl = webUrls[0];
+
+		return webUrl.getUrl();
+	}
+
+	private SimpleDateFormat _simpleDateFormat() {
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return simpleDateFormat;
+	}
+
+	private String _status(Integer status) {
+
+		// Best-guess mapping; adjust to the real Liferay account status codes.
+
+		if (status == null) {
+			return null;
+		}
+
+		if (status == 0) {
+			return "Active";
+		}
+
+		return "Closed";
+	}
+
+	private static final String _CUSTOM_FIELD_NAME_ACCOUNT_CODE = "accountCode";
+
+	private static final String _CUSTOM_FIELD_NAME_ACCOUNT_TIER = "accountTier";
 
 	@Autowired
 	private JiraAssetSchemaNameProvider _jiraAssetSchemaNameProvider;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AssetObjectConverter.java
@@ -5,24 +5,31 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.one.jira.client.JiraAssetObject;
 import com.liferay.one.jira.service.AssetSchemaService;
 import com.liferay.one.jira.util.AQLUtil;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Amos Fong
+ * @author Drew Brokke
  */
 public abstract class AssetObjectConverter {
 
-	public String getBaseAQL() {
-		return AQLUtil.getBaseAQL(getObjectSchemaName(), getObjectTypeName());
+	public String getAQLWithBuilder(Consumer<AQLUtil.Builder> consumer) {
+		AQLUtil.Builder builder = AQLUtil.builder(getBaseAQL());
+
+		if (consumer != null) {
+			consumer.accept(builder);
+		}
+
+		return builder.build();
 	}
 
 	public String getObjectTypeId() {
@@ -30,9 +37,17 @@ public abstract class AssetObjectConverter {
 			getObjectSchemaName(), getObjectTypeName());
 	}
 
+	public JiraAssetObject toJiraAssetObject(JSONObject jsonObject) {
+		return new JiraAssetObject(jsonObject, getAttributeIds());
+	}
+
 	protected Map<String, String> getAttributeIds() {
 		return _assetSchemaService.getAttributeIds(
 			getObjectSchemaName(), getObjectTypeName());
+	}
+
+	protected String getBaseAQL() {
+		return AQLUtil.getBaseAQL(getObjectSchemaName(), getObjectTypeName());
 	}
 
 	protected abstract String getObjectSchemaName();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AssetObjectConverter.java
@@ -35,77 +35,9 @@ public abstract class AssetObjectConverter {
 			getObjectSchemaName(), getObjectTypeName());
 	}
 
-	protected String getAttributeKey(
-		String attributeId, JSONObject jsonObject) {
-
-		return _getAttributeKey(
-			_getAttributeValueJSONObject(
-				attributeId, jsonObject.getJSONArray("attributes")));
-	}
-
-	protected String getAttributeValue(
-		String attributeId, JSONObject jsonObject) {
-
-		JSONObject attributeValueJSONObject = _getAttributeValueJSONObject(
-			attributeId, jsonObject.getJSONArray("attributes"));
-
-		return attributeValueJSONObject.optString(
-			"displayValue", _getAttributeKey(attributeValueJSONObject));
-	}
-
 	protected abstract String getObjectSchemaName();
 
 	protected abstract String getObjectTypeName();
-
-	private String _getAttributeKey(JSONObject attributeValueJSONObject) {
-		String key = attributeValueJSONObject.optString("value");
-
-		if (Validator.isNull(key)) {
-			JSONObject referencedObjectJSONObject =
-				attributeValueJSONObject.optJSONObject("referencedObject");
-
-			if (referencedObjectJSONObject != null) {
-				key = referencedObjectJSONObject.optString("id");
-			}
-		}
-
-		return key;
-	}
-
-	private JSONObject _getAttributeValueJSONObject(
-		String attributeId, JSONArray attributesJSONArray) {
-
-		if (Validator.isNull(attributeId)) {
-			return new JSONObject();
-		}
-
-		for (int i = 0; i < attributesJSONArray.length(); i++) {
-			JSONObject attributeJSONObject = attributesJSONArray.getJSONObject(
-				i);
-
-			String objectTypeAttributeId = attributeJSONObject.optString(
-				"objectTypeAttributeId");
-
-			if (Validator.isNull(objectTypeAttributeId) ||
-				!attributeId.equals(objectTypeAttributeId)) {
-
-				continue;
-			}
-
-			JSONArray attributeValuesJSONArray =
-				attributeJSONObject.optJSONArray("objectAttributeValues");
-
-			if ((attributeValuesJSONArray == null) ||
-				attributeValuesJSONArray.isEmpty()) {
-
-				break;
-			}
-
-			return attributeValuesJSONArray.getJSONObject(0);
-		}
-
-		return new JSONObject();
-	}
 
 	@Autowired
 	private AssetSchemaService _assetSchemaService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseAssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseAssetObjectConverter.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Amos Fong
  * @author Drew Brokke
  */
-public abstract class AssetObjectConverter {
+public abstract class BaseAssetObjectConverter {
 
 	public String getAQLWithBuilder(Consumer<AQLUtil.Builder> consumer) {
 		AQLUtil.Builder builder = AQLUtil.builder(getBaseAQL());

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
  * @author Amos Fong
  */
 @Component
-public class BusinessEventConverter extends AssetObjectConverter {
+public class BusinessEventConverter extends BaseAssetObjectConverter {
 
 	public JiraAssetObject toAssetObject(
 		String accountObjectKey, BusinessEvent businessEvent) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
@@ -149,7 +149,7 @@ public class BusinessEventConverter extends BaseAssetObjectConverter {
 
 	@Override
 	protected String getObjectTypeName() {
-		return BusinessEventConstants.OBJECT_TYPE_PRODUCT_VERSION;
+		return BusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT;
 	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
@@ -5,160 +5,118 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.one.jira.client.JiraAssetObject;
 import com.liferay.one.jira.constants.BusinessEventConstants;
 import com.liferay.one.jira.model.BusinessEvent;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.Validator;
-
-import java.util.Map;
 
 import org.json.JSONObject;
 
 import org.springframework.stereotype.Component;
 
 /**
+ * Maps between a {@link BusinessEvent} and a JSM "Business Event" asset object.
+ *
  * @author Amos Fong
  */
 @Component
 public class BusinessEventConverter extends AssetObjectConverter {
 
-	public JSONObject toAttributesJSONObject(
+	public JiraAssetObject toAssetObject(
 		String accountObjectKey, BusinessEvent businessEvent) {
 
-		Map<String, String> attributeIds = getAttributeIds();
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			getAttributeIds());
 
-		JSONObject attributesJSONObject = new JSONObject();
-
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_ACTUAL_EVENT_DATE,
 			businessEvent.getActualEventDate());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_ASSOCIATED_TICKETS,
 			businessEvent.getAssociatedTickets());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_CURRENT_VERSION,
 			businessEvent.getCurrentLiferayVersionKey());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_DESCRIPTION,
 			businessEvent.getDescription());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_EVENT_STATUS,
 			businessEvent.getEventStatusName());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_EVENT_TYPE,
 			businessEvent.getEventTypeName());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_LAST_COMMENT,
 			businessEvent.getLastComment());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_LAST_UPDATED_AUTHOR,
 			businessEvent.getLastUpdatedAuthorEmailAddress());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_NAME,
 			businessEvent.getName());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION,
 			businessEvent.getNewLiferayVersionKey());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_PLANNED_EVENT_DATE,
 			businessEvent.getPlannedEventDate());
-		_put(
-			attributesJSONObject, attributeIds,
+		jiraAssetObject.setAttributeValue(
 			BusinessEventConstants.ATTRIBUTE_NAME_TIME_ZONE,
 			businessEvent.getTimeZoneName());
 
 		if (accountObjectKey != null) {
-			_put(
-				attributesJSONObject, attributeIds,
+			jiraAssetObject.setAttributeValue(
 				BusinessEventConstants.ATTRIBUTE_NAME_ACCOUNT,
 				accountObjectKey);
-			_put(
-				attributesJSONObject, attributeIds,
+			jiraAssetObject.setAttributeValue(
 				BusinessEventConstants.ATTRIBUTE_NAME_AUTHOR,
 				businessEvent.getAuthorEmailAddress());
 		}
 
-		return attributesJSONObject;
+		return jiraAssetObject;
 	}
 
 	public BusinessEvent toBusinessEvent(
 		String accountExternalReferenceCode,
 		JSONObject jiraAssetObjectJSONObject) {
 
-		Map<String, String> attributeIds = getAttributeIds();
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			jiraAssetObjectJSONObject, getAttributeIds());
 
 		return new BusinessEvent(
 			accountExternalReferenceCode,
-			getAttributeKey(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_ACTUAL_EVENT_DATE),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_ASSOCIATED_TICKETS),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_AUTHOR),
-				jiraAssetObjectJSONObject),
-			jiraAssetObjectJSONObject.optString("id"),
-			getAttributeKey(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_CURRENT_VERSION),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_CURRENT_VERSION),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_DESCRIPTION),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_EVENT_STATUS),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_EVENT_TYPE),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_LAST_COMMENT),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_LAST_UPDATED_AUTHOR),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_NAME),
-				jiraAssetObjectJSONObject),
-			getAttributeKey(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION),
-				jiraAssetObjectJSONObject),
-			getAttributeKey(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_PLANNED_EVENT_DATE),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(
-					BusinessEventConstants.ATTRIBUTE_NAME_TIME_ZONE),
-				jiraAssetObjectJSONObject));
+			jiraAssetObject.getAttributeValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_ACTUAL_EVENT_DATE),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_ASSOCIATED_TICKETS),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_AUTHOR),
+			jiraAssetObject.getObjectId(),
+			jiraAssetObject.getAttributeValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_CURRENT_VERSION),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_CURRENT_VERSION),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_DESCRIPTION),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_EVENT_STATUS),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_EVENT_TYPE),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_LAST_COMMENT),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_LAST_UPDATED_AUTHOR),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_NAME),
+			jiraAssetObject.getAttributeValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION),
+			jiraAssetObject.getAttributeValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_PLANNED_EVENT_DATE),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_TIME_ZONE));
 	}
 
 	public BusinessEvent toBusinessEvent(
@@ -191,18 +149,7 @@ public class BusinessEventConverter extends AssetObjectConverter {
 
 	@Override
 	protected String getObjectTypeName() {
-		return BusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT;
-	}
-
-	private void _put(
-		JSONObject attributesJSONObject, Map<String, String> attributeIds,
-		String attributeName, String value) {
-
-		String attributeId = attributeIds.get(attributeName);
-
-		if (Validator.isNotNull(attributeId)) {
-			attributesJSONObject.put(attributeId, value);
-		}
+		return BusinessEventConstants.OBJECT_TYPE_PRODUCT_VERSION;
 	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventVersionConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventVersionConverter.java
@@ -5,16 +5,18 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.one.jira.client.JiraAssetObject;
 import com.liferay.one.jira.constants.BusinessEventConstants;
 import com.liferay.one.jira.model.BusinessEventVersion;
-
-import java.util.Map;
 
 import org.json.JSONObject;
 
 import org.springframework.stereotype.Component;
 
 /**
+ * Maps a JSM "Business Event Version" asset object to a
+ * {@link BusinessEventVersion}.
+ *
  * @author Amos Fong
  */
 @Component
@@ -23,21 +25,18 @@ public class BusinessEventVersionConverter extends AssetObjectConverter {
 	public BusinessEventVersion toBusinessEventVersion(
 		JSONObject jiraAssetObjectJSONObject) {
 
-		Map<String, String> attributeIds = getAttributeIds();
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			jiraAssetObjectJSONObject, getAttributeIds());
 
 		return new BusinessEventVersion(
-			getAttributeValue(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_AUTHOR),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_CHANGE),
-				jiraAssetObjectJSONObject),
-			getAttributeValue(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_COMMENT),
-				jiraAssetObjectJSONObject),
-			getAttributeKey(
-				attributeIds.get(BusinessEventConstants.ATTRIBUTE_NAME_CREATED),
-				jiraAssetObjectJSONObject));
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_AUTHOR),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_CHANGE),
+			jiraAssetObject.getAttributeDisplayValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_COMMENT),
+			jiraAssetObject.getAttributeValue(
+				BusinessEventConstants.ATTRIBUTE_NAME_CREATED));
 	}
 
 	@Override

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventVersionConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventVersionConverter.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Component;
  * @author Amos Fong
  */
 @Component
-public class BusinessEventVersionConverter extends AssetObjectConverter {
+public class BusinessEventVersionConverter extends BaseAssetObjectConverter {
 
 	public BusinessEventVersion toBusinessEventVersion(
 		JSONObject jiraAssetObjectJSONObject) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/OrganizationConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/OrganizationConverter.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
  * @author Felipe Franca
  */
 @Component
-public class OrganizationConverter extends AssetObjectConverter {
+public class OrganizationConverter extends BaseAssetObjectConverter {
 
 	public Organization toOrganization(JSONObject assetObjectJSONObject) {
 		JiraAssetObject jiraAssetObject = new JiraAssetObject(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/OrganizationConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/OrganizationConverter.java
@@ -5,12 +5,14 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.one.jira.client.JiraAssetObject;
+import com.liferay.one.jira.constants.AccountConstants;
+import com.liferay.one.jira.model.JiraAssetSchemaNameProvider;
 import com.liferay.one.jira.model.Organization;
-import com.liferay.petra.string.StringPool;
 
 import org.json.JSONObject;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,25 +22,26 @@ import org.springframework.stereotype.Component;
 public class OrganizationConverter extends AssetObjectConverter {
 
 	public Organization toOrganization(JSONObject assetObjectJSONObject) {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			assetObjectJSONObject, getAttributeIds());
+
 		return new Organization(
-			getAttributeValue(_externalKeyAttributeId, assetObjectJSONObject),
-			assetObjectJSONObject.optString("id"),
-			assetObjectJSONObject.optString("name"));
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_KEY),
+			jiraAssetObject.getObjectId(), jiraAssetObject.getObjectName());
 	}
 
 	@Override
 	protected String getObjectSchemaName() {
-		return StringPool.BLANK;
+		return _jiraAssetSchemaNameProvider.getSchemaName();
 	}
 
 	@Override
 	protected String getObjectTypeName() {
-		return StringPool.BLANK;
+		return AccountConstants.OBJECT_TYPE_NAME;
 	}
 
-	@Value(
-		"${liferay.one.jira.organization.asset.object.type.attribute.external.key}"
-	)
-	private String _externalKeyAttributeId;
+	@Autowired
+	private JiraAssetSchemaNameProvider _jiraAssetSchemaNameProvider;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetSchemaNameProvider.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetSchemaNameProvider.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.model;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * The sole responsibility of this class is to read the JSM Schema that will be
+ * used as the sync target. It can then create AssetObjectType instances with
+ * the configured schema name applied.
+ *
+ * @author Drew Brokke
+ */
+@Component
+public class JiraAssetSchemaNameProvider {
+
+	public String getSchemaName() {
+		return _schemaName;
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaLoader.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaLoader.java
@@ -5,106 +5,51 @@
 
 package com.liferay.one.jira.service;
 
-import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.one.jira.client.JiraAssetsClient;
 import com.liferay.one.jira.exception.JiraAssetSchemaException;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
+ * Caches and resolves JSM Assets schema metadata to attribute name-to-id maps.
+ *
  * @author Drew Brokke
  */
 @Component
-public class AssetSchemaLoader extends BaseService {
+public class AssetSchemaLoader {
 
 	@Cacheable("assetObjectTypeAttributeIds")
 	public Map<String, String> getAttributeIds(String objectTypeId) {
 		return _toNameIdMap(
-			new JSONArray(
-				_get(
-					StringBundler.concat(
-						"objecttype/", objectTypeId, "/attributes"))));
+			_jiraAssetsClient.getObjectTypeAttributes(objectTypeId));
 	}
 
 	@Cacheable("assetObjectTypeIds")
 	public Map<String, String> getObjectTypeIds(String schemaName) {
 		String schemaId = _resolveSchemaId(schemaName);
 
-		return _toNameIdMap(
-			new JSONArray(
-				_get(
-					StringBundler.concat(
-						"objectschema/", schemaId, "/objecttypes"))));
-	}
-
-	private String _get(String path) {
-		try {
-			return get(
-				_getAuthorization(),
-				UriComponentsBuilder.fromUriString(
-					StringBundler.concat(
-						_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-						_jiraWorkspaceId, "/v1/", path)
-				).build(
-				).toUri());
-		}
-		catch (Exception exception) {
-			throw new JiraAssetSchemaException(
-				"Unable to complete JSM Assets request for " + path, exception);
-		}
-	}
-
-	private String _getAuthorization() {
-		Base64.Encoder encoder = Base64.getEncoder();
-
-		String credentials =
-			_jiraAPIEmailAddress + StringPool.COLON + _jiraAPIToken;
-
-		return "Basic " + encoder.encodeToString(credentials.getBytes());
+		return _toNameIdMap(_jiraAssetsClient.getObjectTypes(schemaId));
 	}
 
 	private String _resolveSchemaId(String schemaName) {
-		int startAt = 0;
+		JSONArray objectSchemasJSONArray = _jiraAssetsClient.getObjectSchemas();
 
-		while (true) {
-			JSONObject responseJSONObject = new JSONObject(
-				_get(
-					StringBundler.concat(
-						"objectschema/list?maxResults=", _MAX_RESULTS,
-						"&startAt=", startAt)));
+		for (int i = 0; i < objectSchemasJSONArray.length(); i++) {
+			JSONObject schemaJSONObject = objectSchemasJSONArray.getJSONObject(
+				i);
 
-			JSONArray valuesJSONArray = responseJSONObject.optJSONArray(
-				"values");
-
-			if ((valuesJSONArray == null) || valuesJSONArray.isEmpty()) {
-				break;
+			if (schemaName.equals(schemaJSONObject.optString("name"))) {
+				return schemaJSONObject.getString("id");
 			}
-
-			for (int i = 0; i < valuesJSONArray.length(); i++) {
-				JSONObject schemaJSONObject = valuesJSONArray.getJSONObject(i);
-
-				if (schemaName.equals(schemaJSONObject.optString("name"))) {
-					return schemaJSONObject.getString("id");
-				}
-			}
-
-			if (responseJSONObject.optBoolean("isLast")) {
-				break;
-			}
-
-			startAt += _MAX_RESULTS;
 		}
 
 		throw new JiraAssetSchemaException(
@@ -131,18 +76,7 @@ public class AssetSchemaLoader extends BaseService {
 		return attributeIds;
 	}
 
-	private static final String _JIRA_CLOUD_API_URL =
-		"https://api.atlassian.com";
-
-	private static final int _MAX_RESULTS = 100;
-
-	@Value("${liferay.one.jira.api.email.address}")
-	private String _jiraAPIEmailAddress;
-
-	@Value("${liferay.one.jira.api.token}")
-	private String _jiraAPIToken;
-
-	@Value("${liferay.one.jira.workspace.id}")
-	private String _jiraWorkspaceId;
+	@Autowired
+	private JiraAssetsClient _jiraAssetsClient;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/BusinessEventService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/BusinessEventService.java
@@ -1,0 +1,188 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import com.liferay.one.jira.client.JiraAssetObject;
+import com.liferay.one.jira.client.JiraAssetsClient;
+import com.liferay.one.jira.constants.BusinessEventConstants;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.BusinessEventConverter;
+import com.liferay.one.jira.converter.BusinessEventVersionConverter;
+import com.liferay.one.jira.model.AssetObject;
+import com.liferay.one.jira.model.AssetObjectFieldOption;
+import com.liferay.one.jira.model.BusinessEvent;
+import com.liferay.one.jira.model.BusinessEventVersion;
+import com.liferay.one.jira.util.AQLUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Jenny Chen
+ * @author Drew Brokke
+ */
+@Component
+public class BusinessEventService {
+
+	public void createBusinessEvent(BusinessEvent businessEvent)
+		throws Exception {
+
+		_jiraAssetsClient.createObject(
+			_businessEventConverter.getObjectTypeId(),
+			_businessEventConverter.toAssetObject(
+				_getAccountObjectKey(
+					businessEvent.getAccountExternalReferenceCode()),
+				businessEvent));
+	}
+
+	public void deleteBusinessEvent(String id) throws Exception {
+		_jiraAssetsClient.deleteObject(id);
+	}
+
+	public BusinessEvent getBusinessEvent(String id) throws Exception {
+		return _businessEventConverter.toBusinessEvent(
+			StringPool.BLANK, _jiraAssetsClient.getObject(id));
+	}
+
+	public List<BusinessEvent> getBusinessEvents(
+			String accountExternalReferenceCode)
+		throws Exception {
+
+		return _jiraAssetsClient.searchObjects(
+			_businessEventConverter.getAQLWithBuilder(
+				aqlBuilder -> aqlBuilder.andEquals(
+					accountExternalReferenceCode,
+					BusinessEventConstants.ATTRIBUTE_NAME_ACCOUNT,
+					"External Key")),
+			jsonObject -> _businessEventConverter.toBusinessEvent(
+				accountExternalReferenceCode, jsonObject));
+	}
+
+	public List<BusinessEventVersion> getBusinessEventVersions(
+			String businessEventId)
+		throws Exception {
+
+		if (!Validator.isNumber(businessEventId)) {
+			return new ArrayList<>();
+		}
+
+		return _jiraAssetsClient.searchObjects(
+			_businessEventVersionConverter.getAQLWithBuilder(
+				aqlBuilder -> aqlBuilder.andEqualsObject(
+					businessEventId,
+					BusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT
+				).orderByDescending(
+					"Updated"
+				)),
+			_businessEventVersionConverter::toBusinessEventVersion);
+	}
+
+	@Cacheable("assetObjectFieldOptions")
+	public List<AssetObjectFieldOption> getFieldOptions(String fieldName)
+		throws Exception {
+
+		List<AssetObjectFieldOption> assetObjectFieldOptions =
+			new ArrayList<>();
+
+		JSONArray objectTypeAttributesJSONArray =
+			_jiraAssetsClient.getObjectTypeAttributes(
+				_businessEventConverter.getObjectTypeId());
+
+		for (int i = 0; i < objectTypeAttributesJSONArray.length(); i++) {
+			JSONObject objectTypeAttributeJSONObject =
+				objectTypeAttributesJSONArray.getJSONObject(i);
+
+			if (!fieldName.equals(
+					objectTypeAttributeJSONObject.optString("name"))) {
+
+				continue;
+			}
+
+			String options = objectTypeAttributeJSONObject.optString("options");
+
+			if (Validator.isNotNull(options)) {
+				for (String option : options.split(",")) {
+					assetObjectFieldOptions.add(
+						new AssetObjectFieldOption(option, option));
+				}
+			}
+
+			break;
+		}
+
+		return assetObjectFieldOptions;
+	}
+
+	@Cacheable("assetObjects")
+	public List<AssetObject> getProductVersions() throws Exception {
+		return _jiraAssetsClient.searchObjects(
+			AQLUtil.getBaseAQL(
+				BusinessEventConstants.OBJECT_SCHEMA_BUSINESS_EVENTS,
+				BusinessEventConstants.OBJECT_TYPE_PRODUCT_VERSION),
+			AssetObject::new);
+	}
+
+	@CacheEvict(
+		allEntries = true, value = {"assetObjectFieldOptions", "assetObjects"}
+	)
+	@Scheduled(cron = "0 0 0 * * *")
+	public void scheduledAssetObjectsCacheEviction() throws Exception {
+	}
+
+	public BusinessEvent updateBusinessEvent(
+			BusinessEvent businessEvent, String id)
+		throws Exception {
+
+		_jiraAssetsClient.updateObject(
+			id, _businessEventConverter.toAssetObject(null, businessEvent));
+
+		return getBusinessEvent(id);
+	}
+
+	private String _getAccountObjectKey(String accountExternalReferenceCode)
+		throws Exception {
+
+		String aql = _accountConverter.getAQLWithBuilder(
+			aqlBuilder -> aqlBuilder.andEquals(
+				accountExternalReferenceCode, "External Key"));
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetsClient.searchObjects(
+				aql, _accountConverter::toJiraAssetObject);
+
+		if (jiraAssetObjects.isEmpty()) {
+			return null;
+		}
+
+		JiraAssetObject jiraAssetObject = jiraAssetObjects.get(0);
+
+		return jiraAssetObject.getObjectKey();
+	}
+
+	@Autowired
+	private AccountConverter _accountConverter;
+
+	@Autowired
+	private BusinessEventConverter _businessEventConverter;
+
+	@Autowired
+	private BusinessEventVersionConverter _businessEventVersionConverter;
+
+	@Autowired
+	private JiraAssetsClient _jiraAssetsClient;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraService.java
@@ -6,18 +6,13 @@
 package com.liferay.one.jira.service;
 
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.one.jira.client.JiraAssetObject;
+import com.liferay.one.jira.client.JiraAssetsClient;
 import com.liferay.one.jira.constants.IssueConstants;
-import com.liferay.one.jira.converter.BusinessEventConverter;
-import com.liferay.one.jira.converter.BusinessEventVersionConverter;
 import com.liferay.one.jira.converter.OrganizationConverter;
 import com.liferay.one.jira.exception.OrganizationNotFoundException;
-import com.liferay.one.jira.model.AssetObject;
-import com.liferay.one.jira.model.AssetObjectFieldOption;
-import com.liferay.one.jira.model.BusinessEvent;
-import com.liferay.one.jira.model.BusinessEventVersion;
 import com.liferay.one.jira.model.Organization;
 import com.liferay.one.jira.model.SupportIssue;
-import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -37,11 +32,8 @@ import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -64,145 +56,6 @@ public class JiraService extends BaseService {
 					_jiraURL, "/rest/api/3/issue/", issueKey, "/comment")
 			).build(
 			).toUri());
-	}
-
-	public void createBusinessEvent(BusinessEvent businessEvent)
-		throws Exception {
-
-		_syncBusinessEvent(businessEvent, null);
-	}
-
-	public void deleteBusinessEvent(String id) throws Exception {
-		_deleteAssetObjectJSONObject(id);
-	}
-
-	public String getAccountObjectKey(String externalKey) throws Exception {
-		JSONObject accountResponseJSONObject =
-			_searchAccountByExternalKeyJSONObject(externalKey);
-
-		JSONArray valuesJSONArray = accountResponseJSONObject.getJSONArray(
-			"values");
-
-		JSONObject accountJSONObject = valuesJSONArray.getJSONObject(0);
-
-		return accountJSONObject.getString("objectKey");
-	}
-
-	@Cacheable("assetObjectFieldOptions")
-	public List<AssetObjectFieldOption> getAssetObjectFieldOptions(
-			String fieldName, String objectTypeId)
-		throws Exception {
-
-		List<AssetObjectFieldOption> assetObjectFieldOptions =
-			new ArrayList<>();
-
-		JSONArray objectTypeAttributesJSONArray =
-			_getObjectTypeAttributesJSONArray(objectTypeId);
-
-		for (int i = 0; i < objectTypeAttributesJSONArray.length(); i++) {
-			JSONObject objectTypeAttributeJSONObject =
-				objectTypeAttributesJSONArray.getJSONObject(i);
-
-			if (!fieldName.equals(
-					objectTypeAttributeJSONObject.optString("name"))) {
-
-				continue;
-			}
-
-			String options = objectTypeAttributeJSONObject.optString("options");
-
-			if (Validator.isNotNull(options)) {
-				for (String option : options.split(",")) {
-					assetObjectFieldOptions.add(
-						new AssetObjectFieldOption(option, option));
-				}
-			}
-
-			break;
-		}
-
-		return assetObjectFieldOptions;
-	}
-
-	@Cacheable("assetObjects")
-	public List<AssetObject> getAssetObjects(
-			String objectSchemaName, String objectTypeName)
-		throws Exception {
-
-		List<AssetObject> assetObjects = new ArrayList<>();
-
-		String aql = AQLUtil.getBaseAQL(objectSchemaName, objectTypeName);
-
-		JSONArray assetsObjectsJSONArray = _searchAssetsObjectsJSONArray(aql);
-
-		for (int i = 0; i < assetsObjectsJSONArray.length(); i++) {
-			assetObjects.add(
-				new AssetObject(assetsObjectsJSONArray.getJSONObject(i)));
-		}
-
-		return assetObjects;
-	}
-
-	public BusinessEvent getBusinessEvent(String id) throws Exception {
-		return _businessEventConverter.toBusinessEvent(
-			StringPool.BLANK, _getAssetObjectJSONObject(id));
-	}
-
-	public List<BusinessEvent> getBusinessEvents(
-			String accountExternalReferenceCode)
-		throws Exception {
-
-		List<BusinessEvent> businessEvents = new ArrayList<>();
-
-		String aql = AQLUtil.builder(
-			_businessEventConverter.getBaseAQL()
-		).andEquals(
-			accountExternalReferenceCode, "Account", "External Key"
-		).build();
-
-		JSONArray assetsObjectsJSONArray = _searchAssetsObjectsJSONArray(aql);
-
-		if (assetsObjectsJSONArray != null) {
-			for (int i = 0; i < assetsObjectsJSONArray.length(); i++) {
-				businessEvents.add(
-					_businessEventConverter.toBusinessEvent(
-						accountExternalReferenceCode,
-						assetsObjectsJSONArray.getJSONObject(i)));
-			}
-		}
-
-		return businessEvents;
-	}
-
-	public List<BusinessEventVersion> getBusinessEventVersions(
-			String businessEventId)
-		throws Exception {
-
-		List<BusinessEventVersion> businessEventVersions = new ArrayList<>();
-
-		if (!Validator.isNumber(businessEventId)) {
-			return businessEventVersions;
-		}
-
-		String aql = AQLUtil.builder(
-			_businessEventVersionConverter.getBaseAQL()
-		).andEqualsObject(
-			businessEventId, "Business Event"
-		).orderByDescending(
-			"Updated"
-		).build();
-
-		JSONArray assetsObjectsJSONArray = _searchAssetsObjectsJSONArray(aql);
-
-		if (assetsObjectsJSONArray != null) {
-			for (int i = 0; i < assetsObjectsJSONArray.length(); i++) {
-				businessEventVersions.add(
-					_businessEventVersionConverter.toBusinessEventVersion(
-						assetsObjectsJSONArray.getJSONObject(i)));
-			}
-		}
-
-		return businessEventVersions;
 	}
 
 	public SupportIssue getSupportIssue(String issueKey)
@@ -266,13 +119,6 @@ public class JiraService extends BaseService {
 			sb.toString(), new String[] {"key", "labels", "status", "summary"});
 	}
 
-	@CacheEvict(
-		allEntries = true, value = {"assetObjectFieldOptions", "assetObjects"}
-	)
-	@Scheduled(cron = "0 0 0 * * *")
-	public void scheduledAssetObjectsCacheEviction() throws Exception {
-	}
-
 	public List<SupportIssue> search(String jql, String[] returnFields)
 		throws Exception {
 
@@ -320,77 +166,6 @@ public class JiraService extends BaseService {
 		return supportIssues;
 	}
 
-	public BusinessEvent updateBusinessEvent(
-			BusinessEvent businessEvent, String id)
-		throws Exception {
-
-		_syncBusinessEvent(businessEvent, id);
-
-		return _businessEventConverter.toBusinessEvent(
-			StringPool.BLANK, _getAssetObjectJSONObject(id));
-	}
-
-	private JSONObject _createAssetObjectJSONObject(
-			JSONObject attributesJSONObject, String objectTypeId)
-		throws Exception {
-
-		JSONObject bodyJSONObject = new JSONObject(
-		).put(
-			"attributes", _transformAttributes(attributesJSONObject)
-		).put(
-			"objectTypeId", objectTypeId
-		);
-
-		String response = post(
-			bodyJSONObject.toString(),
-			HashMapBuilder.put(
-				HttpHeaders.AUTHORIZATION, _getAuthorization()
-			).put(
-				HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
-			).build(),
-			UriComponentsBuilder.fromUriString(
-				StringBundler.concat(
-					_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-					_jiraWorkspaceId, "/v1/object/create")
-			).build(
-			).toUri());
-
-		return new JSONObject(response);
-	}
-
-	private JSONObject _deleteAssetObjectJSONObject(String objectId)
-		throws Exception {
-
-		String response = delete(
-			_getAuthorization(), StringPool.BLANK,
-			UriComponentsBuilder.fromUriString(
-				StringBundler.concat(
-					_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-					_jiraWorkspaceId, "/v1/object/", objectId)
-			).build(
-			).toUri());
-
-		if (Validator.isNull(response)) {
-			return new JSONObject();
-		}
-
-		return new JSONObject(response);
-	}
-
-	private JSONObject _getAssetObjectJSONObject(String objectId)
-		throws Exception {
-
-		return new JSONObject(
-			get(
-				_getAuthorization(),
-				UriComponentsBuilder.fromUriString(
-					StringBundler.concat(
-						_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-						_jiraWorkspaceId, "/v1/object/", objectId)
-				).build(
-				).toUri()));
-	}
-
 	private String _getAuthorization() {
 		Base64.Encoder encoder = Base64.getEncoder();
 
@@ -400,21 +175,6 @@ public class JiraService extends BaseService {
 		return "Basic " + encoder.encodeToString(credentials.getBytes());
 	}
 
-	private JSONArray _getObjectTypeAttributesJSONArray(String objectTypeId)
-		throws Exception {
-
-		return new JSONArray(
-			get(
-				_getAuthorization(),
-				UriComponentsBuilder.fromUriString(
-					StringBundler.concat(
-						_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-						_jiraWorkspaceId, "/v1/objecttype/", objectTypeId,
-						"/attributes")
-				).build(
-				).toUri()));
-	}
-
 	private Organization _getOrganization(JSONObject jsonObject)
 		throws OrganizationNotFoundException {
 
@@ -422,104 +182,16 @@ public class JiraService extends BaseService {
 			JSONArray jsonArray = jsonObject.optJSONArray(
 				_jiraSupportHCFieldOrganization);
 
-			JSONObject assetJSONObject = jsonArray.getJSONObject(0);
+			JiraAssetObject jiraAssetObject =
+				_organizationConverter.toJiraAssetObject(
+					jsonArray.getJSONObject(0));
 
 			return _organizationConverter.toOrganization(
-				_getAssetObjectJSONObject(
-					assetJSONObject.getString("objectId")));
+				_jiraAssetsClient.getObject(jiraAssetObject.getObjectId()));
 		}
 		catch (Exception exception) {
 			throw new OrganizationNotFoundException(exception);
 		}
-	}
-
-	private JSONObject _searchAccountByExternalKeyJSONObject(
-		String externalKey) {
-
-		String aql = AQLUtil.builder(
-			AQLUtil.getBaseAQL("Koroneiki", "Account")
-		).andEquals(
-			externalKey, "External Key"
-		).build();
-
-		return new JSONObject(
-			post(
-				new JSONObject(
-				).put(
-					"qlQuery", aql
-				).toString(),
-				HashMapBuilder.put(
-					HttpHeaders.AUTHORIZATION, _getAuthorization()
-				).put(
-					HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
-				).build(),
-				UriComponentsBuilder.fromUriString(
-					StringBundler.concat(
-						_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-						_jiraWorkspaceId, "/v1/object/aql")
-				).build(
-				).toUri()));
-	}
-
-	private JSONArray _searchAssetsObjectsJSONArray(String aql)
-		throws Exception {
-
-		JSONArray itemsJSONArray = new JSONArray();
-
-		boolean last = false;
-		int startAt = 0;
-
-		while (!last) {
-			JSONObject resultsJSONObject = _searchAssetsObjectsPageJSONObject(
-				aql, _MAX_RESULTS, startAt);
-
-			JSONArray valuesJSONArray = resultsJSONObject.optJSONArray(
-				"values");
-
-			if ((valuesJSONArray == null) || valuesJSONArray.isEmpty()) {
-				break;
-			}
-
-			itemsJSONArray.putAll(valuesJSONArray);
-
-			last = resultsJSONObject.optBoolean("last");
-
-			startAt += _MAX_RESULTS;
-		}
-
-		return itemsJSONArray;
-	}
-
-	private JSONObject _searchAssetsObjectsPageJSONObject(
-			String aql, int maxResults, int startAt)
-		throws Exception {
-
-		String response = post(
-			new JSONObject(
-			).put(
-				"qlQuery", aql
-			).toString(),
-			HashMapBuilder.put(
-				HttpHeaders.AUTHORIZATION, _getAuthorization()
-			).put(
-				HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
-			).build(),
-			UriComponentsBuilder.fromUriString(
-				StringBundler.concat(
-					_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-					_jiraWorkspaceId, "/v1/object/aql")
-			).queryParam(
-				"maxResults", maxResults
-			).queryParam(
-				"startAt", startAt
-			).build(
-			).toUri());
-
-		if (Validator.isNull(response)) {
-			return new JSONObject();
-		}
-
-		return new JSONObject(response);
 	}
 
 	private JSONObject _searchJSONObject(
@@ -557,95 +229,20 @@ public class JiraService extends BaseService {
 		return null;
 	}
 
-	private void _syncBusinessEvent(BusinessEvent businessEvent, String id)
-		throws Exception {
-
-		if (Validator.isNull(id)) {
-			_createAssetObjectJSONObject(
-				_businessEventConverter.toAttributesJSONObject(
-					getAccountObjectKey(
-						businessEvent.getAccountExternalReferenceCode()),
-					businessEvent),
-				_businessEventConverter.getObjectTypeId());
-		}
-		else {
-			_updateAssetObjectJSONObject(
-				_businessEventConverter.toAttributesJSONObject(
-					null, businessEvent),
-				id);
-		}
-	}
-
-	private JSONArray _transformAttributes(JSONObject attributesJSONObject) {
-		JSONArray attributesJSONArray = new JSONArray();
-
-		for (String key : attributesJSONObject.keySet()) {
-			if (Validator.isNull(key)) {
-				continue;
-			}
-
-			attributesJSONArray.put(
-				new JSONObject(
-				).put(
-					"objectAttributeValues",
-					new JSONArray(
-					).put(
-						new JSONObject(
-						).put(
-							"value", attributesJSONObject.get(key)
-						)
-					)
-				).put(
-					"objectTypeAttributeId", key
-				));
-		}
-
-		return attributesJSONArray;
-	}
-
-	private JSONObject _updateAssetObjectJSONObject(
-			JSONObject attributesJSONObject, String objectId)
-		throws Exception {
-
-		return new JSONObject(
-			put(
-				new JSONObject(
-				).put(
-					"attributes", _transformAttributes(attributesJSONObject)
-				).toString(),
-				HashMapBuilder.put(
-					HttpHeaders.AUTHORIZATION, _getAuthorization()
-				).put(
-					HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
-				).build(),
-				UriComponentsBuilder.fromUriString(
-					StringBundler.concat(
-						_JIRA_CLOUD_API_URL, "/jsm/assets/workspace/",
-						_jiraWorkspaceId, "/v1/object/", objectId)
-				).build(
-				).toUri()));
-	}
-
-	private static final String _JIRA_CLOUD_API_URL =
-		"https://api.atlassian.com";
-
 	private static final int _MAX_RESULTS = 100;
 
 	private static final String _URL_REST_API_3 = "/rest/api/3";
 
 	private static final Log _log = LogFactory.getLog(JiraService.class);
 
-	@Autowired
-	private BusinessEventConverter _businessEventConverter;
-
-	@Autowired
-	private BusinessEventVersionConverter _businessEventVersionConverter;
-
 	@Value("${liferay.one.jira.api.email.address}")
 	private String _jiraAPIEmailAddress;
 
 	@Value("${liferay.one.jira.api.token}")
 	private String _jiraAPIToken;
+
+	@Autowired
+	private JiraAssetsClient _jiraAssetsClient;
 
 	@Value("${liferay.one.jira.support.fls.portal.url}")
 	private String _jiraSupportFLSPortalURL;
@@ -664,9 +261,6 @@ public class JiraService extends BaseService {
 
 	@Value("${liferay.one.jira.url}")
 	private String _jiraURL;
-
-	@Value("${liferay.one.jira.workspace.id}")
-	private String _jiraWorkspaceId;
 
 	@Autowired
 	private OrganizationConverter _organizationConverter;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Amos Fong

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -9,12 +9,16 @@ import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
+import com.liferay.one.jira.client.JiraAssetObject;
+import com.liferay.one.jira.client.JiraAssetsClient;
+import com.liferay.one.jira.converter.AccountConverter;
+
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Amos Fong
@@ -86,6 +90,28 @@ public class AccountService extends OneBaseService {
 		return accountResource.getAccountByExternalReferenceCode(
 			externalReferenceCode);
 	}
+
+	public String getAccountObjectKey(String externalKey) {
+		List<JiraAssetObject> objects = _jiraAssetsClient.searchObjects(
+			_accountConverter.getAQLWithBuilder(
+				aqlBuilder -> aqlBuilder.andEquals(
+					externalKey, "External Key")),
+			_accountConverter::toJiraAssetObject);
+
+		if (objects.isEmpty()) {
+			return null;
+		}
+
+		JiraAssetObject jiraAssetObject = objects.getFirst();
+
+		return jiraAssetObject.getObjectKey();
+	}
+
+	@Autowired
+	private AccountConverter _accountConverter;
+
+	@Autowired
+	private JiraAssetsClient _jiraAssetsClient;
 
 	@Autowired
 	private UserAccountService _userAccountService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -7,7 +7,6 @@ liferay.one.gcs.service.account.key=${LIFERAY_ONE_GCS_SERVICE_ACCOUNT_KEY}
 liferay.one.jira.api.email.address=${LIFERAY_ONE_JIRA_API_EMAIL_ADDRESS}
 liferay.one.jira.api.token=${LIFERAY_ONE_JIRA_API_TOKEN}
 liferay.one.jira.asset.schema.name=${LIFERAY_ONE_JIRA_ASSET_SCHEMA_NAME}
-liferay.one.jira.organization.asset.object.type.attribute.external.key=${LIFERAY_ONE_JIRA_ORGANIZATION_ASSET_OBJECT_TYPE_ATTRIBUTE_EXTERNAL_KEY}
 liferay.one.jira.support.fls.portal.url=${LIFERAY_ONE_JIRA_SUPPORT_FLS_PORTAL_URL}
 liferay.one.jira.support.fls.project=${LIFERAY_ONE_JIRA_SUPPORT_FLS_PROJECT}
 liferay.one.jira.support.hc.field.organization=${LIFERAY_ONE_JIRA_SUPPORT_HC_FIELD_ORGANIZATION}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -6,6 +6,7 @@ liferay.one.gcs.bucket.name=${LIFERAY_ONE_GCS_BUCKET_NAME}
 liferay.one.gcs.service.account.key=${LIFERAY_ONE_GCS_SERVICE_ACCOUNT_KEY}
 liferay.one.jira.api.email.address=${LIFERAY_ONE_JIRA_API_EMAIL_ADDRESS}
 liferay.one.jira.api.token=${LIFERAY_ONE_JIRA_API_TOKEN}
+liferay.one.jira.asset.schema.name=${LIFERAY_ONE_JIRA_ASSET_SCHEMA_NAME}
 liferay.one.jira.organization.asset.object.type.attribute.external.key=${LIFERAY_ONE_JIRA_ORGANIZATION_ASSET_OBJECT_TYPE_ATTRIBUTE_EXTERNAL_KEY}
 liferay.one.jira.support.fls.portal.url=${LIFERAY_ONE_JIRA_SUPPORT_FLS_PORTAL_URL}
 liferay.one.jira.support.fls.project=${LIFERAY_ONE_JIRA_SUPPORT_FLS_PROJECT}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/client/JiraAssetObjectTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/client/JiraAssetObjectTest.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.client;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetObjectTest {
+
+	@Test
+	public void testGetAttributeValue() {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			_jsonObject, _attributeNameToIdsMap);
+
+		Assertions.assertEquals(
+			"ACME", jiraAssetObject.getAttributeDisplayValue("Name"));
+		Assertions.assertEquals(
+			"OBJ-42", jiraAssetObject.getAttributeValue("Account"));
+		Assertions.assertEquals(
+			"5", jiraAssetObject.getAttributeValue("Event Status"));
+		Assertions.assertEquals(
+			"", jiraAssetObject.getAttributeValue("Description"));
+	}
+
+	@Test
+	public void testGetObjectId() {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			_jsonObject, _attributeNameToIdsMap);
+
+		Assertions.assertEquals("123", jiraAssetObject.getObjectId());
+	}
+
+	@Test
+	public void testReadGetAttributeDisplayValueResolvesReferenceLabel() {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			_jsonObject, _attributeNameToIdsMap);
+
+		Assertions.assertEquals(
+			"Acme Corp", jiraAssetObject.getAttributeDisplayValue("Account"));
+		Assertions.assertEquals(
+			"Done", jiraAssetObject.getAttributeDisplayValue("Event Status"));
+	}
+
+	@Test
+	public void testToAttributesJSONArray() {
+		JiraAssetObject jiraAssetObject = new JiraAssetObject(
+			_attributeNameToIdsMap);
+
+		jiraAssetObject.setAttributeValue("Name", "ACME");
+		jiraAssetObject.setAttributeValue("Account", "OBJ-42");
+		jiraAssetObject.setAttributeValue("Description", null);
+		jiraAssetObject.setAttributeValue("Nope", "whatever");
+
+		JSONArray attributesJSONArray = jiraAssetObject.toAttributesJSONArray();
+
+		Assertions.assertEquals(2, attributesJSONArray.length());
+
+		JSONObject nameJSONObject = attributesJSONArray.getJSONObject(0);
+
+		Assertions.assertEquals("100", _objectTypeAttributeId(nameJSONObject));
+		Assertions.assertEquals("ACME", _firstValue(nameJSONObject));
+
+		JSONObject accountJSONObject = attributesJSONArray.getJSONObject(1);
+
+		Assertions.assertEquals(
+			"200", _objectTypeAttributeId(accountJSONObject));
+		Assertions.assertEquals("OBJ-42", _firstValue(accountJSONObject));
+	}
+
+	private JSONObject _attributeJSONObject(
+		String objectTypeAttributeId,
+		JSONObject objectAttributeValueJSONObject) {
+
+		return new JSONObject(
+		).put(
+			"objectAttributeValues",
+			new JSONArray(
+			).put(
+				objectAttributeValueJSONObject
+			)
+		).put(
+			"objectTypeAttributeId", objectTypeAttributeId
+		);
+	}
+
+	private String _firstValue(JSONObject jsonObject) {
+		JSONArray objectAttributeValuesJSONArray = jsonObject.getJSONArray(
+			"objectAttributeValues");
+
+		JSONObject objectAttributeValueJSONObject =
+			objectAttributeValuesJSONArray.getJSONObject(0);
+
+		return objectAttributeValueJSONObject.getString("value");
+	}
+
+	private String _objectTypeAttributeId(JSONObject jsonObject) {
+		return jsonObject.getString("objectTypeAttributeId");
+	}
+
+	private final Map<String, String> _attributeNameToIdsMap =
+		HashMapBuilder.put(
+			"Account", "200"
+		).put(
+			"Description", "300"
+		).put(
+			"Event Status", "400"
+		).put(
+			"Name", "100"
+		).build();
+	private final JSONObject _jsonObject = new JSONObject(
+	).put(
+		"attributes",
+		new JSONArray(
+		).put(
+			_attributeJSONObject(
+				"100",
+				new JSONObject(
+				).put(
+					"value", "ACME"
+				))
+		).put(
+			_attributeJSONObject(
+				"400",
+				new JSONObject(
+				).put(
+					"displayValue", "Done"
+				).put(
+					"value", "5"
+				))
+		).put(
+			_attributeJSONObject(
+				"200",
+				new JSONObject(
+				).put(
+					"displayValue", "Acme Corp"
+				).put(
+					"referencedObject",
+					new JSONObject(
+					).put(
+						"id", "OBJ-42"
+					)
+				))
+		)
+	).put(
+		"id", "123"
+	);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96601

## What is being fixed

The JSM sync app concentrated all Jira Service Management interaction in a single JiraService and JiraRestController. Asset API calls, schema lookup, and per-domain conversion logic were entangled, making it hard to add new synced domains or reason about a single asset type in isolation.

## How it is being fixed

Jira asset access is pulled into a dedicated JiraAssetsClient, with a JiraAssetObject wrapper that encapsulates operations on an individual asset and exposes AQL and helper methods. The target JSM asset schema name is now configurable rather than hardcoded, and AssetSchemaLoader delegates schema resolution to the client.

The converter hierarchy is reworked: AssetObjectConverter becomes the abstract BaseAssetObjectConverter, and AccountConverter now handles conversion from the Account DTO to a JiraAssetObject. Domain operations are split out of the monolith into focused services and controllers — AccountService and BusinessEventService back the new BusinessEventsRestController, and the migrated operations are removed from JiraRestController and JiraService.
