### PR TITLE
LPD-95476 Propagate Salesforce account, project, and contract changes

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
@@ -10,6 +10,7 @@ liferay-one-etc-spring-boot-oahs:
         -   Liferay.Headless.Commerce.Admin.Order.everything
         -   Liferay.Headless.Commerce.Admin.Pricing.everything
         -   Liferay.Notification.REST.everything
+        -   c_contract.everything
         -   c_entitlement.everything
         -   c_entitlementdefinition.everything.read
         -   c_licensekey.everything.read

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
@@ -13,7 +13,7 @@ liferay-one-etc-spring-boot-oahs:
         -   c_entitlement.everything
         -   c_entitlementdefinition.everything.read
         -   c_licensekey.everything.read
-        -   c_project.everything.read
+        -   c_project.everything
         -   c_projectmembership.everything
         -   c_subscriptionentry.everything
         -   c_ticketattachment.everything

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Account.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Account.java
@@ -1,0 +1,133 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kyle Bischof
+ */
+public class Account {
+
+	public Account(JSONObject jsonObject) {
+		_accountTier = jsonObject.optString("Account_Tier__c");
+		_activeSubscription = jsonObject.optBoolean("Active_Subscription__c");
+		_billingCity = jsonObject.optString("BillingCity");
+		_billingCountry = jsonObject.optString("BillingCountry");
+		_billingPostalCode = jsonObject.optString("BillingPostalCode");
+		_billingState = jsonObject.optString("BillingState");
+		_billingStreet = jsonObject.optString("BillingStreet");
+		_description = jsonObject.optString("Description");
+		_fax = jsonObject.optString("Fax");
+		_id = jsonObject.optString("Id");
+		_name = jsonObject.optString("Name");
+		_ownerEmail = jsonObject.optString("Owner_Email__c");
+		_phone = jsonObject.optString("Phone");
+		_shippingCity = jsonObject.optString("ShippingCity");
+		_shippingCountry = jsonObject.optString("ShippingCountry");
+		_shippingPostalCode = jsonObject.optString("ShippingPostalCode");
+		_shippingState = jsonObject.optString("ShippingState");
+		_shippingStreet = jsonObject.optString("ShippingStreet");
+		_website = jsonObject.optString("Website");
+	}
+
+	public String getAccountTier() {
+		return _accountTier;
+	}
+
+	public String getBillingCity() {
+		return _billingCity;
+	}
+
+	public String getBillingCountry() {
+		return _billingCountry;
+	}
+
+	public String getBillingPostalCode() {
+		return _billingPostalCode;
+	}
+
+	public String getBillingState() {
+		return _billingState;
+	}
+
+	public String getBillingStreet() {
+		return _billingStreet;
+	}
+
+	public String getDescription() {
+		return _description;
+	}
+
+	public String getFax() {
+		return _fax;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	public String getOwnerEmail() {
+		return _ownerEmail;
+	}
+
+	public String getPhone() {
+		return _phone;
+	}
+
+	public String getShippingCity() {
+		return _shippingCity;
+	}
+
+	public String getShippingCountry() {
+		return _shippingCountry;
+	}
+
+	public String getShippingPostalCode() {
+		return _shippingPostalCode;
+	}
+
+	public String getShippingState() {
+		return _shippingState;
+	}
+
+	public String getShippingStreet() {
+		return _shippingStreet;
+	}
+
+	public String getWebsite() {
+		return _website;
+	}
+
+	public boolean isActiveSubscription() {
+		return _activeSubscription;
+	}
+
+	private final String _accountTier;
+	private final boolean _activeSubscription;
+	private final String _billingCity;
+	private final String _billingCountry;
+	private final String _billingPostalCode;
+	private final String _billingState;
+	private final String _billingStreet;
+	private final String _description;
+	private final String _fax;
+	private final String _id;
+	private final String _name;
+	private final String _ownerEmail;
+	private final String _phone;
+	private final String _shippingCity;
+	private final String _shippingCountry;
+	private final String _shippingPostalCode;
+	private final String _shippingState;
+	private final String _shippingStreet;
+	private final String _website;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Contract.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Contract.java
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kyle Bischof
+ */
+public class Contract {
+
+	public Contract(JSONObject jsonObject) {
+		_accountId = jsonObject.optString("AccountId");
+		_endDate = jsonObject.optString("EndDate");
+		_id = jsonObject.optString("Id");
+		_startDate = jsonObject.optString("StartDate");
+
+		if (jsonObject.isNull("ContractTerm")) {
+			_contractTerm = null;
+		}
+		else {
+			_contractTerm = jsonObject.optInt("ContractTerm");
+		}
+	}
+
+	public String getAccountId() {
+		return _accountId;
+	}
+
+	public Integer getContractTerm() {
+		return _contractTerm;
+	}
+
+	public String getEndDate() {
+		return _endDate;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public String getStartDate() {
+		return _startDate;
+	}
+
+	private final String _accountId;
+	private final Integer _contractTerm;
+	private final String _endDate;
+	private final String _id;
+	private final String _startDate;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Project.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/model/Project.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.model;
+
+import org.json.JSONObject;
+
+/**
+ * @author Kyle Bischof
+ */
+public class Project {
+
+	public Project(JSONObject jsonObject) {
+		_accountId = jsonObject.optString("Account__c");
+		_id = jsonObject.optString("Id");
+		_name = jsonObject.optString("Name");
+	}
+
+	public String getAccountId() {
+		return _accountId;
+	}
+
+	public String getId() {
+		return _id;
+	}
+
+	public String getName() {
+		return _name;
+	}
+
+	private final String _accountId;
+	private final String _id;
+	private final String _name;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
@@ -10,6 +10,7 @@ import com.liferay.headless.commerce.admin.pricing.client.dto.v2_0.PriceList;
 import com.liferay.one.pubsub.Message;
 import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
 import com.liferay.one.salesforce.model.Account;
+import com.liferay.one.salesforce.model.Contract;
 import com.liferay.one.salesforce.model.PricebookEntry;
 import com.liferay.one.salesforce.model.Product2;
 import com.liferay.one.salesforce.model.Project;
@@ -18,6 +19,7 @@ import com.liferay.one.service.CommercePriceEntryService;
 import com.liferay.one.service.CommercePriceListService;
 import com.liferay.one.service.CommerceProductService;
 import com.liferay.one.service.CommerceSkuService;
+import com.liferay.one.service.ContractService;
 import com.liferay.one.service.ProjectService;
 
 import java.util.Objects;
@@ -68,6 +70,9 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 
 				if (Objects.equals(salesforceObjectName, "Account")) {
 					_processAccount(recordJSONObject);
+				}
+				else if (Objects.equals(salesforceObjectName, "Contract")) {
+					_processContract(recordJSONObject);
 				}
 				else if (Objects.equals(
 							salesforceObjectName, "PricebookEntry")) {
@@ -122,6 +127,12 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 		}
 
 		_accountService.upsertAccount(account);
+	}
+
+	private void _processContract(JSONObject recordJSONObject)
+		throws Exception {
+
+		_contractService.upsertContract(new Contract(recordJSONObject));
 	}
 
 	private void _processPricebookEntry(
@@ -206,6 +217,9 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 
 	@Autowired
 	private CommerceSkuService _commerceSkuService;
+
+	@Autowired
+	private ContractService _contractService;
 
 	@Value("${liferay.one.salesforce.object.pubsub.subscriber.project.id}")
 	private String _projectId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
@@ -9,8 +9,10 @@ import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Sku;
 import com.liferay.headless.commerce.admin.pricing.client.dto.v2_0.PriceList;
 import com.liferay.one.pubsub.Message;
 import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
+import com.liferay.one.salesforce.model.Account;
 import com.liferay.one.salesforce.model.PricebookEntry;
 import com.liferay.one.salesforce.model.Product2;
+import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommercePriceEntryService;
 import com.liferay.one.service.CommercePriceListService;
 import com.liferay.one.service.CommerceProductService;
@@ -62,7 +64,12 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 			for (int i = 0; i < recordsJSONArray.length(); i++) {
 				JSONObject recordJSONObject = recordsJSONArray.getJSONObject(i);
 
-				if (Objects.equals(salesforceObjectName, "PricebookEntry")) {
+				if (Objects.equals(salesforceObjectName, "Account")) {
+					_processAccount(recordJSONObject);
+				}
+				else if (Objects.equals(
+							salesforceObjectName, "PricebookEntry")) {
+
 					_processPricebookEntry(action, recordJSONObject);
 				}
 				else if (Objects.equals(salesforceObjectName, "Product2")) {
@@ -95,6 +102,21 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 	@Override
 	protected boolean isAutoCreateTopic() {
 		return false;
+	}
+
+	private void _processAccount(JSONObject recordJSONObject) throws Exception {
+		Account account = new Account(recordJSONObject);
+
+		if (!account.isActiveSubscription()) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Skipping inactive Salesforce account " + account.getId());
+			}
+
+			return;
+		}
+
+		_accountService.upsertAccount(account);
 	}
 
 	private void _processPricebookEntry(
@@ -160,6 +182,9 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 
 	private static final Log _log = LogFactory.getLog(
 		SalesforceObjectPubsubSubscriber.class);
+
+	@Autowired
+	private AccountService _accountService;
 
 	@Autowired
 	private CommercePriceEntryService _commercePriceEntryService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriber.java
@@ -12,11 +12,13 @@ import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
 import com.liferay.one.salesforce.model.Account;
 import com.liferay.one.salesforce.model.PricebookEntry;
 import com.liferay.one.salesforce.model.Product2;
+import com.liferay.one.salesforce.model.Project;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommercePriceEntryService;
 import com.liferay.one.service.CommercePriceListService;
 import com.liferay.one.service.CommerceProductService;
 import com.liferay.one.service.CommerceSkuService;
+import com.liferay.one.service.ProjectService;
 
 import java.util.Objects;
 
@@ -74,6 +76,9 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 				}
 				else if (Objects.equals(salesforceObjectName, "Product2")) {
 					_processProduct2(action, recordJSONObject);
+				}
+				else if (Objects.equals(salesforceObjectName, "Project__c")) {
+					_processProject(recordJSONObject);
 				}
 				else if (_log.isInfoEnabled()) {
 					_log.info(
@@ -180,6 +185,10 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 		}
 	}
 
+	private void _processProject(JSONObject recordJSONObject) throws Exception {
+		_projectService.upsertProject(new Project(recordJSONObject));
+	}
+
 	private static final Log _log = LogFactory.getLog(
 		SalesforceObjectPubsubSubscriber.class);
 
@@ -200,6 +209,9 @@ public class SalesforceObjectPubsubSubscriber extends BasePubsubSubscriber {
 
 	@Value("${liferay.one.salesforce.object.pubsub.subscriber.project.id}")
 	private String _projectId;
+
+	@Autowired
+	private ProjectService _projectService;
 
 	@Value("${liferay.one.salesforce.object.pubsub.subscriber.subscription}")
 	private String _subscription;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -5,10 +5,24 @@
 
 package com.liferay.one.service;
 
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
 import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -85,6 +99,265 @@ public class AccountService extends OneBaseService {
 
 		return accountResource.getAccountByExternalReferenceCode(
 			externalReferenceCode);
+	}
+
+	public void upsertAccount(
+			com.liferay.one.salesforce.model.Account salesforceAccount)
+		throws Exception {
+
+		AccountResource accountResource = AccountResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(salesforceAccount::getId);
+		account.setStatus(() -> WorkflowConstants.STATUS_APPROVED);
+		account.setType(() -> Account.Type.BUSINESS);
+
+		if (Validator.isNotNull(salesforceAccount.getName())) {
+			account.setName(salesforceAccount::getName);
+		}
+
+		if (Validator.isNotNull(salesforceAccount.getDescription())) {
+			account.setDescription(salesforceAccount::getDescription);
+		}
+
+		_setAccountContactInformation(account, salesforceAccount);
+
+		_setCustomFields(account, salesforceAccount);
+
+		_setPostalAddresses(account, salesforceAccount);
+
+		try {
+			_upsertAccount(accountResource, account, salesforceAccount.getId());
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			if ((problem == null) ||
+				!Objects.equals(problem.getTitle(), "The web URL is invalid")) {
+
+				throw problemException;
+			}
+
+			AccountContactInformation accountContactInformation =
+				account.getAccountContactInformation();
+
+			accountContactInformation.setWebUrls(() -> null);
+
+			_upsertAccount(accountResource, account, salesforceAccount.getId());
+		}
+	}
+
+	private void _setAccountContactInformation(
+		Account account,
+		com.liferay.one.salesforce.model.Account salesforceAccount) {
+
+		String id = salesforceAccount.getId();
+
+		List<EmailAddress> emailAddresses = new ArrayList<>();
+		List<Phone> phones = new ArrayList<>();
+		List<WebUrl> webUrls = new ArrayList<>();
+
+		if (Validator.isNotNull(salesforceAccount.getOwnerEmail())) {
+			EmailAddress emailAddress = new EmailAddress();
+
+			emailAddress.setEmailAddress(salesforceAccount::getOwnerEmail);
+			emailAddress.setExternalReferenceCode(() -> id + "-owner-email");
+			emailAddress.setPrimary(() -> Boolean.TRUE);
+
+			emailAddresses.add(emailAddress);
+		}
+
+		if (Validator.isNotNull(salesforceAccount.getPhone())) {
+			Phone phone = new Phone();
+
+			phone.setExternalReferenceCode(() -> id + "-phone");
+			phone.setPhoneNumber(salesforceAccount::getPhone);
+			phone.setPrimary(() -> Boolean.TRUE);
+
+			phones.add(phone);
+		}
+
+		if (Validator.isNotNull(salesforceAccount.getFax())) {
+			Phone phone = new Phone();
+
+			phone.setExternalReferenceCode(() -> id + "-fax");
+			phone.setPhoneNumber(salesforceAccount::getFax);
+			phone.setPhoneType(() -> "fax");
+			phone.setPrimary(() -> Boolean.FALSE);
+
+			phones.add(phone);
+		}
+
+		String url = _toURL(salesforceAccount.getWebsite());
+
+		if (url != null) {
+			WebUrl webUrl = new WebUrl();
+
+			webUrl.setExternalReferenceCode(() -> id + "-website");
+			webUrl.setPrimary(() -> Boolean.TRUE);
+			webUrl.setUrl(() -> url);
+
+			webUrls.add(webUrl);
+		}
+
+		if (emailAddresses.isEmpty() && phones.isEmpty() && webUrls.isEmpty()) {
+			return;
+		}
+
+		AccountContactInformation accountContactInformation =
+			new AccountContactInformation();
+
+		if (!emailAddresses.isEmpty()) {
+			accountContactInformation.setEmailAddresses(
+				() -> emailAddresses.toArray(new EmailAddress[0]));
+		}
+
+		if (!phones.isEmpty()) {
+			accountContactInformation.setTelephones(
+				() -> phones.toArray(new Phone[0]));
+		}
+
+		if (!webUrls.isEmpty()) {
+			accountContactInformation.setWebUrls(
+				() -> webUrls.toArray(new WebUrl[0]));
+		}
+
+		account.setAccountContactInformation(() -> accountContactInformation);
+	}
+
+	private void _setCustomFields(
+		Account account,
+		com.liferay.one.salesforce.model.Account salesforceAccount) {
+
+		if (Validator.isNull(salesforceAccount.getAccountTier())) {
+			return;
+		}
+
+		CustomField customField = new CustomField();
+
+		customField.setName(() -> "accountTier");
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(salesforceAccount::getAccountTier);
+
+		customField.setCustomValue(() -> customValue);
+
+		account.setCustomFields(() -> new CustomField[] {customField});
+	}
+
+	private void _setPostalAddresses(
+		Account account,
+		com.liferay.one.salesforce.model.Account salesforceAccount) {
+
+		String id = salesforceAccount.getId();
+
+		List<PostalAddress> postalAddresses = new ArrayList<>();
+
+		PostalAddress billingPostalAddress = _toPostalAddress(
+			"billing", salesforceAccount.getBillingCity(),
+			salesforceAccount.getBillingCountry(), id + "-billing",
+			"Primary Billing Address", salesforceAccount.getBillingPostalCode(),
+			salesforceAccount.getBillingState(),
+			salesforceAccount.getBillingStreet());
+
+		if (billingPostalAddress != null) {
+			postalAddresses.add(billingPostalAddress);
+
+			account.setDefaultBillingAddressExternalReferenceCode(
+				() -> id + "-billing");
+		}
+
+		PostalAddress shippingPostalAddress = _toPostalAddress(
+			"shipping", salesforceAccount.getShippingCity(),
+			salesforceAccount.getShippingCountry(), id + "-shipping",
+			"Primary Shipping Address",
+			salesforceAccount.getShippingPostalCode(),
+			salesforceAccount.getShippingState(),
+			salesforceAccount.getShippingStreet());
+
+		if (shippingPostalAddress != null) {
+			postalAddresses.add(shippingPostalAddress);
+
+			account.setDefaultShippingAddressExternalReferenceCode(
+				() -> id + "-shipping");
+		}
+
+		if (!postalAddresses.isEmpty()) {
+			account.setPostalAddresses(
+				() -> postalAddresses.toArray(new PostalAddress[0]));
+		}
+	}
+
+	private PostalAddress _toPostalAddress(
+		String addressType, String city, String country,
+		String externalReferenceCode, String name, String postalCode,
+		String region, String street) {
+
+		if (Validator.isNull(street) || Validator.isNull(city) ||
+			Validator.isNull(postalCode)) {
+
+			return null;
+		}
+
+		PostalAddress postalAddress = new PostalAddress();
+
+		postalAddress.setAddressCountry(() -> country);
+		postalAddress.setAddressLocality(() -> city);
+		postalAddress.setAddressRegion(() -> region);
+		postalAddress.setAddressType(() -> addressType);
+		postalAddress.setExternalReferenceCode(() -> externalReferenceCode);
+		postalAddress.setName(() -> name);
+		postalAddress.setPostalCode(() -> postalCode);
+		postalAddress.setStreetAddressLine1(() -> street);
+
+		return postalAddress;
+	}
+
+	private String _toURL(String website) {
+		if (Validator.isNull(website) || website.contains(" ") ||
+			!website.contains(".")) {
+
+			return null;
+		}
+
+		String lowerCaseWebsite = StringUtil.toLowerCase(website);
+
+		if (lowerCaseWebsite.startsWith("http://") ||
+			lowerCaseWebsite.startsWith("https://")) {
+
+			return website;
+		}
+
+		return "https://" + website;
+	}
+
+	private void _upsertAccount(
+			AccountResource accountResource, Account account,
+			String externalReferenceCode)
+		throws Exception {
+
+		try {
+			accountResource.patchAccountByExternalReferenceCode(
+				externalReferenceCode, account);
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			if ((problem != null) && isNotFound(problem.getStatus())) {
+				accountResource.putAccountByExternalReferenceCode(
+					externalReferenceCode, account);
+			}
+			else {
+				throw problemException;
+			}
+		}
 	}
 
 	@Autowired

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ContractService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ContractService.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.salesforce.model.Contract;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.net.URI;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Kyle Bischof
+ */
+@Component
+public class ContractService extends OneBaseService {
+
+	public void upsertContract(Contract contract) throws Exception {
+		if (Validator.isNull(contract.getId()) ||
+			Validator.isNull(contract.getAccountId())) {
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to upsert contract " + contract.getId() +
+						" without an ID and account");
+			}
+
+			return;
+		}
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"externalReferenceCode", contract.getId()
+		).put(
+			"r_accountEntryToContract_accountEntryERC", contract.getAccountId()
+		);
+
+		if (contract.getContractTerm() != null) {
+			jsonObject.put("contractTerm", contract.getContractTerm());
+		}
+
+		String endDate = _toDateTime(contract.getEndDate());
+
+		if (Validator.isNotNull(endDate)) {
+			jsonObject.put("endDate", endDate);
+		}
+
+		String startDate = _toDateTime(contract.getStartDate());
+
+		if (Validator.isNotNull(startDate)) {
+			jsonObject.put("startDate", startDate);
+		}
+
+		URI uri = UriComponentsBuilder.fromPath(
+			"/o/c/contracts/by-external-reference-code/" + contract.getId()
+		).build(
+		).toUri();
+
+		try {
+			patch(getAuthorization(), jsonObject.toString(), uri);
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			int statusCode = webClientResponseException.getStatusCode(
+			).value();
+
+			if (statusCode != HttpStatus.NOT_FOUND.value()) {
+				throw webClientResponseException;
+			}
+
+			put(getAuthorization(), jsonObject.toString(), uri);
+		}
+	}
+
+	private String _toDateTime(String value) {
+		if (Validator.isNull(value)) {
+			return null;
+		}
+
+		Matcher matcher = _datePattern.matcher(value);
+
+		if (matcher.matches()) {
+			return value + "T00:00:00Z";
+		}
+
+		return value;
+	}
+
+	private static final Log _log = LogFactory.getLog(ContractService.class);
+
+	private static final Pattern _datePattern = Pattern.compile(
+		"\\d{4}-\\d{2}-\\d{2}");
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
@@ -8,9 +8,16 @@ package com.liferay.one.service;
 import com.liferay.one.model.Project;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.net.URI;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.json.JSONObject;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -35,5 +42,55 @@ public class ProjectService extends OneBaseService {
 
 		return new Project(new JSONObject(response));
 	}
+
+	public void upsertProject(
+			com.liferay.one.salesforce.model.Project salesforceProject)
+		throws Exception {
+
+		if (Validator.isNull(salesforceProject.getId()) ||
+			Validator.isNull(salesforceProject.getName()) ||
+			Validator.isNull(salesforceProject.getAccountId())) {
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to upsert project " + salesforceProject.getId() +
+						" without an ID, name, and account");
+			}
+
+			return;
+		}
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"externalReferenceCode", salesforceProject.getId()
+		).put(
+			"name", salesforceProject.getName()
+		).put(
+			"r_accountEntryToProject_accountEntryERC",
+			salesforceProject.getAccountId()
+		);
+
+		URI uri = UriComponentsBuilder.fromPath(
+			"/o/c/projects/by-external-reference-code/" +
+				salesforceProject.getId()
+		).build(
+		).toUri();
+
+		try {
+			patch(getAuthorization(), jsonObject.toString(), uri);
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			int statusCode = webClientResponseException.getStatusCode(
+			).value();
+
+			if (statusCode != HttpStatus.NOT_FOUND.value()) {
+				throw webClientResponseException;
+			}
+
+			put(getAuthorization(), jsonObject.toString(), uri);
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(ProjectService.class);
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95476

## What is being fixed

The liferay-one-etc-spring-boot Salesforce object subscriber only handled PricebookEntry and Product2 messages. Account, Project, and Contract changes published on the one-liferay-salesforce-objects subscription fell through to an info log and never reached one.liferay, so edits to those objects in Salesforce never propagated to the AccountEntry, /o/c/projects, or /o/c/contracts.

## How it is being fixed

Three commits, one per object, each adding a model that parses the Salesforce payload, a service that upserts the matching one.liferay entity by external reference code, and a dispatch branch in the subscriber. The upsert PATCH-merges by reference code so a message only touches the fields it carries and never blanks data sourced elsewhere such as the Koroneiki account custom fields, falling back to a PUT when the entity does not yet exist. Accounts whose subscription is inactive are skipped, and projects and contracts link to their account through reference-code relationships. Field mappings, contact-info child reference codes, and website handling mirror the bulk migration in scripts/one so the subscriber and the one-time migration stay interoperable. A bare Salesforce website is normalized to add a scheme, and when the platform still rejects the URL only the web URL is dropped rather than failing the entire account update.
