### PR TITLE
LPD-89413 Fix capitalization in hero banner

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/layouts/01_home/page-definition.json
@@ -149,10 +149,10 @@
 																		},
 																		"text": {
 																			"value_i18n": {
-																				"en_US": "Marketplace, Support, Projects and Account unified into one experience. Browse the catalogue freely or manage your Account.",
-																				"es_ES": "Marketplace, Soporte, Proyectos y Cuenta unificados en una sola experiencia. Explora el catálogo libremente o gestiona tu Cuenta.",
+																				"en_US": "Marketplace, Support, Projects and Account unified into one experience. Browse the catalog freely or manage your account.",
+																				"es_ES": "Marketplace, Soporte, Proyectos y Cuenta unificados en una sola experiencia. Explora el catálogo libremente o gestiona tu cuenta.",
 																				"ja_JP": "Marketplace、サポート、プロジェクト、アカウントをひとつの体験に統合。カタログを自由に閲覧、またはアカウントを管理できます。",
-																				"pt_BR": "Marketplace, Suporte, Projetos e Conta unificados em uma única experiência. Explore o catálogo livremente ou gerencie sua Conta."
+																				"pt_BR": "Marketplace, Suporte, Projetos e Conta unificados em uma única experiência. Explore o catálogo livremente ou gerencie sua conta."
 																			}
 																		}
 																	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89413

## What is being fixed

The home page hero banner subtitle capitalized "Account" mid-sentence across the English, Spanish, and Portuguese translations ("manage your Account", "gestiona tu Cuenta", "gerencie sua Conta"). In that clause the word is a common noun, so the uppercase was incorrect.

## How it is being fixed

Lowercased the word in the "manage your account" clause of the hero banner subtitle in the `01_home` site-initializer page definition for en_US, es_ES, and pt_BR. The ja_JP translation is unaffected.