### PR TITLE
LPD-90604 Add 7-day SaaS Trial provisioning backend and expiry cron

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/Dockerfile
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/Dockerfile
@@ -1,0 +1,3 @@
+FROM liferay/jar-runner:latest
+
+COPY --chown=liferay:liferay *.jar /opt/liferay/jar-runner.jar

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/LCP.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/LCP.json
@@ -1,0 +1,18 @@
+{
+	"concurrencyPolicy": "Forbid",
+	"cpu": 1,
+	"env": {
+		"LIFERAY_ROUTES_CLIENT_EXTENSION": "/etc/liferay/lxc/ext-init-metadata",
+		"LIFERAY_ROUTES_DXP": "/etc/liferay/lxc/dxp-metadata"
+	},
+	"environments": {
+		"infra": {
+			"deploy": false
+		}
+	},
+	"id": "__PROJECT_ID__",
+	"kind": "CronJob",
+	"memory": 512,
+	"scale": 1,
+	"schedule": "0 */6 * * *"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/build.gradle
@@ -1,0 +1,39 @@
+buildscript {
+	dependencies {
+		classpath group: "com.liferay", name: "com.liferay.gradle.plugins.defaults", version: "latest.release"
+		classpath group: "org.springframework.boot", name: "spring-boot-gradle-plugin", version: "2.7.18"
+	}
+
+	repositories {
+		maven {
+			url new File(rootProject.projectDir, "../../.m2-tmp")
+		}
+
+		maven {
+			url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+		}
+	}
+}
+
+apply plugin: "com.liferay.source.formatter"
+apply plugin: "java-library"
+apply plugin: "org.springframework.boot"
+
+dependencies {
+	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
+	implementation group: "com.liferay", name: "com.liferay.petra.string", version: "latest.release"
+	implementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "latest.release"
+	implementation group: "org.json", name: "json", version: "20231013"
+	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
+}
+
+repositories {
+	maven {
+		url new File(rootProject.projectDir, "../../.m2-tmp")
+	}
+
+	maven {
+		url "https://repository-cdn.liferay.com/nexus/content/groups/public"
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/client-extension.yaml
@@ -1,0 +1,9 @@
+assemble:
+    -   fromTask: bootJar
+liferay-one-etc-cron-oahs:
+    .serviceAddress: localhost:8080
+    .serviceScheme: http
+    name: Liferay One Etc Cron OAuth Application Headless Server
+    scopes:
+        -   Liferay.Headless.Commerce.Admin.Order.everything.read
+    type: oAuthApplicationHeadlessServer

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/OneEtcCronSpringBootApplication.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/OneEtcCronSpringBootApplication.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.client.ClientExtensionUtilSpringBootClientComponentScan;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Wellington Barbosa
+ */
+@Import(ClientExtensionUtilSpringBootClientComponentScan.class)
+@SpringBootApplication
+public class OneEtcCronSpringBootApplication {
+
+	public static void main(String[] args) {
+		new SpringApplicationBuilder(
+			OneEtcCronSpringBootApplication.class
+		).web(
+			WebApplicationType.NONE
+		).run(
+			args
+		);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
@@ -137,9 +137,9 @@ public class TrialCommandLineRunner
 		for (int i = 0; i < ordersJSONArray.length(); i++) {
 			JSONObject orderJSONObject = ordersJSONArray.getJSONObject(i);
 
-			try {
-				long orderId = orderJSONObject.getLong("id");
+			long orderId = orderJSONObject.getLong("id");
 
+			try {
 				JSONObject customFieldsJSONObject =
 					orderJSONObject.optJSONObject("customFields");
 
@@ -186,7 +186,7 @@ public class TrialCommandLineRunner
 				}
 			}
 			catch (Exception exception) {
-				_log.error(exception);
+				_log.error("Unable to process order " + orderId, exception);
 			}
 		}
 	}
@@ -224,9 +224,9 @@ public class TrialCommandLineRunner
 
 			JSONObject orderJSONObject = ordersJSONArray.getJSONObject(i);
 
-			try {
-				long orderId = orderJSONObject.getLong("id");
+			long orderId = orderJSONObject.getLong("id");
 
+			try {
 				if (_log.isInfoEnabled()) {
 					_log.info("Processing on hold order " + orderId);
 				}
@@ -240,7 +240,8 @@ public class TrialCommandLineRunner
 				available--;
 			}
 			catch (Exception exception) {
-				_log.error(exception);
+				_log.error(
+					"Unable to process on hold order " + orderId, exception);
 			}
 		}
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
@@ -1,0 +1,271 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
+
+import java.time.ZonedDateTime;
+
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Keven Leone
+ * @author Wellington Barbosa
+ */
+@Component
+public class TrialCommandLineRunner
+	extends BaseRestController implements CommandLineRunner {
+
+	@Override
+	public void run(String... args) throws Exception {
+		_invoke(this::_processInProgressTrials, "In Progress Trials");
+
+		_invoke(this::_processOnHoldTrials, "On Hold Trials");
+	}
+
+	private JSONObject _getAvailabilityJSONObject() throws Exception {
+		return new JSONObject(
+			get(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					_liferayOAuthApplicationExternalReferenceCodes),
+				UriComponentsBuilder.fromUriString(
+					_liferayOneEtcSpringBootURL + "/trial/availability"
+				).build(
+				).toUri()));
+	}
+
+	private JSONArray _getOrdersJSONArray(String filterString)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+			get(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					_liferayOAuthApplicationExternalReferenceCodes),
+				UriComponentsBuilder.fromPath(
+					"/o/headless-commerce-admin-order/v1.0/orders"
+				).queryParam(
+					"filter", filterString
+				).queryParam(
+					"nestedFields", "customFields"
+				).queryParam(
+					"page", "-1"
+				).queryParam(
+					"pageSize", "-1"
+				).build(
+				).encode(
+				).toUri()));
+
+		return jsonObject.optJSONArray("items");
+	}
+
+	private void _invoke(UnsafeRunnable<?> task, String name) {
+		if (_log.isInfoEnabled()) {
+			_log.info("Processing \"" + name + "\"");
+		}
+
+		try {
+			task.run();
+		}
+		catch (Throwable throwable) {
+			_log.error("Unable to process " + name, throwable);
+		}
+	}
+
+	private void _postTrialExpire(long orderId) throws Exception {
+		post(
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				_liferayOAuthApplicationExternalReferenceCodes),
+			"",
+			UriComponentsBuilder.fromUriString(
+				_liferayOneEtcSpringBootURL + "/trial/expire/" + orderId
+			).build(
+			).toUri());
+	}
+
+	private void _postTrialNotifyEnd(long orderId) throws Exception {
+		post(
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				_liferayOAuthApplicationExternalReferenceCodes),
+			"",
+			UriComponentsBuilder.fromUriString(
+				_liferayOneEtcSpringBootURL + "/trial/notify-end/" + orderId
+			).build(
+			).toUri());
+	}
+
+	private void _postTrialProvisioning(long orderId) throws Exception {
+		post(
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				_liferayOAuthApplicationExternalReferenceCodes),
+			new JSONObject(
+			).put(
+				"classPK", orderId
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_liferayOneEtcSpringBootURL + "/trial/provisioning"
+			).build(
+			).toUri());
+	}
+
+	private void _processInProgressTrials() throws Exception {
+		JSONArray ordersJSONArray = _getOrdersJSONArray(
+			StringBundler.concat(
+				"orderStatus/any(x:(x eq ", _ORDER_STATUS_IN_PROGRESS,
+				")) and orderTypeExternalReferenceCode in (",
+				"'SSA_SAAS', 'SOLUTIONS7')"));
+
+		if (ordersJSONArray == null) {
+			return;
+		}
+
+		for (int i = 0; i < ordersJSONArray.length(); i++) {
+			JSONObject orderJSONObject = ordersJSONArray.getJSONObject(i);
+
+			try {
+				long orderId = orderJSONObject.getLong("id");
+
+				JSONObject customFieldsJSONObject =
+					orderJSONObject.optJSONObject("customFields");
+
+				if (customFieldsJSONObject == null) {
+					continue;
+				}
+
+				String trialEndDate = customFieldsJSONObject.optString(
+					"trial-end-date");
+
+				if (trialEndDate.isEmpty()) {
+					continue;
+				}
+
+				ZonedDateTime nowZonedDateTime = ZonedDateTime.now();
+
+				ZonedDateTime trialEndDateZonedDateTime = ZonedDateTime.parse(
+					trialEndDate);
+
+				if (nowZonedDateTime.isAfter(trialEndDateZonedDateTime)) {
+					_postTrialExpire(orderId);
+
+					if (_log.isInfoEnabled()) {
+						_log.info("Processed expired order " + orderId);
+					}
+
+					continue;
+				}
+
+				String trialNotifyEndDate = customFieldsJSONObject.optString(
+					"trial-notify-end-date");
+
+				if (trialNotifyEndDate.isEmpty() &&
+					Objects.equals(
+						nowZonedDateTime.withZoneSameInstant(
+							trialEndDateZonedDateTime.getZone()
+						).toLocalDate(),
+						trialEndDateZonedDateTime.minusDays(
+							1
+						).toLocalDate())) {
+
+					_postTrialNotifyEnd(orderId);
+
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							"Processed notify end of trial for order " +
+								orderId);
+					}
+				}
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
+		}
+	}
+
+	private void _processOnHoldTrials() throws Exception {
+		JSONArray ordersJSONArray = _getOrdersJSONArray(
+			StringBundler.concat(
+				"orderStatus/any(x:(x eq ", _ORDER_STATUS_ON_HOLD,
+				")) and orderTypeExternalReferenceCode eq 'SOLUTIONS7'"));
+
+		if ((ordersJSONArray == null) || (ordersJSONArray.length() == 0)) {
+			return;
+		}
+
+		JSONObject availabilityJSONObject = _getAvailabilityJSONObject();
+
+		if (!availabilityJSONObject.getBoolean("active")) {
+			if (_log.isInfoEnabled()) {
+				_log.info("There are no available seats");
+			}
+
+			return;
+		}
+
+		long available = availabilityJSONObject.getLong("available");
+
+		for (int i = 0; i < ordersJSONArray.length(); i++) {
+			if (available <= 0) {
+				if (_log.isInfoEnabled()) {
+					_log.info("There are no available seats");
+				}
+
+				break;
+			}
+
+			JSONObject orderJSONObject = ordersJSONArray.getJSONObject(i);
+
+			try {
+				long orderId = orderJSONObject.getLong("id");
+
+				if (_log.isInfoEnabled()) {
+					_log.info("Processing on hold order " + orderId);
+				}
+
+				_postTrialProvisioning(orderId);
+
+				if (_log.isInfoEnabled()) {
+					_log.info("Processed on hold order " + orderId);
+				}
+
+				available--;
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
+		}
+	}
+
+	private static final int _ORDER_STATUS_IN_PROGRESS = 6;
+
+	private static final int _ORDER_STATUS_ON_HOLD = 20;
+
+	private static final Log _log = LogFactory.getLog(
+		TrialCommandLineRunner.class);
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	@Value("${liferay.oauth.application.external.reference.codes}")
+	private String _liferayOAuthApplicationExternalReferenceCodes;
+
+	@Value("${liferay.one.etc.spring.boot.url}")
+	private String _liferayOneEtcSpringBootURL;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/java/com/liferay/one/TrialCommandLineRunner.java
@@ -12,8 +12,6 @@ import com.liferay.petra.string.StringBundler;
 
 import java.time.ZonedDateTime;
 
-import java.util.Objects;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -175,13 +173,8 @@ public class TrialCommandLineRunner
 					"trial-notify-end-date");
 
 				if (trialNotifyEndDate.isEmpty() &&
-					Objects.equals(
-						nowZonedDateTime.withZoneSameInstant(
-							trialEndDateZonedDateTime.getZone()
-						).toLocalDate(),
-						trialEndDateZonedDateTime.minusDays(
-							1
-						).toLocalDate())) {
+					!nowZonedDateTime.isBefore(
+						trialEndDateZonedDateTime.minusDays(1))) {
 
 					_postTrialNotifyEnd(orderId);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/resources/application-default.properties
@@ -1,0 +1,20 @@
+#
+# Application
+#
+
+liferay.one.etc.spring.boot.url=${LIFERAY_ONE_ETC_SPRING_BOOT_URL:http://localhost:58081}
+
+#
+# LXC
+#
+
+com.liferay.lxc.dxp.domains=localhost:8080
+com.liferay.lxc.dxp.mainDomain=localhost:8080
+com.liferay.lxc.dxp.server.protocol=http
+
+#
+# OAuth
+#
+
+liferay-one-etc-cron-oahs.oauth2.headless.server.client.secret=${LIFERAY_ONE_ETC_CRON_OAHS_CLIENT_SECRET}
+liferay.oauth.application.external.reference.codes=liferay-one-etc-cron-oahs

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/resources/application.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-cron/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.config.import=\
+    classpath:/application-default.properties,\
+    optional:configtree:/etc/liferay/lxc/*/

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 	implementation group: "com.google.cloud", name: "google-cloud-storage", version: "2.27.0"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
+	implementation group: "com.liferay", name: "com.liferay.headless.portal.instances.client", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.notification.rest.client", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.function", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.petra.io", version: "latest.release"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/client-extension.yaml
@@ -18,6 +18,7 @@ liferay-one-etc-spring-boot-oahs:
         -   c_projectmembership.everything
         -   c_subscriptionentry.everything
         -   c_ticketattachment.everything
+        -   c_trialextensionrequest.everything
     type: oAuthApplicationHeadlessServer
 liferay-one-etc-spring-boot-oaua:
     .serviceAddress: localhost:58081

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -21,6 +21,7 @@ import com.liferay.one.service.NotificationTemplateService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -275,7 +276,7 @@ public class TrialRestController extends BaseRestController {
 				ZonedDateTime.parse(
 					trialEndDate
 				).format(
-					DateTimeFormatter.ofPattern("MMMM d, yyyy")
+					DateTimeFormatter.ofPattern("MMMM d, yyyy", LocaleUtil.US)
 				)
 			).build());
 
@@ -641,6 +642,16 @@ public class TrialRestController extends BaseRestController {
 
 		if (portalInstance != null) {
 			virtualHost = portalInstance.getVirtualHost();
+		}
+
+		try {
+			_consoleService.deleteProject(
+				trialProvisioningContextJSONObject.getString("projectId"));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to delete project during rollback for order " + orderId,
+				exception);
 		}
 
 		try {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -1,0 +1,677 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
+import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.pagination.Page;
+import com.liferay.headless.portal.instances.client.resource.v1_0.PortalInstanceResource;
+import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.ConsoleService;
+import com.liferay.one.service.NotificationQueueEntryService;
+import com.liferay.one.service.NotificationTemplateService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.net.URI;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Keven Leone
+ */
+@RequestMapping("/trial")
+@RestController
+public class TrialRestController extends BaseRestController {
+
+	@DeleteMapping("{orderId}")
+	public void deleteTrial(@PathVariable long orderId) throws Exception {
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(order);
+
+		_consoleService.deleteProject(
+			trialProvisioningContextJSONObject.getString("projectId"));
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		_deletePortalInstance(
+			orderId, trialProvisioningContextJSONObject,
+			customFields.get("trial-virtual-host"));
+	}
+
+	@GetMapping("availability")
+	public String getAvailability(
+			@RequestParam(defaultValue = "SOLUTIONS7", required = false) String
+				orderTypeExternalReferenceCode)
+		throws Exception {
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			_getTrialProvisioningContextJSONObject(
+				_getOrder(orderTypeExternalReferenceCode)));
+
+		return new JSONObject(
+		).put(
+			"active", _trialMaxInstances > portalInstancesPage.getTotalCount()
+		).put(
+			"available",
+			_trialMaxInstances - portalInstancesPage.getTotalCount()
+		).put(
+			"max", _trialMaxInstances
+		).toString();
+	}
+
+	@GetMapping("domain-availability/{projectPrefix}")
+	public ResponseEntity<Void> getDomainAvailability(
+			@PathVariable String projectPrefix,
+			@RequestParam(defaultValue = "SSA_SAAS", required = false) String
+				orderTypeExternalReferenceCode)
+		throws Exception {
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(
+				_getOrder(orderTypeExternalReferenceCode));
+
+		String virtualHost =
+			projectPrefix + "." +
+				trialProvisioningContextJSONObject.getString("domain");
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			trialProvisioningContextJSONObject);
+
+		for (PortalInstance portalInstance : portalInstancesPage.getItems()) {
+			if (Objects.equals(virtualHost, portalInstance.getVirtualHost())) {
+				return ResponseEntity.status(
+					HttpStatus.CONFLICT
+				).build();
+			}
+		}
+
+		return ResponseEntity.status(
+			HttpStatus.OK
+		).build();
+	}
+
+	@PostMapping("expire/{orderId}")
+	public void postExpire(@PathVariable long orderId) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Expired trial " + orderId);
+		}
+
+		_commerceOrderService.completeOrder(
+			orderId, CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED);
+
+		deleteTrial(orderId);
+	}
+
+	@PostMapping("extend/{id}")
+	public void postExtend(@PathVariable long id) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Extend trial " + id);
+		}
+
+		JSONObject trialExtensionRequestJSONObject = new JSONObject(
+			get(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					"liferay-one-etc-spring-boot-oahs"),
+				UriComponentsBuilder.fromPath(
+					"/o/c/trialextensionrequests/" + id
+				).build(
+				).toUri()));
+
+		JSONObject dueStatusJSONObject =
+			trialExtensionRequestJSONObject.getJSONObject("dueStatus");
+
+		if (!(Objects.equals(
+				dueStatusJSONObject.getString("key"), "Approved") ||
+			  Objects.equals(
+				  dueStatusJSONObject.getString("key"), "AutoApproved") ||
+			  Objects.equals(
+				  dueStatusJSONObject.getString("key"), "Pending"))) {
+
+			return;
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(
+			trialExtensionRequestJSONObject.getLong(
+				"r_orderToTrialExtensionRequest_commerceOrderId"));
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		if (Objects.equals(dueStatusJSONObject.getString("key"), "Pending")) {
+			patch(
+				_liferayOAuth2AccessTokenManager.getAuthorization(
+					"liferay-one-etc-spring-boot-oahs"),
+				new JSONObject(
+				).put(
+					"dueStatus", "Approved"
+				).toString(),
+				UriComponentsBuilder.fromPath(
+					"/o/c/trialextensionrequests/" + id
+				).build(
+				).toUri());
+		}
+
+		customFields.put(
+			"trial-end-date",
+			ZonedDateTime.parse(
+				customFields.get("trial-end-date")
+			).plusDays(
+				trialExtensionRequestJSONObject.getInt("duration")
+			).format(
+				DateTimeFormatter.ISO_INSTANT
+			));
+
+		_commerceOrderService.updateOrder(
+			customFields, order.getId(), order.getOrderStatus());
+	}
+
+	@PostMapping("notify-end/{orderId}")
+	public void postNotifyEnd(@PathVariable long orderId) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info("Notify end " + orderId);
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		UserAccount userAccount =
+			_userAccountService.getUserAccountByEmailAddress(
+				order.getCreatorEmailAddress());
+
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		_postNotification(
+			order.getCreatorEmailAddress(), "TRIAL-EXPIRING-ORDER",
+			HashMapBuilder.put(
+				"TRIAL_CREATOR_FIRST_NAME", userAccount.getGivenName()
+			).put(
+				"TRIAL_END_DATE",
+				ZonedDateTime.parse(
+					customFields.get("trial-end-date")
+				).format(
+					DateTimeFormatter.ofPattern("MMMM d, yyyy")
+				)
+			).build());
+
+		customFields.put(
+			"trial-notify-end-date",
+			ZonedDateTime.now(
+			).format(
+				DateTimeFormatter.ISO_INSTANT
+			));
+
+		_commerceOrderService.updateOrder(
+			customFields, orderId, order.getOrderStatus());
+	}
+
+	@PostMapping("provisioning")
+	public void postProvisioning(@RequestBody String json) throws Exception {
+		JSONObject jsonObject = new JSONObject(json);
+
+		postProvisioningOrder(jsonObject.getLong("classPK"));
+	}
+
+	@PostMapping("provisioning/{orderId}")
+	public void postProvisioningOrder(@PathVariable long orderId)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Provisioning order " + orderId);
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		JSONObject trialProvisioningContextJSONObject =
+			_getTrialProvisioningContextJSONObject(order);
+
+		Page<PortalInstance> portalInstancesPage = _getPortalInstancesPage(
+			trialProvisioningContextJSONObject);
+
+		if (portalInstancesPage.getTotalCount() >= _trialMaxInstances) {
+			_log.error("Order is on hold");
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_ON_HOLD);
+
+			return;
+		}
+
+		if (order.getOrderStatus() ==
+				CommerceOrderConstants.ORDER_STATUS_OPEN) {
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_PENDING);
+		}
+
+		_commerceOrderService.updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		UserAccount userAccount =
+			_userAccountService.getUserAccountByEmailAddress(
+				order.getCreatorEmailAddress());
+
+		JSONObject trialSettingsJSONObject = _getTrialSettingsJSONObject(order);
+
+		boolean sendNotificationEmail = trialSettingsJSONObject.optBoolean(
+			"sendNotificationEmail", true);
+
+		if (sendNotificationEmail) {
+			_postNotification(
+				order.getCreatorEmailAddress(), "TRIAL-PROCESSING-ORDER",
+				HashMapBuilder.put(
+					"COMMERCEORDER_AUTHOR_FIRST_NAME",
+					userAccount.getGivenName()
+				).put(
+					"COMMERCEORDER_ID", String.valueOf(orderId)
+				).build());
+		}
+
+		PortalInstance portalInstance = null;
+
+		try {
+			portalInstance = _postPortalInstance(
+				userAccount, order.getCreatorEmailAddress(),
+				trialSettingsJSONObject.optString(
+					"projectId", String.valueOf(orderId)),
+				trialSettingsJSONObject.optString("siteInitializerKey", null),
+				trialProvisioningContextJSONObject);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to provision portal instance for order " + orderId,
+				exception);
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_CANCELLED);
+
+			throw exception;
+		}
+
+		try {
+			_consoleService.setUpProject(
+				trialProvisioningContextJSONObject.getString("cluster"),
+				trialProvisioningContextJSONObject.getBoolean("deployable"),
+				trialProvisioningContextJSONObject.getString("dxpProjectUid"),
+				portalInstance.getVirtualHost(),
+				_toStringArray(
+					trialSettingsJSONObject.optJSONArray(
+						"consoleInviteEmailAddresses", new JSONArray())),
+				orderId,
+				trialProvisioningContextJSONObject.getString("projectId"));
+
+			_commerceOrderService.updateOrder(
+				HashMapBuilder.put(
+					"trial-end-date",
+					ZonedDateTime.now(
+					).plusDays(
+						trialSettingsJSONObject.optInt("duration", 7)
+					).format(
+						DateTimeFormatter.ISO_INSTANT
+					)
+				).put(
+					"trial-start-date",
+					ZonedDateTime.now(
+					).format(
+						DateTimeFormatter.ISO_INSTANT
+					)
+				).put(
+					"trial-virtual-host", portalInstance.getVirtualHost()
+				).build(),
+				orderId, CommerceOrderConstants.ORDER_STATUS_IN_PROGRESS);
+
+			if (sendNotificationEmail) {
+				_postNotification(
+					order.getCreatorEmailAddress(), "TRIAL-COMPLETED-ORDER",
+					HashMapBuilder.put(
+						"EMAIL", order.getCreatorEmailAddress()
+					).put(
+						"NAME", userAccount.getGivenName()
+					).put(
+						"URL", portalInstance.getVirtualHost()
+					).build());
+			}
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_rollBackTrial(
+				webClientResponseException.getResponseBodyAsString(), orderId,
+				portalInstance, trialProvisioningContextJSONObject);
+		}
+		catch (Exception exception) {
+			_rollBackTrial(
+				exception.getMessage(), orderId, portalInstance,
+				trialProvisioningContextJSONObject);
+		}
+	}
+
+	private void _deletePortalInstance(
+			long orderId, JSONObject trialProvisioningContextJSONObject,
+			String virtualHost)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		Page<PortalInstance> portalInstancesPage =
+			portalInstanceResource.getPortalInstancesPage(true);
+
+		for (PortalInstance portalInstance : portalInstancesPage.getItems()) {
+			if (Objects.equals(portalInstance.getVirtualHost(), virtualHost)) {
+				portalInstanceResource.deletePortalInstance(
+					portalInstance.getPortalInstanceId());
+
+				break;
+			}
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Portal instance deleted for order " + orderId);
+		}
+	}
+
+	private Order _getOrder(String orderTypeExternalReferenceCode) {
+		Order order = new Order();
+
+		order.setCustomFields(() -> new HashMap<>());
+		order.setOrderTypeExternalReferenceCode(
+			() -> orderTypeExternalReferenceCode);
+
+		return order;
+	}
+
+	private PortalInstanceResource _getPortalInstanceResource(
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		return PortalInstanceResource.builder(
+		).endpoint(
+			new URI(
+				trialProvisioningContextJSONObject.getString("trialHomePageURL")
+			).toURL()
+		).header(
+			HttpHeaders.AUTHORIZATION,
+			_liferayOAuth2AccessTokenManager.getAuthorization(
+				trialProvisioningContextJSONObject.getString(
+					"trialAuthorizationERC"))
+		).build();
+	}
+
+	private Page<PortalInstance> _getPortalInstancesPage(
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		return portalInstanceResource.getPortalInstancesPage(true);
+	}
+
+	private JSONObject _getTrialProvisioningContextJSONObject(Order order) {
+		JSONObject trialSettingsJSONObject = _getTrialSettingsJSONObject(order);
+
+		String projectId = trialSettingsJSONObject.optString(
+			"projectId", String.valueOf(order.getId()));
+
+		if (Objects.equals(
+				order.getOrderTypeExternalReferenceCode(), "SOLUTIONS7")) {
+
+			return new JSONObject(
+			).put(
+				"cluster", _consoleTrialCluster
+			).put(
+				"deployable", true
+			).put(
+				"domain", _trialDXPDomain
+			).put(
+				"dxpProjectUid", _consoleTrialProjectUid
+			).put(
+				"projectId", _consoleTrialProjectPrefix + "-ext" + projectId
+			).put(
+				"trialAuthorizationERC", "external-trial"
+			).put(
+				"trialHomePageURL", _externalTrialHomePageURL
+			);
+		}
+
+		if (Objects.equals(
+				order.getOrderTypeExternalReferenceCode(), "SSA_SAAS")) {
+
+			return new JSONObject(
+			).put(
+				"cluster", _consoleSSACluster
+			).put(
+				"deployable", false
+			).put(
+				"domain", _trialSSADXPDomain
+			).put(
+				"dxpProjectUid", _consoleSSAProjectUid
+			).put(
+				"projectId", _consoleSSAProjectPrefix + "-ext" + projectId
+			).put(
+				"trialAuthorizationERC", "external-ssa"
+			).put(
+				"trialHomePageURL", _externalSSAHomePageURL
+			);
+		}
+
+		throw new IllegalArgumentException(
+			"Unsupported order type: " +
+				order.getOrderTypeExternalReferenceCode());
+	}
+
+	private JSONObject _getTrialSettingsJSONObject(Order order) {
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		if (customFields == null) {
+			return new JSONObject();
+		}
+
+		return new JSONObject(
+			customFields.getOrDefault("trial-settings", "{}"));
+	}
+
+	private void _postNotification(
+			String toEmailAddress, String externalReferenceCode,
+			Map<String, String> placeholders)
+		throws Exception {
+
+		JSONObject processedTemplateJSONObject =
+			_notificationTemplateService.getAndProcessTemplateJSONObject(
+				externalReferenceCode, "en_US", placeholders);
+
+		_notificationQueueEntryService.addNotificationQueueEntry(
+			"customer-service@liferay.com", "Liferay Support", toEmailAddress,
+			processedTemplateJSONObject.getString("subject"),
+			processedTemplateJSONObject.getString("body"));
+	}
+
+	private PortalInstance _postPortalInstance(
+			UserAccount userAccount, String emailAddress, String projectId,
+			String siteInitializerKey,
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		PortalInstanceResource portalInstanceResource =
+			_getPortalInstanceResource(trialProvisioningContextJSONObject);
+
+		PortalInstance portalInstance = new PortalInstance();
+
+		Admin admin = new Admin();
+
+		admin.setEmailAddress(() -> emailAddress);
+		admin.setFamilyName(
+			() -> Objects.toString(userAccount.getFamilyName(), ""));
+		admin.setGivenName(
+			() -> Objects.toString(userAccount.getGivenName(), ""));
+
+		portalInstance.setAdmin(() -> admin);
+
+		portalInstance.setDomain(() -> "lxc.app");
+		portalInstance.setSiteInitializerKey(() -> siteInitializerKey);
+
+		String domain =
+			projectId + "." +
+				trialProvisioningContextJSONObject.getString("domain");
+
+		portalInstance.setPortalInstanceId(() -> domain);
+		portalInstance.setVirtualHost(() -> domain);
+
+		portalInstance = portalInstanceResource.postPortalInstance(
+			portalInstance);
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Created portal instance " + portalInstance);
+		}
+
+		return portalInstance;
+	}
+
+	private void _rollBackTrial(
+			String errorMessage, long orderId, PortalInstance portalInstance,
+			JSONObject trialProvisioningContextJSONObject)
+		throws Exception {
+
+		_log.error(
+			StringBundler.concat(
+				"Unable to set up project for order ", orderId, ": \n",
+				errorMessage));
+
+		String virtualHost = null;
+
+		if (portalInstance != null) {
+			virtualHost = portalInstance.getVirtualHost();
+		}
+
+		try {
+			_deletePortalInstance(
+				orderId, trialProvisioningContextJSONObject, virtualHost);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to delete portal instance during rollback for order " +
+					orderId,
+				exception);
+		}
+
+		_commerceOrderService.updateOrder(
+			HashMapBuilder.put(
+				"trial-error", errorMessage
+			).put(
+				"trial-error-date",
+				ZonedDateTime.now(
+				).format(
+					DateTimeFormatter.ISO_INSTANT
+				)
+			).put(
+				"trial-virtual-host", virtualHost
+			).build(),
+			orderId, CommerceOrderConstants.ORDER_STATUS_CANCELLED);
+	}
+
+	private String[] _toStringArray(JSONArray jsonArray) {
+		List<String> list = new ArrayList<>();
+
+		for (int i = 0; i < jsonArray.length(); i++) {
+			list.add(jsonArray.getString(i));
+		}
+
+		return list.toArray(new String[0]);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		TrialRestController.class);
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private ConsoleService _consoleService;
+
+	@Value("${liferay.one.console.ssa.cluster}")
+	private String _consoleSSACluster;
+
+	@Value("${liferay.one.console.ssa.project.prefix}")
+	private String _consoleSSAProjectPrefix;
+
+	@Value("${liferay.one.console.ssa.project.uid}")
+	private String _consoleSSAProjectUid;
+
+	@Value("${liferay.one.console.cluster}")
+	private String _consoleTrialCluster;
+
+	@Value("${liferay.one.console.project.prefix}")
+	private String _consoleTrialProjectPrefix;
+
+	@Value("${liferay.one.console.project.uid}")
+	private String _consoleTrialProjectUid;
+
+	@Value("${external.ssa.oauth2.headless.server.home.page.url:}")
+	private String _externalSSAHomePageURL;
+
+	@Value("${external.trial.oauth2.headless.server.home.page.url:}")
+	private String _externalTrialHomePageURL;
+
+	@Autowired
+	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;
+
+	@Autowired
+	private NotificationQueueEntryService _notificationQueueEntryService;
+
+	@Autowired
+	private NotificationTemplateService _notificationTemplateService;
+
+	@Value("${liferay.one.trial.dxp.domain}")
+	private String _trialDXPDomain;
+
+	@Value("${liferay.one.trial.max.instances}")
+	private int _trialMaxInstances;
+
+	@Value("${liferay.one.trial.ssa.dxp.domain}")
+	private String _trialSSADXPDomain;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -21,6 +21,7 @@ import com.liferay.one.service.NotificationTemplateService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
 
@@ -75,9 +76,14 @@ public class TrialRestController extends BaseRestController {
 		Map<String, String> customFields =
 			(Map<String, String>)order.getCustomFields();
 
+		String virtualHost = null;
+
+		if (customFields != null) {
+			virtualHost = customFields.get("trial-virtual-host");
+		}
+
 		_deletePortalInstance(
-			orderId, trialProvisioningContextJSONObject,
-			customFields.get("trial-virtual-host"));
+			orderId, trialProvisioningContextJSONObject, virtualHost);
 	}
 
 	@GetMapping("availability")
@@ -193,10 +199,18 @@ public class TrialRestController extends BaseRestController {
 				).toUri());
 		}
 
+		String trialEndDate = customFields.get("trial-end-date");
+
+		if (Validator.isNull(trialEndDate)) {
+			throw new IllegalStateException(
+				"Order " + order.getId() +
+					" has no \"trial-end-date\" custom field");
+		}
+
 		customFields.put(
 			"trial-end-date",
 			ZonedDateTime.parse(
-				customFields.get("trial-end-date")
+				trialEndDate
 			).plusDays(
 				trialExtensionRequestJSONObject.getInt("duration")
 			).format(
@@ -215,12 +229,19 @@ public class TrialRestController extends BaseRestController {
 
 		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
 
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		String trialEndDate = customFields.get("trial-end-date");
+
+		if (Validator.isNull(trialEndDate)) {
+			throw new IllegalStateException(
+				"Order " + orderId + " has no \"trial-end-date\" custom field");
+		}
+
 		UserAccount userAccount =
 			_userAccountService.getUserAccountByEmailAddress(
 				order.getCreatorEmailAddress());
-
-		Map<String, String> customFields =
-			(Map<String, String>)order.getCustomFields();
 
 		_postNotification(
 			order.getCreatorEmailAddress(), "TRIAL-EXPIRING-ORDER",
@@ -229,7 +250,7 @@ public class TrialRestController extends BaseRestController {
 			).put(
 				"TRIAL_END_DATE",
 				ZonedDateTime.parse(
-					customFields.get("trial-end-date")
+					trialEndDate
 				).format(
 					DateTimeFormatter.ofPattern("MMMM d, yyyy")
 				)
@@ -291,6 +312,12 @@ public class TrialRestController extends BaseRestController {
 		UserAccount userAccount =
 			_userAccountService.getUserAccountByEmailAddress(
 				order.getCreatorEmailAddress());
+
+		if (userAccount == null) {
+			throw new IllegalArgumentException(
+				"No user account exists for email address \"" +
+					order.getCreatorEmailAddress() + "\"");
+		}
 
 		JSONObject trialSettingsJSONObject = _getTrialSettingsJSONObject(order);
 
@@ -389,6 +416,10 @@ public class TrialRestController extends BaseRestController {
 			long orderId, JSONObject trialProvisioningContextJSONObject,
 			String virtualHost)
 		throws Exception {
+
+		if (Validator.isNull(virtualHost)) {
+			return;
+		}
 
 		PortalInstanceResource portalInstanceResource =
 			_getPortalInstanceResource(trialProvisioningContextJSONObject);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -67,6 +67,11 @@ public class TrialRestController extends BaseRestController {
 	public void deleteTrial(@PathVariable long orderId) throws Exception {
 		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
 
+		if (order == null) {
+			throw new IllegalArgumentException(
+				"No order exists with ID " + orderId);
+		}
+
 		JSONObject trialProvisioningContextJSONObject =
 			_getTrialProvisioningContextJSONObject(order);
 
@@ -178,12 +183,29 @@ public class TrialRestController extends BaseRestController {
 			return;
 		}
 
-		Order order = _commerceOrderService.fetchCommerceOrder(
-			trialExtensionRequestJSONObject.getLong(
-				"r_orderToTrialExtensionRequest_commerceOrderId"));
+		long orderId = trialExtensionRequestJSONObject.getLong(
+			"r_orderToTrialExtensionRequest_commerceOrderId");
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		if (order == null) {
+			throw new IllegalArgumentException(
+				"No order exists with ID " + orderId);
+		}
 
 		Map<String, String> customFields =
 			(Map<String, String>)order.getCustomFields();
+
+		String trialEndDate = null;
+
+		if (customFields != null) {
+			trialEndDate = customFields.get("trial-end-date");
+		}
+
+		if (Validator.isNull(trialEndDate)) {
+			throw new IllegalStateException(
+				"Order " + orderId + " has no \"trial-end-date\" custom field");
+		}
 
 		if (Objects.equals(dueStatusJSONObject.getString("key"), "Pending")) {
 			patch(
@@ -199,14 +221,6 @@ public class TrialRestController extends BaseRestController {
 				).toUri());
 		}
 
-		String trialEndDate = customFields.get("trial-end-date");
-
-		if (Validator.isNull(trialEndDate)) {
-			throw new IllegalStateException(
-				"Order " + order.getId() +
-					" has no \"trial-end-date\" custom field");
-		}
-
 		customFields.put(
 			"trial-end-date",
 			ZonedDateTime.parse(
@@ -218,7 +232,7 @@ public class TrialRestController extends BaseRestController {
 			));
 
 		_commerceOrderService.updateOrder(
-			customFields, order.getId(), order.getOrderStatus());
+			customFields, orderId, order.getOrderStatus());
 	}
 
 	@PostMapping("notify-end/{orderId}")
@@ -229,10 +243,19 @@ public class TrialRestController extends BaseRestController {
 
 		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
 
+		if (order == null) {
+			throw new IllegalArgumentException(
+				"No order exists with ID " + orderId);
+		}
+
 		Map<String, String> customFields =
 			(Map<String, String>)order.getCustomFields();
 
-		String trialEndDate = customFields.get("trial-end-date");
+		String trialEndDate = null;
+
+		if (customFields != null) {
+			trialEndDate = customFields.get("trial-end-date");
+		}
 
 		if (Validator.isNull(trialEndDate)) {
 			throw new IllegalStateException(
@@ -283,6 +306,11 @@ public class TrialRestController extends BaseRestController {
 		}
 
 		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		if (order == null) {
+			throw new IllegalArgumentException(
+				"No order exists with ID " + orderId);
+		}
 
 		JSONObject trialProvisioningContextJSONObject =
 			_getTrialProvisioningContextJSONObject(order);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Keven Leone
+ */
+public class CommerceOrderConstants {
+
+	public static final int ORDER_PAYMENT_STATUS_NOT_REQUIRED = 23;
+
+	public static final int ORDER_STATUS_CANCELLED = 8;
+
+	public static final int ORDER_STATUS_COMPLETED = 0;
+
+	public static final int ORDER_STATUS_IN_PROGRESS = 6;
+
+	public static final int ORDER_STATUS_ON_HOLD = 20;
+
+	public static final int ORDER_STATUS_OPEN = 2;
+
+	public static final int ORDER_STATUS_PENDING = 1;
+
+	public static final int ORDER_STATUS_PROCESSING = 10;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -16,6 +16,7 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.headless.commerce.admin.order.client.pagination.Page;
 import com.liferay.headless.commerce.admin.order.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
+import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.constants.SupportRegionConstants;
 import com.liferay.one.util.SupportRegionUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -61,32 +62,49 @@ public class CommerceOrderService extends OneBaseService {
 
 		BigDecimal total = subtotalAmount.add(taxAmount);
 
-		orderResource.patchOrder(
-			commerceOrderId,
-			new Order() {
-				{
-					setCustomFields(() -> customFields);
-					setTaxAmount(() -> taxAmount);
-					setTotal(() -> total);
-				}
-			});
+		Order taxedOrder = new Order();
+
+		taxedOrder.setCustomFields(() -> customFields);
+		taxedOrder.setTaxAmount(() -> taxAmount);
+		taxedOrder.setTotal(() -> total);
+
+		orderResource.patchOrder(commerceOrderId, taxedOrder);
 
 		for (OrderItem orderItem : order.getOrderItems()) {
 			BigDecimal finalPrice = orderItem.getFinalPrice();
 
+			OrderItem taxedOrderItem = new OrderItem();
+
+			taxedOrderItem.setFinalPrice(() -> finalPrice);
+			taxedOrderItem.setFinalPriceWithTaxAmount(
+				() -> finalPrice.add(
+					finalPrice.multiply(BigDecimal.valueOf(_TAX_PERCENTAGE))));
+			taxedOrderItem.setPriceManuallyAdjusted(() -> true);
+
 			_commerceOrderItemService.patchOrderItem(
-				orderItem.getId(),
-				new OrderItem() {
-					{
-						setFinalPrice(() -> finalPrice);
-						setFinalPriceWithTaxAmount(
-							() -> finalPrice.add(
-								finalPrice.multiply(
-									BigDecimal.valueOf(_TAX_PERCENTAGE))));
-						setPriceManuallyAdjusted(() -> true);
-					}
-				});
+				orderItem.getId(), taxedOrderItem);
 		}
+	}
+
+	public void completeOrder(long orderId, int paymentStatus)
+		throws Exception {
+
+		completeOrder(null, orderId, paymentStatus);
+	}
+
+	public void completeOrder(
+			Map<String, ?> customFields, long orderId, int paymentStatus)
+		throws Exception {
+
+		updateOrder(
+			customFields, orderId, CommerceOrderConstants.ORDER_STATUS_PENDING);
+
+		updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_COMPLETED,
+			paymentStatus);
 	}
 
 	public Order fetchCommerceOrder(long commerceOrderId) throws Exception {
@@ -142,6 +160,36 @@ public class CommerceOrderService extends OneBaseService {
 		}
 
 		return SupportRegionConstants.GLOBAL;
+	}
+
+	public void updateOrder(
+			Map<String, ?> customFields, long orderId, int orderStatus)
+		throws Exception {
+
+		OrderResource orderResource = _buildOrderResource();
+
+		Order order = new Order();
+
+		order.setCustomFields(() -> customFields);
+		order.setOrderStatus(() -> orderStatus);
+
+		orderResource.patchOrder(orderId, order);
+	}
+
+	public void updateOrder(
+			Map<String, ?> customFields, long orderId, int orderStatus,
+			int paymentStatus)
+		throws Exception {
+
+		OrderResource orderResource = _buildOrderResource();
+
+		Order order = new Order();
+
+		order.setCustomFields(() -> customFields);
+		order.setOrderStatus(() -> orderStatus);
+		order.setPaymentStatus(() -> paymentStatus);
+
+		orderResource.patchOrder(orderId, order);
 	}
 
 	private CurrencyResource _buildCurrencyResource() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ConsoleService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ConsoleService.java
@@ -1,0 +1,268 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+
+import java.time.Duration;
+
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import reactor.util.retry.Retry;
+
+/**
+ * @author Keven Leone
+ */
+@Component
+public class ConsoleService extends BaseService {
+
+	public void deleteProject(String projectId) throws Exception {
+		delete(
+			getAuthorization(), "",
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/projects/" + projectId
+			).build(
+			).toUri());
+	}
+
+	public JSONObject deployApp(
+			String emailAddress, String orderId, String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+			post(
+				getAuthorization(),
+				new JSONObject(
+				).put(
+					"orderId", orderId
+				).put(
+					"userEmail", emailAddress
+				).toString(),
+				UriComponentsBuilder.fromUriString(
+					_consoleAuthURL
+				).path(
+					"/admin/projects/" + projectId + "/apps"
+				).build(
+				).toUri()));
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Deployed app for project " + projectId);
+		}
+
+		return jsonObject;
+	}
+
+	public synchronized String getAuthorization() throws Exception {
+		if ((_authorization != null) &&
+			(System.currentTimeMillis() < (_tokenExpirationMillis - 30000))) {
+
+			return _authorization;
+		}
+
+		String json = post(
+			null,
+			new JSONObject(
+			).put(
+				"email", _consoleAuthEmailAddress
+			).put(
+				"password", _consoleAuthPassword
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/login"
+			).build(
+			).toUri());
+
+		if (json == null) {
+			throw new Exception("Unable to get authorization");
+		}
+
+		String token = new JSONObject(
+			json
+		).getString(
+			"token"
+		);
+
+		_authorization = "Bearer " + token;
+
+		_tokenExpirationMillis = System.currentTimeMillis() + 900000;
+
+		return _authorization;
+	}
+
+	public void setUpProject(
+			String cluster, boolean deployable, String dxpProjectUid,
+			String dxpVirtualInstanceId, String[] emailAddresses, long orderId,
+			String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = _postProject(cluster, projectId);
+
+		for (String emailAddress : emailAddresses) {
+			try {
+				_inviteProject(emailAddress, projectId);
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to invite ", emailAddress, " to project ",
+						projectId),
+					exception);
+			}
+		}
+
+		_linkDXPWithProject(
+			dxpProjectUid, dxpVirtualInstanceId, jsonObject.getString("id"));
+
+		if (deployable) {
+			deployApp(
+				_consoleAuthEmailAddress, String.valueOf(orderId), projectId);
+		}
+	}
+
+	@Override
+	protected ExchangeFilterFunction getWebClientExchangeFilterFunction() {
+		return (clientRequest, exchangeFunction) -> exchangeFunction.exchange(
+			clientRequest
+		).retryWhen(
+			Retry.fixedDelay(
+				3, Duration.ofSeconds(5)
+			).doBeforeRetry(
+				retrySignal -> {
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Retrying ", clientRequest.url(),
+								retrySignal.totalRetries() + 1));
+					}
+				}
+			)
+		);
+	}
+
+	private void _inviteProject(String emailAddress, String projectId)
+		throws Exception {
+
+		if (Objects.equals(emailAddress, _consoleAuthEmailAddress)) {
+			return;
+		}
+
+		post(
+			getAuthorization(),
+			new JSONObject(
+			).put(
+				"email", emailAddress
+			).put(
+				"role", "admin"
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/projects/" + projectId + "/invite"
+			).build(
+			).toUri());
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Invited ", emailAddress, " to project ", projectId));
+		}
+	}
+
+	private void _linkDXPWithProject(
+			String dxpProjectUid, String dxpVirtualInstanceId,
+			String extensionProjectUid)
+		throws Exception {
+
+		post(
+			getAuthorization(),
+			new JSONObject(
+			).put(
+				"dxpProjectUid", dxpProjectUid
+			).put(
+				"dxpVirtualInstanceId", dxpVirtualInstanceId
+			).put(
+				"extensionProjectUid", extensionProjectUid
+			).toString(),
+			UriComponentsBuilder.fromUriString(
+				_consoleAuthURL
+			).path(
+				"/lxc-extension-links"
+			).build(
+			).toUri());
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Linked Liferay virtual instance ", dxpVirtualInstanceId,
+					" with project ", extensionProjectUid));
+		}
+	}
+
+	private JSONObject _postProject(String cluster, String projectId)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+			post(
+				getAuthorization(),
+				new JSONObject(
+				).put(
+					"cluster", cluster
+				).put(
+					"environment", true
+				).put(
+					"metadata",
+					new JSONObject(
+					).put(
+						"skipCloudProviderIamConfiguration", true
+					)
+				).put(
+					"projectId", projectId
+				).toString(),
+				UriComponentsBuilder.fromUriString(
+					_consoleAuthURL
+				).path(
+					"/projects"
+				).build(
+				).toUri()));
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Created project " + jsonObject);
+		}
+
+		return jsonObject;
+	}
+
+	private static final Log _log = LogFactory.getLog(ConsoleService.class);
+
+	private String _authorization;
+
+	@Value("${liferay.one.console.auth.email.address}")
+	private String _consoleAuthEmailAddress;
+
+	@Value("${liferay.one.console.auth.password}")
+	private String _consoleAuthPassword;
+
+	@Value("${liferay.one.console.auth.url}")
+	private String _consoleAuthURL;
+
+	private long _tokenExpirationMillis;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -79,6 +79,19 @@ public class UserAccountService extends OneBaseService {
 		return userAccountResource.getUserAccount(userId);
 	}
 
+	public UserAccount getUserAccountByEmailAddress(String emailAddress)
+		throws Exception {
+
+		UserAccountResource userAccountResource = UserAccountResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+
+		return userAccountResource.getUserAccountByEmailAddress(emailAddress);
+	}
+
 	private static final int _PAGE_SIZE = 500;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -54,6 +54,7 @@ liferay-one-etc-spring-boot-oahs.oauth2.headless.server.client.secret=${LIFERAY_
 liferay.oauth.application.external.reference.codes=\
     external-ssa,\
     external-trial,\
+    liferay-one-etc-cron-oahs,\
     liferay-one-etc-spring-boot-oahs,\
     liferay-one-etc-spring-boot-oaua
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -2,6 +2,15 @@
 # Application
 #
 
+liferay.one.console.auth.email.address=${LIFERAY_ONE_CONSOLE_AUTH_EMAIL_ADDRESS}
+liferay.one.console.auth.password=${LIFERAY_ONE_CONSOLE_AUTH_PASSWORD}
+liferay.one.console.auth.url=${LIFERAY_ONE_CONSOLE_AUTH_URL}
+liferay.one.console.cluster=${LIFERAY_ONE_CONSOLE_CLUSTER}
+liferay.one.console.project.prefix=${LIFERAY_ONE_CONSOLE_PROJECT_PREFIX}
+liferay.one.console.project.uid=${LIFERAY_ONE_CONSOLE_PROJECT_UID}
+liferay.one.console.ssa.cluster=${LIFERAY_ONE_CONSOLE_SSA_CLUSTER}
+liferay.one.console.ssa.project.prefix=${LIFERAY_ONE_CONSOLE_SSA_PROJECT_PREFIX}
+liferay.one.console.ssa.project.uid=${LIFERAY_ONE_CONSOLE_SSA_PROJECT_UID}
 liferay.one.gcs.bucket.name=${LIFERAY_ONE_GCS_BUCKET_NAME}
 liferay.one.gcs.service.account.key=${LIFERAY_ONE_GCS_SERVICE_ACCOUNT_KEY}
 liferay.one.jira.api.email.address=${LIFERAY_ONE_JIRA_API_EMAIL_ADDRESS}
@@ -26,6 +35,9 @@ liferay.one.provisioning.email.address.japan=${LIFERAY_ONE_PROVISIONING_EMAIL_AD
 liferay.one.provisioning.email.address.spain=${LIFERAY_ONE_PROVISIONING_EMAIL_ADDRESS_SPAIN}
 liferay.one.provisioning.email.address.us=${LIFERAY_ONE_PROVISIONING_EMAIL_ADDRESS_US}
 liferay.one.provisioning.partner.user.update.recipient=${LIFERAY_ONE_PROVISIONING_PARTNER_USER_UPDATE_RECIPIENT}
+liferay.one.trial.dxp.domain=${LIFERAY_ONE_TRIAL_DXP_DOMAIN}
+liferay.one.trial.max.instances=${LIFERAY_ONE_TRIAL_MAX_INSTANCES:50}
+liferay.one.trial.ssa.dxp.domain=${LIFERAY_ONE_TRIAL_SSA_DXP_DOMAIN}
 
 #
 # Email Address Validator
@@ -40,6 +52,8 @@ liferay.one.email.address.validator.liferay.domains=bp.liferay.com,connect.lifer
 liferay-one-etc-spring-boot-oahs.oauth2.headless.server.client.secret=${LIFERAY_ONE_ETC_SPRING_BOOT_OAHS_CLIENT_SECRET:myfancypassword}
 
 liferay.oauth.application.external.reference.codes=\
+    external-ssa,\
+    external-trial,\
     liferay-one-etc-spring-boot-oahs,\
     liferay-one-etc-spring-boot-oaua
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90604

## What is being fixed

liferay-one had no backend to provision the 7-day SaaS trial or to expire it once the window closes. The provisioning logic existed only in the marketplace codebase, and there was no scheduled job to end trials after seven days (AC4).

## How it is being fixed

This ports the 7-day SaaS trial provisioning into the `liferay-one-etc-spring-boot` client extension and adds a dedicated cron client extension for expiry.

The `liferay-one-etc-spring-boot` change adds a `TrialRestController` exposing availability, domain availability, provisioning, extension, expiry, and deletion, backed by a new `ConsoleService` that talks to the external trial console, plus the supporting `CommerceOrderConstants` and additions to `CommerceOrderService` and `UserAccountService`.

The new `liferay-one-etc-cron` client extension is a Spring Boot command-line runner that runs on a schedule and expires trials whose seven-day window has elapsed, closing the AC4 gap.
