### PR TITLE
LPD-92999 Hide Help & Support tab when an app has no support details

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/components/HelpSupportCard/HelpSupportCard.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/components/HelpSupportCard/HelpSupportCard.tsx
@@ -3,58 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import i18n, {Word} from '~/i18n';
+import i18n from '~/i18n';
 
 import DetailsCard from '../DetailsCard/DetailsCard';
+import {SUPPORT_LINKS} from '../../utils/constants';
 
 import type {DeliveryProductSpecification} from '~/types/product';
 
 type HelpSupportCardProps = {
 	specifications: DeliveryProductSpecification[];
 };
-
-type SupportLink = {
-	href: (value: string) => string;
-	label: Word;
-	specificationKey: string;
-};
-
-function withProtocol(value: string): string {
-	return /^https?:\/\//.test(value) ? value : `https://${value}`;
-}
-
-const SUPPORT_LINKS: SupportLink[] = [
-	{
-		href: withProtocol,
-		label: 'support-url',
-		specificationKey: 'support-url',
-	},
-	{
-		href: withProtocol,
-		label: 'publisher-website',
-		specificationKey: 'publisher-web-site-url',
-	},
-	{
-		href: (value) => `mailto:${value}`,
-		label: 'support-email-address',
-		specificationKey: 'support-email-address',
-	},
-	{
-		href: (value) => `tel:${value.replace(/\s/g, '')}`,
-		label: 'support-phone-number',
-		specificationKey: 'support-phone',
-	},
-	{
-		href: withProtocol,
-		label: 'app-usage-terms-eula-url',
-		specificationKey: 'app-usage-terms-url',
-	},
-	{
-		href: withProtocol,
-		label: 'app-documentation-url',
-		specificationKey: 'app-documentation-url',
-	},
-];
 
 export default function HelpSupportCard({
 	specifications,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
@@ -40,14 +40,52 @@ export const STATUS_DOT_COLORS: {[key: string]: string} = {
 	processing: 'var(--color-warning)',
 };
 
-export const SUPPORT_SPECIFICATION_KEYS = [
-	'app-documentation-url',
-	'app-usage-terms-url',
-	'publisher-web-site-url',
-	'support-email-address',
-	'support-phone',
-	'support-url',
+export type SupportLink = {
+	href: (value: string) => string;
+	label: Word;
+	specificationKey: string;
+};
+
+function withProtocol(value: string): string {
+	return /^https?:\/\//.test(value) ? value : `https://${value}`;
+}
+
+export const SUPPORT_LINKS: SupportLink[] = [
+	{
+		href: withProtocol,
+		label: 'support-url',
+		specificationKey: 'support-url',
+	},
+	{
+		href: withProtocol,
+		label: 'publisher-website',
+		specificationKey: 'publisher-web-site-url',
+	},
+	{
+		href: (value) => `mailto:${value}`,
+		label: 'support-email-address',
+		specificationKey: 'support-email-address',
+	},
+	{
+		href: (value) => `tel:${value.replace(/\s/g, '')}`,
+		label: 'support-phone-number',
+		specificationKey: 'support-phone',
+	},
+	{
+		href: withProtocol,
+		label: 'app-usage-terms-eula-url',
+		specificationKey: 'app-usage-terms-url',
+	},
+	{
+		href: withProtocol,
+		label: 'app-documentation-url',
+		specificationKey: 'app-documentation-url',
+	},
 ];
+
+export const SUPPORT_SPECIFICATION_KEYS = SUPPORT_LINKS.map(
+	(link) => link.specificationKey
+);
 
 export const TAB_VISIBILITY: Partial<Record<OrderTypes, ProjectTabKey[]>> = {
 	ADDONS: ['details', 'orders'],

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
@@ -40,6 +40,15 @@ export const STATUS_DOT_COLORS: {[key: string]: string} = {
 	processing: 'var(--color-warning)',
 };
 
+export const SUPPORT_SPECIFICATION_KEYS = [
+	'app-documentation-url',
+	'app-usage-terms-url',
+	'publisher-web-site-url',
+	'support-email-address',
+	'support-phone',
+	'support-url',
+];
+
 export const TAB_VISIBILITY: Partial<Record<OrderTypes, ProjectTabKey[]>> = {
 	ADDONS: ['details', 'orders'],
 	AI_HUB: ['details', 'activation', 'orders'],

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/getVisibleProjectTabKeys.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/getVisibleProjectTabKeys.ts
@@ -3,9 +3,16 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {getSpecificationValues} from '~/hooks/useProjectCommerce';
+import {
+	getSpecificationValue,
+	getSpecificationValues,
+} from '~/hooks/useProjectCommerce';
 
-import {PROJECT_TAB_ORDER, TAB_VISIBILITY} from './constants';
+import {
+	PROJECT_TAB_ORDER,
+	SUPPORT_SPECIFICATION_KEYS,
+	TAB_VISIBILITY,
+} from './constants';
 
 import type {OrderTypes} from '~/types/orders';
 import type {DeliveryProduct} from '~/types/product';
@@ -68,7 +75,22 @@ export function getVisibleProjectTabKeys({
 		(resolvedOrderType && TAB_VISIBILITY[resolvedOrderType]) ??
 		FALLBACK_TABS[kind];
 
-	return PROJECT_TAB_ORDER.filter((tabKey) => allowedTabs.includes(tabKey));
+	return PROJECT_TAB_ORDER.filter((tabKey) => {
+		if (!allowedTabs.includes(tabKey)) {
+			return false;
+		}
+
+		if (tabKey === 'help-and-support') {
+			return (
+				!!product &&
+				SUPPORT_SPECIFICATION_KEYS.some((specificationKey) =>
+					getSpecificationValue(product, specificationKey)
+				)
+			);
+		}
+
+		return true;
+	});
 }
 
 export default getVisibleProjectTabKeys;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92999

## What is being fixed

The Help & Support tab on the /my-account application detail page already matches the spec — six support links driven by product specifications, application-only visibility, and the required tab order — but it rendered an empty card when the application carried none of the support specifications. The old marketplace customer dashboard hid the Support tab entirely in that case.

## How it is being fixed

getVisibleProjectTabKeys now drops the help-and-support tab when the product has a value for none of the six support specification keys, restoring the old marketplace behavior. The keys are also single-sourced: SUPPORT_LINKS (labels, href builders, and specification keys) moved into the shared Projects constants, HelpSupportCard renders from it, and SUPPORT_SPECIFICATION_KEYS is derived from the same list so the visibility check and the rendered rows cannot drift apart.

**pr-check: PASS** — tested on `5ff80f605d6d37a56936d02c733f9e366c0a713c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "5ff80f605d6d37a56936d02c733f9e366c0a713c"} -->
