### PR TITLE
LPD-90491 Add article structure and categories

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/data-definitions/announcement.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/data-definitions/announcement.json
@@ -6,7 +6,8 @@
 	"dataDefinitionFields": [
 		{
 			"customProperties": {
-				"dataType": "string"
+				"dataType": "string",
+				"fieldReference": "content"
 			},
 			"defaultValue": {
 				"en_US": ""
@@ -18,6 +19,114 @@
 			},
 			"localizable": true,
 			"name": "content",
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"fieldReference": "button",
+				"rows": [
+					{
+						"columns": [
+							{
+								"fields": [
+									"buttonText"
+								],
+								"size": 12
+							}
+						]
+					},
+					{
+						"columns": [
+							{
+								"fields": [
+									"buttonURL"
+								],
+								"size": 12
+							}
+						]
+					}
+				]
+			},
+			"fieldType": "fieldset",
+			"label": {
+				"en_US": "Button"
+			},
+			"localizable": false,
+			"name": "button",
+			"nestedDataDefinitionFields": [
+				{
+					"customProperties": {
+						"dataType": "string",
+						"fieldReference": "buttonText"
+					},
+					"defaultValue": {
+						"en_US": ""
+					},
+					"fieldType": "text",
+					"indexType": "keyword",
+					"label": {
+						"en_US": "Button Text"
+					},
+					"localizable": true,
+					"name": "buttonText",
+					"readOnly": false,
+					"repeatable": false,
+					"required": false,
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					}
+				},
+				{
+					"customProperties": {
+						"dataType": "string",
+						"fieldReference": "buttonURL"
+					},
+					"defaultValue": {
+						"en_US": ""
+					},
+					"fieldType": "text",
+					"indexType": "keyword",
+					"label": {
+						"en_US": "Button URL"
+					},
+					"localizable": true,
+					"name": "buttonURL",
+					"readOnly": false,
+					"repeatable": false,
+					"required": false,
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					}
+				}
+			],
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldReference": "category"
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Category"
+			},
+			"localizable": false,
+			"name": "category",
 			"readOnly": false,
 			"repeatable": false,
 			"required": false,
@@ -38,6 +147,26 @@
 								"columnSize": 12,
 								"fieldNames": [
 									"content"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"button"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"category"
 								]
 							}
 						]

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/data-definitions/article.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/data-definitions/article.json
@@ -1,0 +1,98 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldReference": "content"
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "rich_text",
+			"indexType": "text",
+			"label": {
+				"en_US": "Content"
+			},
+			"localizable": true,
+			"name": "content",
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		},
+		{
+			"customProperties": {
+				"dataType": "string",
+				"fieldReference": "category"
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "text",
+			"indexType": "keyword",
+			"label": {
+				"en_US": "Category"
+			},
+			"localizable": false,
+			"name": "category",
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"dataDefinitionKey": "ARTICLE",
+	"defaultDataLayout": {
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"content"
+								]
+							}
+						]
+					},
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"category"
+								]
+							}
+						]
+					}
+				],
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"name": {
+			"en_US": "Article"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+		"en_US": ""
+	},
+	"name": {
+		"en_US": "Article"
+	},
+	"storageType": "default"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/administration.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/administration.json
@@ -1,0 +1,18 @@
+{
+	"description": "Administration",
+	"description_i18n": {
+		"en_US": "Administration",
+		"es_ES": "Administración",
+		"ja_JP": "管理部門",
+		"pt_BR": "Administração"
+	},
+	"externalReferenceCode": "T_AC_ADMINISTRATION",
+	"name": "Administration",
+	"name_i18n": {
+		"en_US": "Administration",
+		"es_ES": "Administración",
+		"ja_JP": "管理部門",
+		"pt_BR": "Administração"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/cloud-activation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/cloud-activation.json
@@ -1,0 +1,18 @@
+{
+	"description": "Cloud Activation",
+	"description_i18n": {
+		"en_US": "Cloud Activation",
+		"es_ES": "Activación de Cloud",
+		"ja_JP": "クラウドアクティベーション",
+		"pt_BR": "Ativação de Cloud"
+	},
+	"externalReferenceCode": "T_AC_CLOUD_ACTIVATION",
+	"name": "Cloud Activation",
+	"name_i18n": {
+		"en_US": "Cloud Activation",
+		"es_ES": "Activación de Cloud",
+		"ja_JP": "クラウドアクティベーション",
+		"pt_BR": "Ativação de Cloud"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/dxp-activation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/dxp-activation.json
@@ -1,0 +1,18 @@
+{
+	"description": "DXP Activation",
+	"description_i18n": {
+		"en_US": "DXP Activation",
+		"es_ES": "Activación de DXP",
+		"ja_JP": "DXPアクティベーション",
+		"pt_BR": "Ativação do DXP"
+	},
+	"externalReferenceCode": "T_AC_DXP_ACTIVATION",
+	"name": "DXP Activation",
+	"name_i18n": {
+		"en_US": "DXP Activation",
+		"es_ES": "Activación de DXP",
+		"ja_JP": "DXPアクティベーション",
+		"pt_BR": "Ativação do DXP"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started.json
@@ -1,0 +1,18 @@
+{
+	"description": "<p>Whether you are part of a brand new project which is just starting or you are now joining an already existing project, this article is for you! Follow along to learn how to access, activate and make the most of your Liferay Support resources.</p>",
+	"description_i18n": {
+		"en_US": "<p>Whether you are part of a brand new project which is just starting or you are now joining an already existing project, this article is for you! Follow along to learn how to access, activate and make the most of your Liferay Support resources.</p>",
+		"es_ES": "<p>Tanto si eres parte de un proyecto que acaba de empezar como si te has unido a uno ya existente, este artículo es para ti. Continúa para saber cómo acceder, activar y sacar lo máximo de los recursos de Soporte de Liferay.</p>",
+		"ja_JP": "<p>開始したばかりの新しいプロジェクトに参加している方も、既存のプロジェクトに参加している方も、こちらの記事をぜひご覧ください。Liferayサポートリソースへのアクセス、アクティベーション、ベストな活用方法などをご紹介します。</p>",
+		"pt_BR": "<p>Quer você esteja participando de um projeto totalmente novo que está apenas começando, ou esteja ingressando agora em um projeto já existente, este artigo é para você! Acompanhe para aprender como acessar, ativar e aproveitar ao máximo os seus recursos do Liferay Support.</p>"
+	},
+	"externalReferenceCode": "T_AC_GETTING_STARTED",
+	"name": "Getting Started",
+	"name_i18n": {
+		"en_US": "Getting Started",
+		"es_ES": "Cómo empezar",
+		"ja_JP": "はじめに",
+		"pt_BR": "Primeiros passos"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/admin.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/admin.json
@@ -1,0 +1,18 @@
+{
+	"description": "Admin",
+	"description_i18n": {
+		"en_US": "Admin",
+		"es_ES": "Administración",
+		"ja_JP": "管理者",
+		"pt_BR": "Administração"
+	},
+	"externalReferenceCode": "T_AC_ADMIN",
+	"name": "Admin",
+	"name_i18n": {
+		"en_US": "Admin",
+		"es_ES": "Administración",
+		"ja_JP": "管理者",
+		"pt_BR": "Administração"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/new-users.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/new-users.json
@@ -1,0 +1,18 @@
+{
+	"description": "New Users",
+	"description_i18n": {
+		"en_US": "New Users",
+		"es_ES": "Nuevos usuarios",
+		"ja_JP": "新規ユーザー",
+		"pt_BR": "Novos Usuários"
+	},
+	"externalReferenceCode": "T_AC_NEW_USERS",
+	"name": "New Users",
+	"name_i18n": {
+		"en_US": "New Users",
+		"es_ES": "Nuevos usuarios",
+		"ja_JP": "新規ユーザー",
+		"pt_BR": "Novos Usuários"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/partners.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/getting-started/partners.json
@@ -1,0 +1,18 @@
+{
+	"description": "Partners",
+	"description_i18n": {
+		"en_US": "Partners",
+		"es_ES": "Partners",
+		"ja_JP": "パートナー",
+		"pt_BR": "Partners"
+	},
+	"externalReferenceCode": "T_AC_PARTNERS",
+	"name": "Partners",
+	"name_i18n": {
+		"en_US": "Partners",
+		"es_ES": "Partners",
+		"ja_JP": "パートナー",
+		"pt_BR": "Partners"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/team-members.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/customer-portal-help/team-members.json
@@ -1,0 +1,18 @@
+{
+	"description": "Team Members",
+	"description_i18n": {
+		"en_US": "Team Members",
+		"es_ES": "Miembros del equipo",
+		"ja_JP": "チームメンバー",
+		"pt_BR": "Membros da equipe"
+	},
+	"externalReferenceCode": "T_AC_TEAM_MEMBERS",
+	"name": "Team Members",
+	"name_i18n": {
+		"en_US": "Team Members",
+		"es_ES": "Miembros del equipo",
+		"ja_JP": "チームメンバー",
+		"pt_BR": "Membros da equipe"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/liferay-enterprise-search.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/liferay-enterprise-search.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Enterprise Search",
+	"description_i18n": {
+		"en_US": "Liferay Enterprise Search",
+		"es_ES": "Liferay Enterprise Search",
+		"ja_JP": "Liferay エンタープライズサーチ",
+		"pt_BR": "Liferay Enterprise Search"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_ENTERPRISE_SEARCH",
+	"name": "Liferay Enterprise Search",
+	"name_i18n": {
+		"en_US": "Liferay Enterprise Search",
+		"es_ES": "Liferay Enterprise Search",
+		"ja_JP": "Liferay エンタープライズサーチ",
+		"pt_BR": "Liferay Enterprise Search"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes.json
@@ -1,0 +1,18 @@
+{
+	"description": "Release Notes",
+	"description_i18n": {
+		"en_US": "Release Notes",
+		"es_ES": "Notas de las actualizaciones",
+		"ja_JP": "リリースノート",
+		"pt_BR": "Notas de versão"
+	},
+	"externalReferenceCode": "T_AC_RELEASE_NOTES",
+	"name": "Release Notes",
+	"name_i18n": {
+		"en_US": "Release Notes",
+		"es_ES": "Notas de las actualizaciones",
+		"ja_JP": "リリースノート",
+		"pt_BR": "Notas de versão"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-analytics-cloud.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-analytics-cloud.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Analytics Cloud",
+	"description_i18n": {
+		"en_US": "Liferay Analytics Cloud",
+		"es_ES": "Liferay Analytics Cloud",
+		"ja_JP": "Liferay Analytics Cloud",
+		"pt_BR": "Liferay Analytics Cloud"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_ANALYTICS_CLOUD",
+	"name": "Liferay Analytics Cloud",
+	"name_i18n": {
+		"en_US": "Liferay Analytics Cloud",
+		"es_ES": "Liferay Analytics Cloud",
+		"ja_JP": "Liferay Analytics Cloud",
+		"pt_BR": "Liferay Analytics Cloud"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-analytics-cloud/analytics-cloud-product-changelog.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-analytics-cloud/analytics-cloud-product-changelog.json
@@ -1,0 +1,18 @@
+{
+	"description": "Analytics Cloud - Product Changelog",
+	"description_i18n": {
+		"en_US": "Analytics Cloud - Product Changelog",
+		"es_ES": "Analytics Cloud - Histórico de Actualizaciones",
+		"ja_JP": "Analytics Cloud - 製品チェンジログ",
+		"pt_BR": "Analytics Cloud - Histórico de Atualizações"
+	},
+	"externalReferenceCode": "T_AC_ANALYTICS_CLOUD_PRODUCT_CHANGELOG",
+	"name": "Analytics Cloud - Product Changelog",
+	"name_i18n": {
+		"en_US": "Analytics Cloud - Product Changelog",
+		"es_ES": "Analytics Cloud - Histórico de Actualizaciones",
+		"ja_JP": "Analytics Cloud - 製品チェンジログ",
+		"pt_BR": "Analytics Cloud - Histórico de Atualizações"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Cloud Infrastructure",
+	"description_i18n": {
+		"en_US": "Liferay Cloud Infrastructure",
+		"es_ES": "Infraestructura de Liferay Cloud",
+		"ja_JP": "Liferay クラウドインフラストラクチャ",
+		"pt_BR": "Infraestrutura do Liferay Cloud"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_CLOUD_INFRASTRUCTURE",
+	"name": "Liferay Cloud Infrastructure",
+	"name_i18n": {
+		"en_US": "Liferay Cloud Infrastructure",
+		"es_ES": "Infraestructura de Liferay Cloud",
+		"ja_JP": "Liferay クラウドインフラストラクチャ",
+		"pt_BR": "Infraestrutura do Liferay Cloud"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure/platform-changelog.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure/platform-changelog.json
@@ -1,0 +1,18 @@
+{
+	"description": "Platform Changelog",
+	"description_i18n": {
+		"en_US": "Platform Changelog",
+		"es_ES": "Registro de cambios en la plataforma",
+		"ja_JP": "プラットフォームチェンジログ",
+		"pt_BR": "Registro de Alterações da Plataforma"
+	},
+	"externalReferenceCode": "T_AC_PLATFORM_CHANGELOG",
+	"name": "Platform Changelog",
+	"name_i18n": {
+		"en_US": "Platform Changelog",
+		"es_ES": "Registro de cambios en la plataforma",
+		"ja_JP": "プラットフォームチェンジログ",
+		"pt_BR": "Registro de Alterações da Plataforma"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure/services-changelog.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/release-notes/liferay-cloud-infrastructure/services-changelog.json
@@ -1,0 +1,18 @@
+{
+	"description": "Services Changelog",
+	"description_i18n": {
+		"en_US": "Services Changelog",
+		"es_ES": "Registro de cambios en los servicios",
+		"ja_JP": "サービスチェンジログ",
+		"pt_BR": "Registro de Alterações dos Serviços"
+	},
+	"externalReferenceCode": "T_AC_SERVICES_CHANGELOG",
+	"name": "Services Changelog",
+	"name_i18n": {
+		"en_US": "Services Changelog",
+		"es_ES": "Registro de cambios en los servicios",
+		"ja_JP": "サービスチェンジログ",
+		"pt_BR": "Registro de Alterações dos Serviços"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/security.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/security.json
@@ -1,0 +1,18 @@
+{
+	"description": "Security",
+	"description_i18n": {
+		"en_US": "Security",
+		"es_ES": "Seguridad",
+		"ja_JP": "セキュリティ",
+		"pt_BR": "Segurança"
+	},
+	"externalReferenceCode": "T_AC_SECURITY",
+	"name": "Security",
+	"name_i18n": {
+		"en_US": "Security",
+		"es_ES": "Seguridad",
+		"ja_JP": "セキュリティ",
+		"pt_BR": "Segurança"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/security/security-alert.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/security/security-alert.json
@@ -1,0 +1,18 @@
+{
+	"description": "Security Alert",
+	"description_i18n": {
+		"en_US": "Security Alert",
+		"es_ES": "Alerta de seguridad",
+		"ja_JP": "セキュリティアラート",
+		"pt_BR": "Alerta de Segurança"
+	},
+	"externalReferenceCode": "T_AC_SECURITY_ALERT",
+	"name": "Security Alert",
+	"name_i18n": {
+		"en_US": "Security Alert",
+		"es_ES": "Alerta de seguridad",
+		"ja_JP": "セキュリティアラート",
+		"pt_BR": "Alerta de Segurança"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility.json
@@ -1,0 +1,18 @@
+{
+	"description": "Services and Compatibility",
+	"description_i18n": {
+		"en_US": "Services and Compatibility",
+		"es_ES": "Servicios y compatibilidad",
+		"ja_JP": "サービスと互換性",
+		"pt_BR": "Serviços e Compatibilidade"
+	},
+	"externalReferenceCode": "T_AC_SERVICES_AND_COMPATIBILITY",
+	"name": "Services and Compatibility",
+	"name_i18n": {
+		"en_US": "Services and Compatibility",
+		"es_ES": "Servicios y compatibilidad",
+		"ja_JP": "サービスと互換性",
+		"pt_BR": "Serviços e Compatibilidade"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/compatibility-matrix.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/compatibility-matrix.json
@@ -1,0 +1,18 @@
+{
+	"description": "Compatibility Matrix",
+	"description_i18n": {
+		"en_US": "Compatibility Matrix",
+		"es_ES": "Matriz de compatibilidad",
+		"ja_JP": "互換性マトリクス",
+		"pt_BR": "Matriz de compatibilidade"
+	},
+	"externalReferenceCode": "T_AC_COMPATIBILITY_MATRIX",
+	"name": "Compatibility Matrix",
+	"name_i18n": {
+		"en_US": "Compatibility Matrix",
+		"es_ES": "Matriz de compatibilidad",
+		"ja_JP": "互換性マトリクス",
+		"pt_BR": "Matriz de compatibilidade"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/patching-and-release.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/patching-and-release.json
@@ -1,0 +1,18 @@
+{
+	"description": "Patching and Release",
+	"description_i18n": {
+		"en_US": "Patching and Release",
+		"es_ES": "Aplicación de parches y versiones",
+		"ja_JP": "パッチとリリース",
+		"pt_BR": "Aplicação de Patches e Versões"
+	},
+	"externalReferenceCode": "T_AC_PATCHING_AND_RELEASE",
+	"name": "Patching and Release",
+	"name_i18n": {
+		"en_US": "Patching and Release",
+		"es_ES": "Aplicación de parches y versiones",
+		"ja_JP": "パッチとリリース",
+		"pt_BR": "Aplicação de Patches e Versões"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/search-compatibility.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/search-compatibility.json
@@ -1,0 +1,18 @@
+{
+	"description": "Search Compatibility",
+	"description_i18n": {
+		"en_US": "Search Compatibility",
+		"es_ES": "Compatibilidad de búsqueda",
+		"ja_JP": "検索互換性",
+		"pt_BR": "Compatibilidade de Pesquisa"
+	},
+	"externalReferenceCode": "T_AC_SEARCH_COMPATIBILITY",
+	"name": "Search Compatibility",
+	"name_i18n": {
+		"en_US": "Search Compatibility",
+		"es_ES": "Compatibilidad de búsqueda",
+		"ja_JP": "検索互換性",
+		"pt_BR": "Compatibilidade de Pesquisa"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/service-levels.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/service-levels.json
@@ -1,0 +1,18 @@
+{
+	"description": "Service Levels",
+	"description_i18n": {
+		"en_US": "Service Levels",
+		"es_ES": "Niveles de servicio",
+		"ja_JP": "サービスレベル",
+		"pt_BR": "Níveis de serviço"
+	},
+	"externalReferenceCode": "T_AC_SERVICE_LEVELS",
+	"name": "Service Levels",
+	"name_i18n": {
+		"en_US": "Service Levels",
+		"es_ES": "Niveles de servicio",
+		"ja_JP": "サービスレベル",
+		"pt_BR": "Níveis de serviço"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs.json
@@ -1,0 +1,18 @@
+{
+	"description": "Support FAQs",
+	"description_i18n": {
+		"en_US": "Support FAQs",
+		"es_ES": "Preguntas más frecuentes sobre soporte",
+		"ja_JP": "サポートFAQ",
+		"pt_BR": "Perguntas Frequentes sobre Suporte"
+	},
+	"externalReferenceCode": "T_AC_SUPPORT_FAQS",
+	"name": "Support FAQs",
+	"name_i18n": {
+		"en_US": "Support FAQs",
+		"es_ES": "Preguntas más frecuentes sobre soporte",
+		"ja_JP": "サポートFAQ",
+		"pt_BR": "Perguntas Frequentes sobre Suporte"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/before-opening.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/before-opening.json
@@ -1,0 +1,18 @@
+{
+	"description": "Before Opening",
+	"description_i18n": {
+		"en_US": "Before Opening",
+		"es_ES": "Antes de abrir",
+		"ja_JP": "チケットの作成前に",
+		"pt_BR": "Antes de Abrir"
+	},
+	"externalReferenceCode": "T_AC_BEFORE_OPENING",
+	"name": "Before Opening",
+	"name_i18n": {
+		"en_US": "Before Opening",
+		"es_ES": "Antes de abrir",
+		"ja_JP": "チケットの作成前に",
+		"pt_BR": "Antes de Abrir"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/general.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/general.json
@@ -1,0 +1,18 @@
+{
+	"description": "General",
+	"description_i18n": {
+		"en_US": "General",
+		"es_ES": "General",
+		"ja_JP": "全般",
+		"pt_BR": "General"
+	},
+	"externalReferenceCode": "T_AC_GENERAL",
+	"name": "General",
+	"name_i18n": {
+		"en_US": "General",
+		"es_ES": "General",
+		"ja_JP": "全般",
+		"pt_BR": "General"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/product-delivery.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-faqs/product-delivery.json
@@ -1,0 +1,18 @@
+{
+	"description": "Product Delivery",
+	"description_i18n": {
+		"en_US": "Product Delivery",
+		"es_ES": "Entrega de Producto",
+		"ja_JP": "プロダクトデリバリー",
+		"pt_BR": "Entrega do Produto"
+	},
+	"externalReferenceCode": "T_AC_PRODUCT_DELIVERY",
+	"name": "Product Delivery",
+	"name_i18n": {
+		"en_US": "Product Delivery",
+		"es_ES": "Entrega de Producto",
+		"ja_JP": "プロダクトデリバリー",
+		"pt_BR": "Entrega do Produto"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-language-matrix.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/services-and-compatibility/support-language-matrix.json
@@ -1,0 +1,18 @@
+{
+	"description": "Support Language Matrix",
+	"description_i18n": {
+		"en_US": "Support Language Matrix",
+		"es_ES": "Matriz de soporte de idiomas",
+		"ja_JP": "サポート言語のマトリクス",
+		"pt_BR": "Matriz de Idiomas de Suporte"
+	},
+	"externalReferenceCode": "T_AC_SUPPORT_LANGUAGE_MATRIX",
+	"name": "Support Language Matrix",
+	"name_i18n": {
+		"en_US": "Support Language Matrix",
+		"es_ES": "Matriz de soporte de idiomas",
+		"ja_JP": "サポート言語のマトリクス",
+		"pt_BR": "Matriz de Idiomas de Suporte"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage.json
@@ -1,0 +1,18 @@
+{
+	"description": "Support Coverage",
+	"description_i18n": {
+		"en_US": "Support Coverage",
+		"es_ES": "Cobertura de soporte",
+		"ja_JP": "サポート範囲",
+		"pt_BR": "Cobertura de suporte"
+	},
+	"externalReferenceCode": "T_AC_SUPPORT_COVERAGE",
+	"name": "Support Coverage",
+	"name_i18n": {
+		"en_US": "Support Coverage",
+		"es_ES": "Cobertura de soporte",
+		"ja_JP": "サポート範囲",
+		"pt_BR": "Cobertura de suporte"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage.json
@@ -1,0 +1,18 @@
+{
+	"description": "DXP Support Coverage",
+	"description_i18n": {
+		"en_US": "DXP Support Coverage",
+		"es_ES": "Cobertura de soporte DXP",
+		"ja_JP": "DXPのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do DXP"
+	},
+	"externalReferenceCode": "T_AC_DXP_SUPPORT_COVERAGE",
+	"name": "DXP Support Coverage",
+	"name_i18n": {
+		"en_US": "DXP Support Coverage",
+		"es_ES": "Cobertura de soporte DXP",
+		"ja_JP": "DXPのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do DXP"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported.json
@@ -1,0 +1,18 @@
+{
+	"description": "Not Supported",
+	"description_i18n": {
+		"en_US": "Not Supported",
+		"es_ES": "No soportado",
+		"ja_JP": "サポート範囲外",
+		"pt_BR": "Não Suportado"
+	},
+	"externalReferenceCode": "T_AC_NOT_SUPPORTED",
+	"name": "Not Supported",
+	"name_i18n": {
+		"en_US": "Not Supported",
+		"es_ES": "No soportado",
+		"ja_JP": "サポート範囲外",
+		"pt_BR": "Não Suportado"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/architectural-assistance.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/architectural-assistance.json
@@ -1,0 +1,18 @@
+{
+	"description": "Architectural Assistance",
+	"description_i18n": {
+		"en_US": "Architectural Assistance",
+		"es_ES": "Ayuda de arquitectura",
+		"ja_JP": "アーキテクチャのサポート",
+		"pt_BR": "Assistência de Arquitetura"
+	},
+	"externalReferenceCode": "T_AC_ARCHITECTURAL_ASSISTANCE",
+	"name": "Architectural Assistance",
+	"name_i18n": {
+		"en_US": "Architectural Assistance",
+		"es_ES": "Ayuda de arquitectura",
+		"ja_JP": "アーキテクチャのサポート",
+		"pt_BR": "Assistência de Arquitetura"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/beta-feature.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/beta-feature.json
@@ -1,0 +1,18 @@
+{
+	"description": "Beta Feature",
+	"description_i18n": {
+		"en_US": "Beta Feature",
+		"es_ES": "Funcionalidades beta",
+		"ja_JP": "ベータ版機能",
+		"pt_BR": "Recursos Beta"
+	},
+	"externalReferenceCode": "T_AC_BETA_FEATURE",
+	"name": "Beta Feature",
+	"name_i18n": {
+		"en_US": "Beta Feature",
+		"es_ES": "Funcionalidades beta",
+		"ja_JP": "ベータ版機能",
+		"pt_BR": "Recursos Beta"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/code-development.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/code-development.json
@@ -1,0 +1,18 @@
+{
+	"description": "Code Development",
+	"description_i18n": {
+		"en_US": "Code Development",
+		"es_ES": "Desarrollo de código",
+		"ja_JP": "コード開発／API関連事象",
+		"pt_BR": "Desenvolvimento de Código"
+	},
+	"externalReferenceCode": "T_AC_CODE_DEVELOPMENT",
+	"name": "Code Development",
+	"name_i18n": {
+		"en_US": "Code Development",
+		"es_ES": "Desarrollo de código",
+		"ja_JP": "コード開発／API関連事象",
+		"pt_BR": "Desenvolvimento de Código"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/customization.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/customization.json
@@ -1,0 +1,18 @@
+{
+	"description": "Customization",
+	"description_i18n": {
+		"en_US": "Customization",
+		"es_ES": "Personalización",
+		"ja_JP": "カスタマイズ",
+		"pt_BR": "Customização"
+	},
+	"externalReferenceCode": "T_AC_CUSTOMIZATION",
+	"name": "Customization",
+	"name_i18n": {
+		"en_US": "Customization",
+		"es_ES": "Personalización",
+		"ja_JP": "カスタマイズ",
+		"pt_BR": "Customização"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/hardware-and-performance.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/hardware-and-performance.json
@@ -1,0 +1,18 @@
+{
+	"description": "Hardware and Performance",
+	"description_i18n": {
+		"en_US": "Hardware and Performance",
+		"es_ES": "Hardware y rendimiento",
+		"ja_JP": "ハードウェアとパフォーマンス",
+		"pt_BR": "Hardware e Desempenho"
+	},
+	"externalReferenceCode": "T_AC_HARDWARE_AND_PERFORMANCE",
+	"name": "Hardware and Performance",
+	"name_i18n": {
+		"en_US": "Hardware and Performance",
+		"es_ES": "Hardware y rendimiento",
+		"ja_JP": "ハードウェアとパフォーマンス",
+		"pt_BR": "Hardware e Desempenho"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/interoperable-technologies.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/interoperable-technologies.json
@@ -1,0 +1,18 @@
+{
+	"description": "Interoperable Technologies",
+	"description_i18n": {
+		"en_US": "Interoperable Technologies",
+		"es_ES": "Tecnologías interoperables",
+		"ja_JP": "相互運用可能な技術",
+		"pt_BR": "Tecnologias Interoperáveis"
+	},
+	"externalReferenceCode": "T_AC_INTEROPERABLE_TECHNOLOGIES",
+	"name": "Interoperable Technologies",
+	"name_i18n": {
+		"en_US": "Interoperable Technologies",
+		"es_ES": "Tecnologías interoperables",
+		"ja_JP": "相互運用可能な技術",
+		"pt_BR": "Tecnologias Interoperáveis"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/new-feature-implementation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/new-feature-implementation.json
@@ -1,0 +1,18 @@
+{
+	"description": "New Feature Implementation",
+	"description_i18n": {
+		"en_US": "New Feature Implementation",
+		"es_ES": "Implementación de nuevas funcionalidades",
+		"ja_JP": "新機能の実装",
+		"pt_BR": "Implementação de Nova Funcionalidade"
+	},
+	"externalReferenceCode": "T_AC_NEW_FEATURE_IMPLEMENTATION",
+	"name": "New Feature Implementation",
+	"name_i18n": {
+		"en_US": "New Feature Implementation",
+		"es_ES": "Implementación de nuevas funcionalidades",
+		"ja_JP": "新機能の実装",
+		"pt_BR": "Implementação de Nova Funcionalidade"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/third-party-technology.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/not-supported/third-party-technology.json
@@ -1,0 +1,18 @@
+{
+	"description": "Third-Party Technology",
+	"description_i18n": {
+		"en_US": "Third-Party Technology",
+		"es_ES": "Tecnología de terceros",
+		"ja_JP": "サードパーティのテクノロジー",
+		"pt_BR": "Tecnologia de Terceiros"
+	},
+	"externalReferenceCode": "T_AC_THIRDPARTY_TECHNOLOGY",
+	"name": "Third-Party Technology",
+	"name_i18n": {
+		"en_US": "Third-Party Technology",
+		"es_ES": "Tecnología de terceros",
+		"ja_JP": "サードパーティのテクノロジー",
+		"pt_BR": "Tecnologia de Terceiros"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported.json
@@ -1,0 +1,18 @@
+{
+	"description": "Supported",
+	"description_i18n": {
+		"en_US": "Supported",
+		"es_ES": "Soportado",
+		"ja_JP": "サポート範囲",
+		"pt_BR": "Suportado"
+	},
+	"externalReferenceCode": "T_AC_SUPPORTED",
+	"name": "Supported",
+	"name_i18n": {
+		"en_US": "Supported",
+		"es_ES": "Soportado",
+		"ja_JP": "サポート範囲",
+		"pt_BR": "Suportado"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/application-servers.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/application-servers.json
@@ -1,0 +1,18 @@
+{
+	"description": "Application Servers",
+	"description_i18n": {
+		"en_US": "Application Servers",
+		"es_ES": "Servidores de aplicaciones",
+		"ja_JP": "アプリケーション・サーバー",
+		"pt_BR": "Servidores de aplicação"
+	},
+	"externalReferenceCode": "T_AC_APPLICATION_SERVERS",
+	"name": "Application Servers",
+	"name_i18n": {
+		"en_US": "Application Servers",
+		"es_ES": "Servidores de aplicaciones",
+		"ja_JP": "アプリケーション・サーバー",
+		"pt_BR": "Servidores de aplicação"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/configuration.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/configuration.json
@@ -1,0 +1,18 @@
+{
+	"description": "Configuration",
+	"description_i18n": {
+		"en_US": "Configuration",
+		"es_ES": "Configuración",
+		"ja_JP": "構成",
+		"pt_BR": "Configuração"
+	},
+	"externalReferenceCode": "T_AC_CONFIGURATION",
+	"name": "Configuration",
+	"name_i18n": {
+		"en_US": "Configuration",
+		"es_ES": "Configuración",
+		"ja_JP": "構成",
+		"pt_BR": "Configuração"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/databases.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/databases.json
@@ -1,0 +1,18 @@
+{
+	"description": "Databases",
+	"description_i18n": {
+		"en_US": "Databases",
+		"es_ES": "Bases de datos",
+		"ja_JP": "データベース",
+		"pt_BR": "Banco de dados"
+	},
+	"externalReferenceCode": "T_AC_DATABASES",
+	"name": "Databases",
+	"name_i18n": {
+		"en_US": "Databases",
+		"es_ES": "Bases de datos",
+		"ja_JP": "データベース",
+		"pt_BR": "Banco de dados"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/installation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/installation.json
@@ -1,0 +1,18 @@
+{
+	"description": "Installation",
+	"description_i18n": {
+		"en_US": "Installation",
+		"es_ES": "Instalación",
+		"ja_JP": "インストール",
+		"pt_BR": "Instalação"
+	},
+	"externalReferenceCode": "T_AC_INSTALLATION",
+	"name": "Installation",
+	"name_i18n": {
+		"en_US": "Installation",
+		"es_ES": "Instalación",
+		"ja_JP": "インストール",
+		"pt_BR": "Instalação"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/liferay-docker-images.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/liferay-docker-images.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Docker Images",
+	"description_i18n": {
+		"en_US": "Liferay Docker Images",
+		"es_ES": "Imágenes de Docker de Liferay",
+		"ja_JP": "Liferay Dockerイメージ",
+		"pt_BR": "Imagens Docker do Liferay"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_DOCKER_IMAGES",
+	"name": "Liferay Docker Images",
+	"name_i18n": {
+		"en_US": "Liferay Docker Images",
+		"es_ES": "Imágenes de Docker de Liferay",
+		"ja_JP": "Liferay Dockerイメージ",
+		"pt_BR": "Imagens Docker do Liferay"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/liferay-documentation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/liferay-documentation.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Documentation",
+	"description_i18n": {
+		"en_US": "Liferay Documentation",
+		"es_ES": "Documentación de Liferay",
+		"ja_JP": "Liferay ドキュメンテーション",
+		"pt_BR": "Documentação Liferay"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_DOCUMENTATION",
+	"name": "Liferay Documentation",
+	"name_i18n": {
+		"en_US": "Liferay Documentation",
+		"es_ES": "Documentación de Liferay",
+		"ja_JP": "Liferay ドキュメンテーション",
+		"pt_BR": "Documentação Liferay"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/maintenance-mode-and-deprecation.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/maintenance-mode-and-deprecation.json
@@ -1,0 +1,18 @@
+{
+	"description": "Maintenance Mode and Deprecation",
+	"description_i18n": {
+		"en_US": "Maintenance Mode and Deprecation",
+		"es_ES": "Modo de mantenimiento y en desuso",
+		"ja_JP": "メンテナンス・モードと非推奨",
+		"pt_BR": "Modo de Manutenção e Descontinuação"
+	},
+	"externalReferenceCode": "T_AC_MAINTENANCE_MODE_AND_DEPRECATION",
+	"name": "Maintenance Mode and Deprecation",
+	"name_i18n": {
+		"en_US": "Maintenance Mode and Deprecation",
+		"es_ES": "Modo de mantenimiento y en desuso",
+		"ja_JP": "メンテナンス・モードと非推奨",
+		"pt_BR": "Modo de Manutenção e Descontinuação"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/operating-systems.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/operating-systems.json
@@ -1,0 +1,18 @@
+{
+	"description": "Operating Systems",
+	"description_i18n": {
+		"en_US": "Operating Systems",
+		"es_ES": "Sistemas operativos",
+		"ja_JP": "オペレーティング・システム",
+		"pt_BR": "Sistemas Operacionais"
+	},
+	"externalReferenceCode": "T_AC_OPERATING_SYSTEMS",
+	"name": "Operating Systems",
+	"name_i18n": {
+		"en_US": "Operating Systems",
+		"es_ES": "Sistemas operativos",
+		"ja_JP": "オペレーティング・システム",
+		"pt_BR": "Sistemas Operacionais"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/product-defects.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/product-defects.json
@@ -1,0 +1,18 @@
+{
+	"description": "Product Defects",
+	"description_i18n": {
+		"en_US": "Product Defects",
+		"es_ES": "Defectos de producto",
+		"ja_JP": "製品の欠陥",
+		"pt_BR": "Defeitos do Produto"
+	},
+	"externalReferenceCode": "T_AC_PRODUCT_DEFECTS",
+	"name": "Product Defects",
+	"name_i18n": {
+		"en_US": "Product Defects",
+		"es_ES": "Defectos de producto",
+		"ja_JP": "製品の欠陥",
+		"pt_BR": "Defeitos do Produto"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/upgrades.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/upgrades.json
@@ -1,0 +1,18 @@
+{
+	"description": "Upgrades",
+	"description_i18n": {
+		"en_US": "Upgrades",
+		"es_ES": "Migraciones",
+		"ja_JP": "アップグレード",
+		"pt_BR": "Atualizações"
+	},
+	"externalReferenceCode": "T_AC_UPGRADES",
+	"name": "Upgrades",
+	"name_i18n": {
+		"en_US": "Upgrades",
+		"es_ES": "Migraciones",
+		"ja_JP": "アップグレード",
+		"pt_BR": "Atualizações"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/usage.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/dxp-support-coverage/supported/usage.json
@@ -1,0 +1,18 @@
+{
+	"description": "Usage",
+	"description_i18n": {
+		"en_US": "Usage",
+		"es_ES": "Uso",
+		"ja_JP": "使用方法",
+		"pt_BR": "Uso"
+	},
+	"externalReferenceCode": "T_AC_USAGE",
+	"name": "Usage",
+	"name_i18n": {
+		"en_US": "Usage",
+		"es_ES": "Uso",
+		"ja_JP": "使用方法",
+		"pt_BR": "Uso"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/liferay-cloud-platform.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/liferay-cloud-platform.json
@@ -1,0 +1,18 @@
+{
+	"description": "Liferay Cloud Platform",
+	"description_i18n": {
+		"en_US": "Liferay Cloud Platform",
+		"es_ES": "Plataforma de Liferay Cloud",
+		"ja_JP": "Liferay Cloud Platform",
+		"pt_BR": "Plataforma Liferay Cloud"
+	},
+	"externalReferenceCode": "T_AC_LIFERAY_CLOUD_PLATFORM",
+	"name": "Liferay Cloud Platform",
+	"name_i18n": {
+		"en_US": "Liferay Cloud Platform",
+		"es_ES": "Plataforma de Liferay Cloud",
+		"ja_JP": "Liferay Cloud Platform",
+		"pt_BR": "Plataforma Liferay Cloud"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/paas-support-coverage.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/paas-support-coverage.json
@@ -1,0 +1,18 @@
+{
+	"description": "PaaS Support Coverage",
+	"description_i18n": {
+		"en_US": "PaaS Support Coverage",
+		"es_ES": "Cobertura de soporte PaaS",
+		"ja_JP": "PaaSのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do PaaS"
+	},
+	"externalReferenceCode": "T_AC_PAAS_SUPPORT_COVERAGE",
+	"name": "PaaS Support Coverage",
+	"name_i18n": {
+		"en_US": "PaaS Support Coverage",
+		"es_ES": "Cobertura de soporte PaaS",
+		"ja_JP": "PaaSのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do PaaS"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/saas-support-coverage.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-coverage/saas-support-coverage.json
@@ -1,0 +1,18 @@
+{
+	"description": "SaaS Support Coverage",
+	"description_i18n": {
+		"en_US": "SaaS Support Coverage",
+		"es_ES": "Cobertura de soporte SaaS",
+		"ja_JP": "SaaSのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do SaaS"
+	},
+	"externalReferenceCode": "T_AC_SAAS_SUPPORT_COVERAGE",
+	"name": "SaaS Support Coverage",
+	"name_i18n": {
+		"en_US": "SaaS Support Coverage",
+		"es_ES": "Cobertura de soporte SaaS",
+		"ja_JP": "SaaSのサポート範囲",
+		"pt_BR": "Cobertura de Suporte do SaaS"
+	},
+	"viewableBy": "Anyone"
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-policy-knowledge-base.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/taxonomy-vocabularies/group/article-categories/support-policy-knowledge-base.json
@@ -1,0 +1,18 @@
+{
+	"description": "Support Policy Knowledge Base",
+	"description_i18n": {
+		"en_US": "Support Policy Knowledge Base",
+		"es_ES": "Base de conocimiento de la política de soporte",
+		"ja_JP": "サポートポリシー ナレッジベース",
+		"pt_BR": "Base de Conhecimento da Política de Suporte"
+	},
+	"externalReferenceCode": "T_AC_SUPPORT_POLICY_KNOWLEDGE_BASE",
+	"name": "Support Policy Knowledge Base",
+	"name_i18n": {
+		"en_US": "Support Policy Knowledge Base",
+		"es_ES": "Base de conocimiento de la política de soporte",
+		"ja_JP": "サポートポリシー ナレッジベース",
+		"pt_BR": "Base de Conhecimento da Política de Suporte"
+	},
+	"viewableBy": "Anyone"
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90491

## What is being fixed

The One.Liferay site initializer had no content model for migrating the Customer Portal Help knowledge base. It was missing a data definition to back help articles and the taxonomy needed to classify them, so the Support Announcements and Customer Portal Help articles could not be imported into the new site.

## How it is being fixed

Adds an `article` data definition to the site initializer and extends the existing `announcement` data definition to carry the fields the migrated content needs. Introduces an `article-categories` taxonomy vocabulary that reproduces the Customer Portal Help category tree — Customer Portal Help, Release Notes, Security, Services and Compatibility, Support Coverage, and their nested subcategories — so the migrated articles can be filed under the same structure they use today.