### PR TITLE
LPD-97360 Add detached-license entitlement name mapping

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/DetachedLicenseEntitlementNames.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/DetachedLicenseEntitlementNames.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import java.io.InputStream;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class DetachedLicenseEntitlementNames {
+
+	public static String getEntitlementName(String productKey, String sizing) {
+		Map<String, String> entitlementNames = _entitlementNames.get(
+			productKey);
+
+		if (entitlementNames == null) {
+			return null;
+		}
+
+		return entitlementNames.get(_normalizeSizing(sizing));
+	}
+
+	private static String _normalizeSizing(String sizing) {
+		if ((sizing == null) || sizing.isEmpty()) {
+			return "default";
+		}
+
+		if (sizing.startsWith("sizing-")) {
+			return "Sizing " + sizing.substring(7);
+		}
+
+		return sizing;
+	}
+
+	private static final Map<String, Map<String, String>> _entitlementNames;
+
+	static {
+		Yaml yaml = new Yaml();
+
+		try (InputStream inputStream =
+				DetachedLicenseEntitlementNames.class.getResourceAsStream(
+					"/detached-license-entitlement-names.yaml")) {
+
+			Map<String, Map<String, String>> entitlementNames = yaml.load(
+				inputStream);
+
+			_entitlementNames = Collections.unmodifiableMap(entitlementNames);
+		}
+		catch (Exception exception) {
+			throw new ExceptionInInitializerError(exception);
+		}
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/detached-license-entitlement-names.sql
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/detached-license-entitlement-names.sql
@@ -1,0 +1,46 @@
+SELECT
+  d.productKey,
+  IF(d.sizing_norm = '', 'default', d.sizing_norm) AS sizing,
+  TRIM(
+    CONCAT(
+      CASE
+        WHEN d.catalog_name LIKE 'DXP%' THEN 'Liferay Self-Hosted'
+        WHEN d.catalog_name LIKE 'Commerce Subscription%' THEN 'Commerce'
+        WHEN d.catalog_name LIKE 'Portal%'
+          OR d.catalog_name LIKE 'TCAT Portal%'
+          OR d.catalog_name LIKE 'Social Office%' THEN 'Portal'
+        ELSE '(UNKNOWN GROUP)'
+      END,
+      ' ',
+      CASE
+        WHEN d.catalog_name LIKE '%Non-Production%' THEN 'Non-Prod'
+        WHEN d.catalog_name LIKE '%Production%' THEN 'Prod'
+        WHEN d.catalog_name LIKE '%Backup%' THEN 'Backup'
+        WHEN d.catalog_name LIKE '%Develop%' THEN 'Dev'
+        WHEN d.catalog_name LIKE '%OEM%' THEN 'OEM'
+        WHEN d.catalog_name LIKE '%Enterprise%' THEN 'Enterprise'
+        WHEN d.catalog_name LIKE '%Limited%' THEN 'Limited'
+        WHEN d.catalog_name LIKE '%Flex%' THEN 'Flex'
+        ELSE ''
+      END,
+      IF(d.sizing_norm = '', '', CONCAT(' ', d.sizing_norm))
+    )
+  ) AS entitlementName
+FROM (
+  SELECT
+    lk.productKey,
+    CASE
+      WHEN lk.sizing IS NULL OR lk.sizing = '' THEN ''
+      WHEN lk.sizing LIKE 'sizing-%' THEN CONCAT('Sizing ', SUBSTRING(lk.sizing, 8))
+      ELSE lk.sizing
+    END AS sizing_norm,
+    (
+      SELECT MIN(le.name)
+      FROM Provisioning_LicenseEntry le
+      WHERE le.productKey = lk.productKey
+    ) AS catalog_name
+  FROM Provisioning_LicenseKey lk
+  WHERE lk.productPurchaseKey IS NULL AND lk.productKey IS NOT NULL
+  GROUP BY lk.productKey, sizing_norm
+) d
+ORDER BY d.productKey, d.sizing_norm;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/detached-license-entitlement-names.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/detached-license-entitlement-names.yaml
@@ -1,0 +1,104 @@
+KOR-36115:
+    default: Portal
+KOR-36125:
+    Sizing 1: Portal Backup Sizing 1
+    default: Portal Backup
+KOR-36134:
+    Sizing 1: Portal Non-Prod Sizing 1
+    Sizing 3: Portal Non-Prod Sizing 3
+    Sizing 4: Portal Non-Prod Sizing 4
+    default: Portal Non-Prod
+KOR-36143:
+    Sizing 1: Portal Prod Sizing 1
+    Sizing 2: Portal Prod Sizing 2
+    Sizing 3: Portal Prod Sizing 3
+    Sizing 4: Portal Prod Sizing 4
+    default: Portal Prod
+KOR-36152:
+    Sizing 1: Portal Dev Sizing 1
+    Sizing 4: Portal Dev Sizing 4
+    default: Portal Dev
+KOR-36154:
+    Sizing 1: Portal OEM Sizing 1
+    Sizing 4: Portal OEM Sizing 4
+    default: Portal OEM
+KOR-36156:
+    Sizing 1: Portal Enterprise Sizing 1
+    Sizing 3: Portal Enterprise Sizing 3
+    Sizing 4: Portal Enterprise Sizing 4
+    default: Portal Enterprise
+KOR-36166:
+    default: Portal Prod
+KOR-36170:
+    default: Portal Non-Prod
+KOR-36174:
+    default: Portal Backup
+KOR-36180:
+    default: Portal Limited
+KOR-36183:
+    Sizing 3: Portal Prod Sizing 3
+    default: Portal Prod
+KOR-36187:
+    Sizing 3: Portal Non-Prod Sizing 3
+    default: Portal Non-Prod
+KOR-36191:
+    default: Portal Backup
+KOR-36198:
+    default: Portal Non-Prod
+KOR-36302:
+    Sizing 1: Portal Non-Prod Sizing 1
+KOR-36327:
+    Sizing 1: Liferay Self-Hosted Backup Sizing 1
+    Sizing 2: Liferay Self-Hosted Backup Sizing 2
+    Sizing 3: Liferay Self-Hosted Backup Sizing 3
+    Sizing 4: Liferay Self-Hosted Backup Sizing 4
+    default: Liferay Self-Hosted Backup
+KOR-36333:
+    Sizing 1: Liferay Self-Hosted Dev Sizing 1
+    Sizing 2: Liferay Self-Hosted Dev Sizing 2
+    Sizing 3: Liferay Self-Hosted Dev Sizing 3
+    Sizing 4: Liferay Self-Hosted Dev Sizing 4
+    default: Liferay Self-Hosted Dev
+KOR-36335:
+    Sizing 1: Liferay Self-Hosted Enterprise Sizing 1
+    Sizing 3: Liferay Self-Hosted Enterprise Sizing 3
+    Sizing 4: Liferay Self-Hosted Enterprise Sizing 4
+    default: Liferay Self-Hosted Enterprise
+KOR-36343:
+    Sizing 1: Liferay Self-Hosted Limited Sizing 1
+    default: Liferay Self-Hosted Limited
+KOR-36346:
+    Sizing 1: Liferay Self-Hosted Non-Prod Sizing 1
+    Sizing 2: Liferay Self-Hosted Non-Prod Sizing 2
+    Sizing 3: Liferay Self-Hosted Non-Prod Sizing 3
+    Sizing 4: Liferay Self-Hosted Non-Prod Sizing 4
+    default: Liferay Self-Hosted Non-Prod
+KOR-36352:
+    Sizing 1: Liferay Self-Hosted OEM Sizing 1
+    Sizing 4: Liferay Self-Hosted OEM Sizing 4
+    default: Liferay Self-Hosted OEM
+KOR-36354:
+    Sizing 1: Liferay Self-Hosted Prod Sizing 1
+    Sizing 2: Liferay Self-Hosted Prod Sizing 2
+    Sizing 3: Liferay Self-Hosted Prod Sizing 3
+    Sizing 4: Liferay Self-Hosted Prod Sizing 4
+    default: Liferay Self-Hosted Prod
+KOR-36385:
+    Sizing 1: Commerce Backup Sizing 1
+KOR-36394:
+    Sizing 1: Commerce Non-Prod Sizing 1
+    Sizing 4: Commerce Non-Prod Sizing 4
+    default: Commerce Non-Prod
+KOR-36403:
+    Sizing 1: Commerce Prod Sizing 1
+    default: Commerce Prod
+KOR-36572:
+    Sizing 1: Commerce Enterprise Sizing 1
+    default: Commerce Enterprise
+KOR-36574:
+    Sizing 1: Liferay Self-Hosted Flex Sizing 1
+KOR-36580:
+    Sizing 1: Commerce Dev Sizing 1
+    Sizing 2: Commerce Dev Sizing 2
+    Sizing 4: Commerce Dev Sizing 4
+    default: Commerce Dev

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/DetachedLicenseEntitlementNamesTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/DetachedLicenseEntitlementNamesTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class DetachedLicenseEntitlementNamesTest {
+
+	@Test
+	public void testGetEntitlementNameWithLegacySizingEncoding() {
+		Assertions.assertEquals(
+			"Liferay Self-Hosted Prod Sizing 2",
+			DetachedLicenseEntitlementNames.getEntitlementName(
+				"KOR-36354", "sizing-2"));
+	}
+
+	@Test
+	public void testGetEntitlementNameWithNullSizing() {
+		Assertions.assertEquals(
+			"Liferay Self-Hosted Prod",
+			DetachedLicenseEntitlementNames.getEntitlementName(
+				"KOR-36354", null));
+	}
+
+	@Test
+	public void testGetEntitlementNameWithSizing() {
+		Assertions.assertEquals(
+			"Liferay Self-Hosted Prod Sizing 2",
+			DetachedLicenseEntitlementNames.getEntitlementName(
+				"KOR-36354", "Sizing 2"));
+	}
+
+	@Test
+	public void testGetEntitlementNameWithUnknownProductKey() {
+		Assertions.assertNull(
+			DetachedLicenseEntitlementNames.getEntitlementName(
+				"KOR-00000", null));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97360

## What is being fixed

Detached license keys — `Provisioning_LicenseKey` rows with a null `productPurchaseKey` (162,446 of 233,948 rows in production) — have no purchase chain for the LPD-89266 data migration to follow, so it cannot resolve their entitlement the normal way (`productPurchaseKey` → `ProductPurchase` → `Entitlement`). This defines the fallback lookup the migration uses for those rows.

## How it is being fixed

Adds a `(productKey, sizing) → entitlementName` lookup for detached licenses:

- `detached-license-entitlement-names.yaml` — the mapping data. Keyed by the 29 distinct non-null `productKey`s found on detached rows in production, each with a `default` entry (licenses with no sizing) plus one entry per `sizing` tier that actually occurs.
- `detached-license-entitlement-names.sql` — the generator. The YAML is produced from a production Provisioning dump by this query; rerun it to regenerate against a fresh dump.
- `DetachedLicenseEntitlementNames` — loads the YAML and resolves `(productKey, sizing)`, normalizing the two sizing encodings (`Sizing 1` / `sizing-1`) and treating no-sizing as `default`.
- A unit test covers loading plus the default / sizing / legacy-encoding / unknown-key cases.

## Needs review (Amos)

The entitlement-name **values are proposed** — derived by rule from the `Provisioning_LicenseEntry` catalog names, pending stakeholder sign-off. Confirmed so far: DXP → `Liferay Self-Hosted`, and `Prod` / `Non-Prod`. Still open: the group names for Portal / TCAT Portal / Social Office / Commerce, the environment abbreviations beyond Prod/Non-Prod, and whether the authoritative names should come from the Salesforce product catalog. Please redline the YAML values.

Out of scope: 2,452 detached rows with a null `productKey` (marketplace-app licenses + legacy core Portal licenses keyed only by `licenseEntryName`).
