### PR TITLE
LPD-97363 Port LicenseKey validators and exception types

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
@@ -7,6 +7,9 @@ package com.liferay.one;
 
 import com.liferay.client.extension.util.spring.boot3.BaseRestController;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.exception.LicenseKeyActiveException;
+import com.liferay.one.exception.LicenseKeyValidationException;
+import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.jira.exception.AccountNotFoundException;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
@@ -52,6 +55,36 @@ public abstract class OneBaseRestController extends BaseRestController {
 
 		return _toResponseEntity(
 			HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");
+	}
+
+	@ExceptionHandler(LicenseKeyActiveException.class)
+	public ResponseEntity<?> handleException(
+		LicenseKeyActiveException licenseKeyActiveException) {
+
+		_log.error("The license key is active", licenseKeyActiveException);
+
+		return _toResponseEntity(
+			HttpStatus.CONFLICT, "The license key is active");
+	}
+
+	@ExceptionHandler(LicenseKeyValidationException.class)
+	public ResponseEntity<?> handleException(
+		LicenseKeyValidationException licenseKeyValidationException) {
+
+		_log.error("Invalid license key", licenseKeyValidationException);
+
+		return _toResponseEntity(
+			HttpStatus.BAD_REQUEST, licenseKeyValidationException.getMessage());
+	}
+
+	@ExceptionHandler(NoSuchLicenseKeyException.class)
+	public ResponseEntity<?> handleException(
+		NoSuchLicenseKeyException noSuchLicenseKeyException) {
+
+		_log.error("The license key was not found", noSuchLicenseKeyException);
+
+		return _toResponseEntity(
+			HttpStatus.NOT_FOUND, "The license key was not found");
 	}
 
 	@ExceptionHandler(PrincipalException.class)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/DuplicateIPAddressException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/DuplicateIPAddressException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class DuplicateIPAddressException extends LicenseKeyValidationException {
+
+	public DuplicateIPAddressException() {
+	}
+
+	public DuplicateIPAddressException(String message) {
+		super(message);
+	}
+
+	public DuplicateIPAddressException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public DuplicateIPAddressException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/DuplicateMACAddressException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/DuplicateMACAddressException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class DuplicateMACAddressException
+	extends LicenseKeyValidationException {
+
+	public DuplicateMACAddressException() {
+	}
+
+	public DuplicateMACAddressException(String message) {
+		super(message);
+	}
+
+	public DuplicateMACAddressException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public DuplicateMACAddressException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyActiveException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyActiveException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyActiveException extends Exception {
+
+	public LicenseKeyActiveException() {
+	}
+
+	public LicenseKeyActiveException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyActiveException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyActiveException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyDateException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyDateException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyDateException extends LicenseKeyValidationException {
+
+	public LicenseKeyDateException() {
+	}
+
+	public LicenseKeyDateException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyDateException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyDateException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyDescriptionException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyDescriptionException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyDescriptionException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyDescriptionException() {
+	}
+
+	public LicenseKeyDescriptionException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyDescriptionException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyDescriptionException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyIPAddressException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyIPAddressException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyIPAddressException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyIPAddressException() {
+	}
+
+	public LicenseKeyIPAddressException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyIPAddressException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyIPAddressException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyMACAddressException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyMACAddressException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyMACAddressException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyMACAddressException() {
+	}
+
+	public LicenseKeyMACAddressException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyMACAddressException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyMACAddressException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyMaxClusterNodesException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyMaxClusterNodesException.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyMaxClusterNodesException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyMaxClusterNodesException() {
+	}
+
+	public LicenseKeyMaxClusterNodesException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyMaxClusterNodesException(
+		String message, Throwable throwable) {
+
+		super(message, throwable);
+	}
+
+	public LicenseKeyMaxClusterNodesException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyNameException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyNameException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyNameException extends LicenseKeyValidationException {
+
+	public LicenseKeyNameException() {
+	}
+
+	public LicenseKeyNameException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyNameException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyNameException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyOwnerException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyOwnerException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyOwnerException extends LicenseKeyValidationException {
+
+	public LicenseKeyOwnerException() {
+	}
+
+	public LicenseKeyOwnerException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyOwnerException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyOwnerException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyProductPurchaseKeyException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyProductPurchaseKeyException.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyProductPurchaseKeyException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyProductPurchaseKeyException() {
+	}
+
+	public LicenseKeyProductPurchaseKeyException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyProductPurchaseKeyException(
+		String message, Throwable throwable) {
+
+		super(message, throwable);
+	}
+
+	public LicenseKeyProductPurchaseKeyException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyProductVersionException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyProductVersionException.java
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyProductVersionException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyProductVersionException() {
+	}
+
+	public LicenseKeyProductVersionException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyProductVersionException(
+		String message, Throwable throwable) {
+
+		super(message, throwable);
+	}
+
+	public LicenseKeyProductVersionException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyServerIdException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyServerIdException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyServerIdException extends LicenseKeyValidationException {
+
+	public LicenseKeyServerIdException() {
+	}
+
+	public LicenseKeyServerIdException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyServerIdException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyServerIdException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyServerInfoException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyServerInfoException.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyServerInfoException
+	extends LicenseKeyValidationException {
+
+	public LicenseKeyServerInfoException() {
+	}
+
+	public LicenseKeyServerInfoException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyServerInfoException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyServerInfoException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyValidationException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/LicenseKeyValidationException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyValidationException extends Exception {
+
+	public LicenseKeyValidationException() {
+	}
+
+	public LicenseKeyValidationException(String message) {
+		super(message);
+	}
+
+	public LicenseKeyValidationException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public LicenseKeyValidationException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/NoSuchLicenseKeyException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/NoSuchLicenseKeyException.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class NoSuchLicenseKeyException extends Exception {
+
+	public NoSuchLicenseKeyException() {
+	}
+
+	public NoSuchLicenseKeyException(String message) {
+		super(message);
+	}
+
+	public NoSuchLicenseKeyException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public NoSuchLicenseKeyException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyValidator.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyValidator.java
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.one.exception.DuplicateIPAddressException;
+import com.liferay.one.exception.DuplicateMACAddressException;
+import com.liferay.one.exception.LicenseKeyDateException;
+import com.liferay.one.exception.LicenseKeyDescriptionException;
+import com.liferay.one.exception.LicenseKeyIPAddressException;
+import com.liferay.one.exception.LicenseKeyMACAddressException;
+import com.liferay.one.exception.LicenseKeyMaxClusterNodesException;
+import com.liferay.one.exception.LicenseKeyNameException;
+import com.liferay.one.exception.LicenseKeyOwnerException;
+import com.liferay.one.exception.LicenseKeyProductVersionException;
+import com.liferay.one.exception.LicenseKeyServerInfoException;
+import com.liferay.one.exception.LicenseKeyValidationException;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class LicenseKeyValidator {
+
+	public void validateDates(
+			String licenseEntryType, String hostName, String ipAddresses,
+			String macAddresses, Date startDate, Date expirationDate)
+		throws LicenseKeyValidationException {
+
+		if ((startDate == null) || (expirationDate == null) ||
+			expirationDate.before(startDate)) {
+
+			throw new LicenseKeyDateException(
+				"Invalid start date or expiration date");
+		}
+
+		if (_requiresServerInfo(licenseEntryType)) {
+			validateServerInfo(hostName, ipAddresses, macAddresses);
+		}
+	}
+
+	public void validateMetadata(
+			String productVersion, String name, String owner,
+			String description, String licenseEntryType, int maxClusterNodes)
+		throws LicenseKeyValidationException {
+
+		if (Validator.isNull(productVersion)) {
+			throw new LicenseKeyProductVersionException(
+				"Invalid product version");
+		}
+
+		if (Validator.isNull(name) || (name.length() > 75)) {
+			throw new LicenseKeyNameException("Invalid license name");
+		}
+
+		if (Validator.isNull(owner) || (owner.length() > 75)) {
+			throw new LicenseKeyOwnerException("Invalid owner");
+		}
+
+		if (Validator.isNull(description) || (description.length() > 255)) {
+			throw new LicenseKeyDescriptionException("Invalid description");
+		}
+
+		if (licenseEntryType.equals(LicenseConstants.TYPE_VIRTUAL_CLUSTER) &&
+			(maxClusterNodes <= 0)) {
+
+			throw new LicenseKeyMaxClusterNodesException(
+				"Invalid max cluster nodes");
+		}
+	}
+
+	public void validateServerInfo(
+			String hostName, String ipAddresses, String macAddresses)
+		throws LicenseKeyValidationException {
+
+		Set<String> distinctIpAddresses = new HashSet<>();
+
+		for (String ipAddress : StringUtil.split(ipAddresses)) {
+			_validateIpAddress(ipAddress);
+
+			if (distinctIpAddresses.contains(ipAddress)) {
+				throw new DuplicateIPAddressException("Duplicate IP addresses");
+			}
+
+			distinctIpAddresses.add(ipAddress);
+		}
+
+		Set<String> distinctMacAddresses = new HashSet<>();
+
+		for (String macAddress : StringUtil.split(macAddresses)) {
+			_validateMacAddress(macAddress);
+
+			if (distinctMacAddresses.contains(macAddress)) {
+				throw new DuplicateMACAddressException(
+					"Duplicate MAC addresses");
+			}
+
+			distinctMacAddresses.add(macAddress);
+		}
+
+		if (Validator.isNull(hostName) && distinctIpAddresses.isEmpty() &&
+			distinctMacAddresses.isEmpty()) {
+
+			throw new LicenseKeyServerInfoException("Invalid server details");
+		}
+	}
+
+	public void validateUpdate(
+			String licenseEntryType, String owner, String description,
+			String hostName, String ipAddresses, String macAddresses)
+		throws LicenseKeyValidationException {
+
+		if (Validator.isNull(owner) || (owner.length() > 75)) {
+			throw new LicenseKeyOwnerException("Invalid owner");
+		}
+
+		if (Validator.isNull(description) || (description.length() > 255)) {
+			throw new LicenseKeyDescriptionException("Invalid description");
+		}
+
+		if (_requiresServerInfo(licenseEntryType)) {
+			validateServerInfo(hostName, ipAddresses, macAddresses);
+		}
+	}
+
+	private boolean _requiresServerInfo(String licenseEntryType) {
+		if (_TYPE_BACKUP.equals(licenseEntryType) ||
+			LicenseConstants.TYPE_LIMITED.equals(licenseEntryType) ||
+			LicenseConstants.TYPE_PER_USER.equals(licenseEntryType) ||
+			LicenseConstants.TYPE_PRODUCTION.equals(licenseEntryType)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _validateIpAddress(String ipAddress)
+		throws LicenseKeyValidationException {
+
+		if (!Validator.isIPAddress(ipAddress)) {
+			throw new LicenseKeyIPAddressException("Invalid IP addresses");
+		}
+	}
+
+	private void _validateMacAddress(String macAddress)
+		throws LicenseKeyValidationException {
+
+		String curMacAddress = StringUtil.replace(
+			macAddress, CharPool.DASH, CharPool.COLON);
+
+		String[] octets = StringUtil.split(curMacAddress, StringPool.COLON);
+
+		if (octets.length != 6) {
+			throw new LicenseKeyMACAddressException("Invalid MAC addresses");
+		}
+
+		for (String octet : octets) {
+			if (octet.length() > 2) {
+				throw new LicenseKeyMACAddressException(
+					"Invalid MAC addresses");
+			}
+
+			for (char c : octet.toCharArray()) {
+				if (!Validator.isDigit(c) &&
+					((c < 65) || ((c > 70) && (c < 97)) || (c > 102))) {
+
+					throw new LicenseKeyMACAddressException(
+						"Invalid MAC addresses");
+				}
+			}
+		}
+	}
+
+	private static final String _TYPE_BACKUP = "backup";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyValidatorTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyValidatorTest.java
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.one.exception.DuplicateIPAddressException;
+import com.liferay.one.exception.DuplicateMACAddressException;
+import com.liferay.one.exception.LicenseKeyDateException;
+import com.liferay.one.exception.LicenseKeyDescriptionException;
+import com.liferay.one.exception.LicenseKeyIPAddressException;
+import com.liferay.one.exception.LicenseKeyMACAddressException;
+import com.liferay.one.exception.LicenseKeyMaxClusterNodesException;
+import com.liferay.one.exception.LicenseKeyNameException;
+import com.liferay.one.exception.LicenseKeyOwnerException;
+import com.liferay.one.exception.LicenseKeyProductVersionException;
+import com.liferay.one.exception.LicenseKeyServerInfoException;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyValidatorTest {
+
+	@Test
+	public void testValidateDatesExpirationBeforeStart() {
+		Assertions.assertThrows(
+			LicenseKeyDateException.class,
+			() -> _licenseKeyValidator.validateDates(
+				LicenseConstants.TYPE_ENTERPRISE, null, null, null,
+				new Date(2000), new Date(1000)));
+	}
+
+	@Test
+	public void testValidateDatesNullExpirationDate() {
+		Assertions.assertThrows(
+			LicenseKeyDateException.class,
+			() -> _licenseKeyValidator.validateDates(
+				LicenseConstants.TYPE_ENTERPRISE, null, null, null,
+				new Date(1000), null));
+	}
+
+	@Test
+	public void testValidateDatesNullStartDate() {
+		Assertions.assertThrows(
+			LicenseKeyDateException.class,
+			() -> _licenseKeyValidator.validateDates(
+				LicenseConstants.TYPE_ENTERPRISE, null, null, null, null,
+				new Date(1000)));
+	}
+
+	@Test
+	public void testValidateDatesValid() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateDates(
+				LicenseConstants.TYPE_ENTERPRISE, null, null, null,
+				new Date(1000), new Date(2000)));
+	}
+
+	@Test
+	public void testValidateMetadataInvalidDescription() {
+		Assertions.assertThrows(
+			LicenseKeyDescriptionException.class,
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", "name", "owner", null, LicenseConstants.TYPE_ENTERPRISE,
+				0));
+	}
+
+	@Test
+	public void testValidateMetadataInvalidMaxClusterNodes() {
+		Assertions.assertThrows(
+			LicenseKeyMaxClusterNodesException.class,
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", "name", "owner", "description",
+				LicenseConstants.TYPE_VIRTUAL_CLUSTER, 0));
+	}
+
+	@Test
+	public void testValidateMetadataInvalidName() {
+		Assertions.assertThrows(
+			LicenseKeyNameException.class,
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", null, "owner", "description",
+				LicenseConstants.TYPE_ENTERPRISE, 0));
+	}
+
+	@Test
+	public void testValidateMetadataInvalidOwner() {
+		Assertions.assertThrows(
+			LicenseKeyOwnerException.class,
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", "name", null, "description",
+				LicenseConstants.TYPE_ENTERPRISE, 0));
+	}
+
+	@Test
+	public void testValidateMetadataInvalidProductVersion() {
+		Assertions.assertThrows(
+			LicenseKeyProductVersionException.class,
+			() -> _licenseKeyValidator.validateMetadata(
+				null, "name", "owner", "description",
+				LicenseConstants.TYPE_ENTERPRISE, 0));
+	}
+
+	@Test
+	public void testValidateMetadataValid() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", "name", "owner", "description",
+				LicenseConstants.TYPE_ENTERPRISE, 0));
+	}
+
+	@Test
+	public void testValidateMetadataValidVirtualCluster() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateMetadata(
+				"7.4", "name", "owner", "description",
+				LicenseConstants.TYPE_VIRTUAL_CLUSTER, 3));
+	}
+
+	@Test
+	public void testValidateServerInfoDuplicateIpAddresses() {
+		Assertions.assertThrows(
+			DuplicateIPAddressException.class,
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, "127.0.0.1,127.0.0.1", null));
+	}
+
+	@Test
+	public void testValidateServerInfoDuplicateMacAddresses() {
+		Assertions.assertThrows(
+			DuplicateMACAddressException.class,
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, null, "00:11:22:33:44:55,00:11:22:33:44:55"));
+	}
+
+	@Test
+	public void testValidateServerInfoInvalidIpAddress() {
+		Assertions.assertThrows(
+			LicenseKeyIPAddressException.class,
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, "not-an-ip", null));
+	}
+
+	@Test
+	public void testValidateServerInfoInvalidMacAddressCharacter() {
+		Assertions.assertThrows(
+			LicenseKeyMACAddressException.class,
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, null, "00:11:22:33:44:5g"));
+	}
+
+	@Test
+	public void testValidateServerInfoInvalidMacAddressOctetCount() {
+		Assertions.assertThrows(
+			LicenseKeyMACAddressException.class,
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, null, "00:11:22"));
+	}
+
+	@Test
+	public void testValidateServerInfoMissingAllDetails() {
+		Assertions.assertThrows(
+			LicenseKeyServerInfoException.class,
+			() -> _licenseKeyValidator.validateServerInfo(null, null, null));
+	}
+
+	@Test
+	public void testValidateServerInfoValidHostNameOnly() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateServerInfo(
+				"myhost.example.com", null, null));
+	}
+
+	@Test
+	public void testValidateServerInfoValidIpAndMacAddresses() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateServerInfo(
+				null, "127.0.0.1,192.168.0.1",
+				"00-11-22-33-44-55,AA:BB:CC:DD:EE:FF"));
+	}
+
+	@Test
+	public void testValidateUpdateInvalidOwner() {
+		Assertions.assertThrows(
+			LicenseKeyOwnerException.class,
+			() -> _licenseKeyValidator.validateUpdate(
+				LicenseConstants.TYPE_ENTERPRISE, null, "description", null,
+				null, null));
+	}
+
+	@Test
+	public void testValidateUpdateRequiresServerInfoForProduction() {
+		Assertions.assertThrows(
+			LicenseKeyServerInfoException.class,
+			() -> _licenseKeyValidator.validateUpdate(
+				LicenseConstants.TYPE_PRODUCTION, "owner", "description", null,
+				null, null));
+	}
+
+	@Test
+	public void testValidateUpdateValid() {
+		Assertions.assertDoesNotThrow(
+			() -> _licenseKeyValidator.validateUpdate(
+				LicenseConstants.TYPE_ENTERPRISE, "owner", "description", null,
+				null, null));
+	}
+
+	private final LicenseKeyValidator _licenseKeyValidator =
+		new LicenseKeyValidator();
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97363

## What is being fixed

The LicenseKey validation rules and exception types existed only in the
OSB-provisioning OSGi service (LicenseKeyLocalServiceImpl), with no
equivalent in the One Liferay Spring Boot client extension. The validation
logic was also untested in the original — the license module had no unit
tests, and its REST integration test was disabled.

## How it is being fixed

The validation rules, previously private methods on
LicenseKeyLocalServiceImpl, are ported into a standalone LicenseKeyValidator
component so they can be exercised in isolation and reused by the upcoming
service port (LPD-97362). Each LicenseKey exception gets a Spring
equivalent, with the validation family sharing a common
LicenseKeyValidationException base so the REST layer maps them to a single
400 response through OneBaseRestController, while the active and not-found
cases map to 409 and 404. New unit tests cover every validation rule with
positive and negative cases.
