### PR TITLE
LPD-97362 Port LicenseKey create, update, and reads to the Object API

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -5,11 +5,9 @@
 
 package com.liferay.one.license;
 
-import com.liferay.one.constants.ProductVersion;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.ee.license.shared.KeyGenerator;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -23,12 +21,12 @@ import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import java.text.DateFormat;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
@@ -98,7 +96,7 @@ public class LicenseKeyExporter {
 			Date createDate)
 		throws Exception {
 
-		Map<String, String> properties = _getProperties(
+		Map<String, String> properties = _licenseKeyGenerator.getProperties(
 			accountName, licenseEntryName, licenseType, licenseVersion,
 			productName, productId, productVersion, owner, maxClusterNodes,
 			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
@@ -122,13 +120,14 @@ public class LicenseKeyExporter {
 		Element serversElement = rootElement.addElement("servers");
 
 		for (int i = 0; i < serverIds.length; i++) {
-			Map<String, String> curProperties = _getProperties(
-				accountName, licenseEntryName, licenseType, licenseVersion,
-				productName, productId, productVersion, owner, maxClusterNodes,
-				maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers,
-				sizing, description, domains, hostNames[i], ipAddresses[i],
-				macAddresses[i], serverIds[i], startDate, expirationDate,
-				createDate);
+			Map<String, String> curProperties =
+				_licenseKeyGenerator.getProperties(
+					accountName, licenseEntryName, licenseType, licenseVersion,
+					productName, productId, productVersion, owner,
+					maxClusterNodes, maxServers, maxHttpSessions,
+					maxConcurrentUsers, maxUsers, sizing, description, domains,
+					hostNames[i], ipAddresses[i], macAddresses[i], serverIds[i],
+					startDate, expirationDate, createDate);
 
 			Element serverElement = serversElement.addElement("server");
 
@@ -155,7 +154,7 @@ public class LicenseKeyExporter {
 		properties.put("ipAddresses", StringUtil.merge(allIpAddresses));
 		properties.put("macAddresses", StringUtil.merge(allMacAddresses));
 
-		String key = KeyGenerator.encrypt(properties);
+		String key = _licenseKeyGenerator.encrypt(properties);
 
 		_addElement(rootElement, "key", key);
 
@@ -175,7 +174,7 @@ public class LicenseKeyExporter {
 
 		Document document = null;
 
-		Map<String, String> properties = _getProperties(
+		Map<String, String> properties = _licenseKeyGenerator.getProperties(
 			accountName, licenseEntryName, licenseType, licenseVersion,
 			productName, productId, productVersion, owner, maxClusterNodes,
 			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
@@ -461,39 +460,7 @@ public class LicenseKeyExporter {
 		}
 	}
 
-	private Map<String, String> _getProperties(
-		String accountName, String licenseEntryName, String licenseType,
-		int licenseVersion, String productName, String productId,
-		String productVersion, String owner, int maxClusterNodes,
-		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
-		long maxUsers, String sizing, String description, String domains,
-		String hostNames, String ipAddresses, String macAddresses,
-		String serverIds, Date startDate, Date expirationDate,
-		Date createDate) {
-
-		Map<String, String> properties = KeyGenerator.getProperties(
-			accountName, description, StringUtil.split(domains), expirationDate,
-			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
-			licenseEntryName, licenseType, String.valueOf(licenseVersion),
-			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
-			maxHttpSessions, maxServers, maxUsers, owner, productName,
-			productId, productVersion, new String[] {serverIds}, startDate);
-
-		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
-			productVersion.equals("6.1 GA 1")) {
-
-			Calendar cal = Calendar.getInstance();
-
-			cal.set(Calendar.DAY_OF_MONTH, 31);
-			cal.set(Calendar.MONTH, 6);
-			cal.set(Calendar.YEAR, 2012);
-
-			if (createDate.before(cal.getTime())) {
-				properties.put("productVersion", "6.1");
-			}
-		}
-
-		return properties;
-	}
+	@Autowired
+	private LicenseKeyGenerator _licenseKeyGenerator;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyGenerator.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyGenerator.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.one.constants.ProductVersion;
+import com.liferay.portal.ee.license.shared.KeyGenerator;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class LicenseKeyGenerator {
+
+	public String encrypt(Map<String, String> properties) throws Exception {
+		return KeyGenerator.encrypt(properties);
+	}
+
+	public String generateKey(
+			String accountName, String licenseEntryName, String licenseType,
+			int licenseVersion, String productName, String productId,
+			String productVersion, String owner, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String description, String domains,
+			String hostNames, String ipAddresses, String macAddresses,
+			String serverIds, Date startDate, Date expirationDate,
+			Date createDate)
+		throws Exception {
+
+		return encrypt(
+			getProperties(
+				accountName, licenseEntryName, licenseType, licenseVersion,
+				productName, productId, productVersion, owner, maxClusterNodes,
+				maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers,
+				sizing, description, domains, hostNames, ipAddresses,
+				macAddresses, serverIds, startDate, expirationDate,
+				createDate));
+	}
+
+	public Map<String, String> getProperties(
+		String accountName, String licenseEntryName, String licenseType,
+		int licenseVersion, String productName, String productId,
+		String productVersion, String owner, int maxClusterNodes,
+		int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+		long maxUsers, String sizing, String description, String domains,
+		String hostNames, String ipAddresses, String macAddresses,
+		String serverIds, Date startDate, Date expirationDate,
+		Date createDate) {
+
+		Map<String, String> properties = KeyGenerator.getProperties(
+			accountName, description, StringUtil.split(domains), expirationDate,
+			StringUtil.split(hostNames), sizing, StringUtil.split(ipAddresses),
+			licenseEntryName, licenseType, String.valueOf(licenseVersion),
+			StringUtil.split(macAddresses), maxClusterNodes, maxConcurrentUsers,
+			maxHttpSessions, maxServers, maxUsers, owner, productName,
+			productId, productVersion, new String[] {serverIds}, startDate);
+
+		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
+			productVersion.equals("6.1 GA 1")) {
+
+			Calendar cal = Calendar.getInstance();
+
+			cal.set(Calendar.DAY_OF_MONTH, 31);
+			cal.set(Calendar.MONTH, 6);
+			cal.set(Calendar.YEAR, 2012);
+
+			if (createDate.before(cal.getTime())) {
+				properties.put("productVersion", "6.1");
+			}
+		}
+
+		return properties;
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyGenerator.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyGenerator.java
@@ -64,8 +64,9 @@ public class LicenseKeyGenerator {
 			maxHttpSessions, maxServers, maxUsers, owner, productName,
 			productId, productVersion, new String[] {serverIds}, startDate);
 
-		if (productVersion.equals(ProductVersion.PORTAL_VERSION_6_1_10) ||
-			productVersion.equals("6.1 GA 1")) {
+		if (StringUtil.equals(
+				productVersion, ProductVersion.PORTAL_VERSION_6_1_10) ||
+			StringUtil.equals(productVersion, "6.1 GA 1")) {
 
 			Calendar cal = Calendar.getInstance();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -283,9 +283,12 @@ public class LicenseKeyService extends OneBaseService {
 			throw new LicenseKeyActiveException();
 		}
 
+		LicenseKey newLicenseKey = _copyLicenseKey(
+			licenseKey, startDate, expirationDate);
+
 		updateLicenseKey(licenseKeyId, licenseKey.isComplimentary(), false);
 
-		return _copyLicenseKey(licenseKey, startDate, expirationDate);
+		return newLicenseKey;
 	}
 
 	public List<LicenseKey> search(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -203,6 +203,17 @@ public class LicenseKeyService extends OneBaseService {
 		return licenseKeys.get(0);
 	}
 
+	public List<LicenseKey> getLicenseKeys(
+			long entitlementId, boolean complimentary, boolean active)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(entitlementId eq '", entitlementId,
+				"') and (complimentary eq ", complimentary, ") and (active eq ",
+				active, ")"));
+	}
+
 	public List<LicenseKey> getLicenseKeys(String filterString)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -5,22 +5,454 @@
 
 package com.liferay.one.service;
 
+import com.liferay.one.constants.ClassNameConstants;
+import com.liferay.one.exception.LicenseKeyActiveException;
+import com.liferay.one.exception.NoSuchLicenseKeyException;
+import com.liferay.one.license.LicenseKeyGenerator;
+import com.liferay.one.license.LicenseKeyValidator;
 import com.liferay.one.model.LicenseKey;
+import com.liferay.one.model.SubscriptionEntry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * @author Amos Fong
+ * @author Allen Ziegenfus
  */
 @Component
 public class LicenseKeyService extends OneBaseService {
+
+	public LicenseKey addLicenseKey(
+			String licenseType, String licenseName, String productExternalId,
+			String productName, String productVersion, int licenseVersion,
+			String name, String owner, String description, String domains,
+			String hostName, String ipAddresses, String macAddresses,
+			String serverId, String accountName, int maxClusterNodes,
+			int maxServers, int maxHttpSessions, long maxConcurrentUsers,
+			long maxUsers, String sizing, String additionalInfo, String orderId,
+			Date startDate, Date expirationDate, boolean complimentary,
+			boolean active)
+		throws Exception {
+
+		_licenseKeyValidator.validateMetadata(
+			description, licenseType, maxClusterNodes, name, owner,
+			productVersion);
+
+		_licenseKeyValidator.validateDates(
+			expirationDate, hostName, ipAddresses, licenseType, macAddresses,
+			startDate);
+
+		String key = _licenseKeyGenerator.generateKey(
+			accountName, licenseName, licenseType, licenseVersion, productName,
+			productExternalId, productVersion, owner, maxClusterNodes,
+			maxServers, maxHttpSessions, maxConcurrentUsers, maxUsers, sizing,
+			description, domains, hostName, ipAddresses, macAddresses, serverId,
+			startDate, expirationDate, new Date());
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"accountName", accountName
+		).put(
+			"active", active
+		).put(
+			"additionalInfo", additionalInfo
+		).put(
+			"complimentary", complimentary
+		).put(
+			"customExpirationDate", _toISO8601(expirationDate)
+		).put(
+			"description", description
+		).put(
+			"domains", domains
+		).put(
+			"hostName", hostName
+		).put(
+			"ipAddresses", ipAddresses
+		).put(
+			"key", key
+		).put(
+			"licenseName", licenseName
+		).put(
+			"licenseType", licenseType
+		).put(
+			"licenseVersion", licenseVersion
+		).put(
+			"macAddresses", macAddresses
+		).put(
+			"maxClusterNodes", maxClusterNodes
+		).put(
+			"maxConcurrentUsers", maxConcurrentUsers
+		).put(
+			"maxHttpSessions", maxHttpSessions
+		).put(
+			"maxServers", maxServers
+		).put(
+			"maxUsers", maxUsers
+		).put(
+			"name", name
+		).put(
+			"orderId", orderId
+		).put(
+			"owner", owner
+		).put(
+			"productExternalId", productExternalId
+		).put(
+			"productName", productName
+		).put(
+			"productVersion", productVersion
+		).put(
+			"serverId", serverId
+		).put(
+			"sizing", sizing
+		).put(
+			"startDate", _toISO8601(startDate)
+		);
+
+		String response = post(
+			getAuthorization(), jsonObject.toString(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys"
+			).build(
+			).toUri());
+
+		return new LicenseKey(new JSONObject(response));
+	}
+
+	public LicenseKey extendLicenseKey(
+			long licenseKeyId, Date startDate, Date expirationDate)
+		throws Exception {
+
+		LicenseKey newLicenseKey = _copyLicenseKey(
+			getLicenseKey(licenseKeyId), startDate, expirationDate);
+
+		List<SubscriptionEntry> subscriptionEntries =
+			_subscriptionEntryService.getSubscriptionEntries(
+				StringBundler.concat(
+					"(className eq '", ClassNameConstants.LICENSE_KEY,
+					"') and (classPK eq ", licenseKeyId, ")"));
+
+		for (SubscriptionEntry subscriptionEntry : subscriptionEntries) {
+			_subscriptionEntryService.addSubscriptionEntry(
+				ClassNameConstants.LICENSE_KEY, newLicenseKey.getLicenseKeyId(),
+				subscriptionEntry.getCustomUserId());
+		}
+
+		return newLicenseKey;
+	}
+
+	public List<LicenseKey> getAssetReceiptLicenseLicenseKeys(
+			String orderId, boolean complimentary, boolean active)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(orderId eq '", orderId, "') and (complimentary eq ",
+				complimentary, ") and (active eq ", active, ")"));
+	}
+
+	public int getAssetReceiptLicenseLicenseKeysCount(
+			String orderId, boolean complimentary, boolean active)
+		throws Exception {
+
+		return _getCount(
+			StringBundler.concat(
+				"(orderId eq '", orderId, "') and (complimentary eq ",
+				complimentary, ") and (active eq ", active, ")"));
+	}
+
+	public LicenseKey getLicenseKey(long licenseKeyId) throws Exception {
+		String response = get(
+			getAuthorization(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys/{id}"
+			).buildAndExpand(
+				licenseKeyId
+			).toUri());
+
+		return new LicenseKey(new JSONObject(response));
+	}
+
+	public LicenseKey getLicenseKeyByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception {
+
+		List<LicenseKey> licenseKeys = getLicenseKeys(
+			StringBundler.concat(
+				"externalReferenceCode eq '", externalReferenceCode, "'"));
+
+		if (licenseKeys.isEmpty()) {
+			throw new NoSuchLicenseKeyException(
+				"{externalReferenceCode=" + externalReferenceCode + "}");
+		}
+
+		return licenseKeys.get(0);
+	}
 
 	public List<LicenseKey> getLicenseKeys(String filterString)
 		throws Exception {
 
 		return getAllItems("/o/c/licensekeys", filterString, LicenseKey::new);
 	}
+
+	public List<LicenseKey> getLicenseKeys(
+			String productExternalId, String serverId)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(productExternalId eq '", productExternalId,
+				"') and (serverId eq '", serverId, "')"));
+	}
+
+	public List<LicenseKey> getLicenseKeys(
+			String licenseType, String owner, String domains)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(licenseType eq '", licenseType, "') and (owner eq '", owner,
+				"') and (domains eq '", domains, "')"));
+	}
+
+	public List<LicenseKey> getLicenseKeys(
+			String orderId, String productExternalId, String serverId,
+			boolean active)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(orderId eq '", orderId, "') and (productExternalId eq '",
+				productExternalId, "') and (serverId eq '", serverId,
+				"') and (active eq ", active, ")"));
+	}
+
+	public List<LicenseKey> getLicenseKeysByName(
+			String productName, String serverId, boolean active)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"(productName eq '", productName, "') and (serverId eq '",
+				serverId, "') and (active eq ", active, ")"));
+	}
+
+	public LicenseKey replaceLicenseKey(
+			long licenseKeyId, Date startDate, Date expirationDate)
+		throws Exception {
+
+		LicenseKey licenseKey = getLicenseKey(licenseKeyId);
+
+		if (Validator.isNotNull(licenseKey.getOrderId()) &&
+			!licenseKey.isActive()) {
+
+			throw new LicenseKeyActiveException();
+		}
+
+		updateLicenseKey(licenseKeyId, licenseKey.isComplimentary(), false);
+
+		return _copyLicenseKey(licenseKey, startDate, expirationDate);
+	}
+
+	public List<LicenseKey> search(
+			String licenseType, String owner, String description,
+			String hostName, String ipAddress, String macAddress,
+			String serverId, String productName, String productExternalId,
+			Boolean active)
+		throws Exception {
+
+		return getLicenseKeys(
+			_buildSearchFilter(
+				licenseType, owner, description, hostName, ipAddress,
+				macAddress, serverId, productName, productExternalId, active));
+	}
+
+	public int searchCount(
+			String licenseType, String owner, String description,
+			String hostName, String ipAddress, String macAddress,
+			String serverId, String productName, String productExternalId,
+			Boolean active)
+		throws Exception {
+
+		return _getCount(
+			_buildSearchFilter(
+				licenseType, owner, description, hostName, ipAddress,
+				macAddress, serverId, productName, productExternalId, active));
+	}
+
+	public LicenseKey updateLicenseKey(
+			long licenseKeyId, boolean complimentary, boolean active)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"active", active
+		).put(
+			"complimentary", complimentary
+		);
+
+		String response = patch(
+			getAuthorization(), jsonObject.toString(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys/{id}"
+			).buildAndExpand(
+				licenseKeyId
+			).toUri());
+
+		return new LicenseKey(new JSONObject(response));
+	}
+
+	public LicenseKey updateLicenseKeyActive(long licenseKeyId, boolean active)
+		throws Exception {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"active", active
+		);
+
+		String response = patch(
+			getAuthorization(), jsonObject.toString(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys/{id}"
+			).buildAndExpand(
+				licenseKeyId
+			).toUri());
+
+		return new LicenseKey(new JSONObject(response));
+	}
+
+	private String _buildSearchFilter(
+		String licenseType, String owner, String description, String hostName,
+		String ipAddress, String macAddress, String serverId,
+		String productName, String productExternalId, Boolean active) {
+
+		List<String> conditions = new ArrayList<>();
+
+		if (Validator.isNotNull(licenseType)) {
+			conditions.add("(licenseType eq '" + licenseType + "')");
+		}
+
+		if (Validator.isNotNull(owner)) {
+			conditions.add("(owner eq '" + owner + "')");
+		}
+
+		if (Validator.isNotNull(description)) {
+			conditions.add("(description eq '" + description + "')");
+		}
+
+		if (Validator.isNotNull(hostName)) {
+			conditions.add("(hostName eq '" + hostName + "')");
+		}
+
+		if (Validator.isNotNull(ipAddress)) {
+			conditions.add("(ipAddresses eq '" + ipAddress + "')");
+		}
+
+		if (Validator.isNotNull(macAddress)) {
+			conditions.add("(macAddresses eq '" + macAddress + "')");
+		}
+
+		if (Validator.isNotNull(serverId)) {
+			conditions.add("(serverId eq '" + serverId + "')");
+		}
+
+		if (Validator.isNotNull(productName)) {
+			conditions.add("(productName eq '" + productName + "')");
+		}
+
+		if (Validator.isNotNull(productExternalId)) {
+			conditions.add(
+				"(productExternalId eq '" + productExternalId + "')");
+		}
+
+		if (active != null) {
+			conditions.add("(active eq " + active + ")");
+		}
+
+		if (conditions.isEmpty()) {
+			return null;
+		}
+
+		return String.join(" and ", conditions);
+	}
+
+	private LicenseKey _copyLicenseKey(
+			LicenseKey licenseKey, Date startDate, Date expirationDate)
+		throws Exception {
+
+		return addLicenseKey(
+			licenseKey.getLicenseType(), licenseKey.getLicenseName(),
+			licenseKey.getProductExternalId(), licenseKey.getProductName(),
+			licenseKey.getProductVersion(), licenseKey.getLicenseVersion(),
+			licenseKey.getName(), licenseKey.getOwner(),
+			licenseKey.getDescription(), licenseKey.getDomains(),
+			licenseKey.getHostName(), licenseKey.getIpAddresses(),
+			licenseKey.getMacAddresses(), licenseKey.getServerId(),
+			licenseKey.getAccountName(), licenseKey.getMaxClusterNodes(),
+			licenseKey.getMaxServers(), licenseKey.getMaxHttpSessions(),
+			licenseKey.getMaxConcurrentUsers(), licenseKey.getMaxUsers(),
+			licenseKey.getSizing(), licenseKey.getAdditionalInfo(),
+			licenseKey.getOrderId(), startDate, expirationDate,
+			licenseKey.isComplimentary(), true);
+	}
+
+	private int _getCount(String filterString) throws Exception {
+		UriComponentsBuilder uriComponentsBuilder =
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys"
+			).queryParam(
+				"pageSize", 1
+			);
+
+		if (filterString != null) {
+			uriComponentsBuilder.queryParam("filter", filterString);
+		}
+
+		String response = get(
+			getAuthorization(),
+			uriComponentsBuilder.build(
+			).toUri());
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		return jsonObject.optInt("totalCount");
+	}
+
+	private String _toISO8601(Date date) {
+		if (date == null) {
+			return null;
+		}
+
+		DateFormat dateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return dateFormat.format(date);
+	}
+
+	@Autowired
+	private LicenseKeyGenerator _licenseKeyGenerator;
+
+	@Autowired
+	private LicenseKeyValidator _licenseKeyValidator;
+
+	@Autowired
+	@Lazy
+	private SubscriptionEntryService _subscriptionEntryService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -13,6 +13,7 @@ import com.liferay.one.license.LicenseKeyValidator;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.text.DateFormat;
@@ -161,8 +162,9 @@ public class LicenseKeyService extends OneBaseService {
 
 		return getLicenseKeys(
 			StringBundler.concat(
-				"(orderId eq '", orderId, "') and (complimentary eq ",
-				complimentary, ") and (active eq ", active, ")"));
+				"(orderId eq '", _escapeODataString(orderId),
+				"') and (complimentary eq ", complimentary, ") and (active eq ",
+				active, ")"));
 	}
 
 	public int getAssetReceiptLicenseLicenseKeysCount(
@@ -171,8 +173,9 @@ public class LicenseKeyService extends OneBaseService {
 
 		return _getCount(
 			StringBundler.concat(
-				"(orderId eq '", orderId, "') and (complimentary eq ",
-				complimentary, ") and (active eq ", active, ")"));
+				"(orderId eq '", _escapeODataString(orderId),
+				"') and (complimentary eq ", complimentary, ") and (active eq ",
+				active, ")"));
 	}
 
 	public LicenseKey getLicenseKey(long licenseKeyId) throws Exception {
@@ -193,7 +196,8 @@ public class LicenseKeyService extends OneBaseService {
 
 		List<LicenseKey> licenseKeys = getLicenseKeys(
 			StringBundler.concat(
-				"externalReferenceCode eq '", externalReferenceCode, "'"));
+				"externalReferenceCode eq '",
+				_escapeODataString(externalReferenceCode), "'"));
 
 		if (licenseKeys.isEmpty()) {
 			throw new NoSuchLicenseKeyException(
@@ -226,8 +230,9 @@ public class LicenseKeyService extends OneBaseService {
 
 		return getLicenseKeys(
 			StringBundler.concat(
-				"(productExternalId eq '", productExternalId,
-				"') and (serverId eq '", serverId, "')"));
+				"(productExternalId eq '",
+				_escapeODataString(productExternalId), "') and (serverId eq '",
+				_escapeODataString(serverId), "')"));
 	}
 
 	public List<LicenseKey> getLicenseKeys(
@@ -236,8 +241,9 @@ public class LicenseKeyService extends OneBaseService {
 
 		return getLicenseKeys(
 			StringBundler.concat(
-				"(licenseType eq '", licenseType, "') and (owner eq '", owner,
-				"') and (domains eq '", domains, "')"));
+				"(licenseType eq '", _escapeODataString(licenseType),
+				"') and (owner eq '", _escapeODataString(owner),
+				"') and (domains eq '", _escapeODataString(domains), "')"));
 	}
 
 	public List<LicenseKey> getLicenseKeys(
@@ -247,9 +253,11 @@ public class LicenseKeyService extends OneBaseService {
 
 		return getLicenseKeys(
 			StringBundler.concat(
-				"(orderId eq '", orderId, "') and (productExternalId eq '",
-				productExternalId, "') and (serverId eq '", serverId,
-				"') and (active eq ", active, ")"));
+				"(orderId eq '", _escapeODataString(orderId),
+				"') and (productExternalId eq '",
+				_escapeODataString(productExternalId), "') and (serverId eq '",
+				_escapeODataString(serverId), "') and (active eq ", active,
+				")"));
 	}
 
 	public List<LicenseKey> getLicenseKeysByName(
@@ -258,8 +266,9 @@ public class LicenseKeyService extends OneBaseService {
 
 		return getLicenseKeys(
 			StringBundler.concat(
-				"(productName eq '", productName, "') and (serverId eq '",
-				serverId, "') and (active eq ", active, ")"));
+				"(productName eq '", _escapeODataString(productName),
+				"') and (serverId eq '", _escapeODataString(serverId),
+				"') and (active eq ", active, ")"));
 	}
 
 	public LicenseKey replaceLicenseKey(
@@ -354,40 +363,48 @@ public class LicenseKeyService extends OneBaseService {
 		List<String> conditions = new ArrayList<>();
 
 		if (Validator.isNotNull(licenseType)) {
-			conditions.add("(licenseType eq '" + licenseType + "')");
+			conditions.add(
+				"(licenseType eq '" + _escapeODataString(licenseType) + "')");
 		}
 
 		if (Validator.isNotNull(owner)) {
-			conditions.add("(owner eq '" + owner + "')");
+			conditions.add("(owner eq '" + _escapeODataString(owner) + "')");
 		}
 
 		if (Validator.isNotNull(description)) {
-			conditions.add("(description eq '" + description + "')");
+			conditions.add(
+				"(description eq '" + _escapeODataString(description) + "')");
 		}
 
 		if (Validator.isNotNull(hostName)) {
-			conditions.add("(hostName eq '" + hostName + "')");
+			conditions.add(
+				"(hostName eq '" + _escapeODataString(hostName) + "')");
 		}
 
 		if (Validator.isNotNull(ipAddress)) {
-			conditions.add("(ipAddresses eq '" + ipAddress + "')");
+			conditions.add(
+				"(ipAddresses eq '" + _escapeODataString(ipAddress) + "')");
 		}
 
 		if (Validator.isNotNull(macAddress)) {
-			conditions.add("(macAddresses eq '" + macAddress + "')");
+			conditions.add(
+				"(macAddresses eq '" + _escapeODataString(macAddress) + "')");
 		}
 
 		if (Validator.isNotNull(serverId)) {
-			conditions.add("(serverId eq '" + serverId + "')");
+			conditions.add(
+				"(serverId eq '" + _escapeODataString(serverId) + "')");
 		}
 
 		if (Validator.isNotNull(productName)) {
-			conditions.add("(productName eq '" + productName + "')");
+			conditions.add(
+				"(productName eq '" + _escapeODataString(productName) + "')");
 		}
 
 		if (Validator.isNotNull(productExternalId)) {
 			conditions.add(
-				"(productExternalId eq '" + productExternalId + "')");
+				"(productExternalId eq '" +
+					_escapeODataString(productExternalId) + "')");
 		}
 
 		if (active != null) {
@@ -419,6 +436,14 @@ public class LicenseKeyService extends OneBaseService {
 			licenseKey.getSizing(), licenseKey.getAdditionalInfo(),
 			licenseKey.getOrderId(), startDate, expirationDate,
 			licenseKey.isComplimentary(), true);
+	}
+
+	private String _escapeODataString(String value) {
+		if (value == null) {
+			return null;
+		}
+
+		return StringUtil.replace(value, '\'', "''");
 	}
 
 	private int _getCount(String filterString) throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyGeneratorTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyGeneratorTest.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyGeneratorTest {
+
+	@Test
+	public void testGenerateKeyIsDeterministic() throws Exception {
+		String key1 = _generateKey();
+		String key2 = _generateKey();
+
+		Assertions.assertEquals(key1, key2);
+	}
+
+	@Test
+	public void testGenerateKeyReturnsDigest() throws Exception {
+		String key = _generateKey();
+
+		Assertions.assertNotNull(key);
+		Assertions.assertFalse(key.isEmpty());
+	}
+
+	private String _generateKey() throws Exception {
+		return _licenseKeyGenerator.generateKey(
+			"Acme Corp", "Enterprise", LicenseConstants.TYPE_ENTERPRISE, 3,
+			"Liferay DXP", LicenseConstants.PRODUCT_ID_PORTAL, "7.4",
+			"Acme Corp", 0, 0, 0, 0L, 0L, "", "Test license", "",
+			"host.example.com", "127.0.0.1", "00:11:22:33:44:55", "srv-1",
+			new Date(1000000000000L), new Date(2000000000000L),
+			new Date(1000000000000L));
+	}
+
+	private final LicenseKeyGenerator _licenseKeyGenerator =
+		new LicenseKeyGenerator();
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
@@ -1,0 +1,135 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.exception.NoSuchLicenseKeyException;
+import com.liferay.one.model.LicenseKey;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_licenseKeyService = Mockito.spy(new LicenseKeyService());
+
+		_filterCaptor = ArgumentCaptor.forClass(String.class);
+
+		Mockito.doReturn(
+			Collections.<LicenseKey>emptyList()
+		).when(
+			_licenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/licensekeys"), _filterCaptor.capture(),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testGetAssetReceiptLicenseLicenseKeysFilter() throws Exception {
+		_licenseKeyService.getAssetReceiptLicenseLicenseKeys(
+			"order-1", false, true);
+
+		Assertions.assertEquals(
+			"(orderId eq 'order-1') and (complimentary eq false) and (active " +
+				"eq true)",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetLicenseKeyByExternalReferenceCodeThrowsWhenMissing() {
+		Assertions.assertThrows(
+			NoSuchLicenseKeyException.class,
+			() -> _licenseKeyService.getLicenseKeyByExternalReferenceCode(
+				"missing-erc"));
+	}
+
+	@Test
+	public void testGetLicenseKeysByEntitlementFilter() throws Exception {
+		_licenseKeyService.getLicenseKeys(777L, false, true);
+
+		Assertions.assertEquals(
+			"(entitlementId eq '777') and (complimentary eq false) and " +
+				"(active eq true)",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetLicenseKeysByNameFilter() throws Exception {
+		_licenseKeyService.getLicenseKeysByName("DXP", "srv-1", true);
+
+		Assertions.assertEquals(
+			"(productName eq 'DXP') and (serverId eq 'srv-1') and (active eq " +
+				"true)",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetLicenseKeysByOrderProductServerActiveFilter()
+		throws Exception {
+
+		_licenseKeyService.getLicenseKeys("order-1", "portal", "srv-1", true);
+
+		Assertions.assertEquals(
+			"(orderId eq 'order-1') and (productExternalId eq 'portal') and " +
+				"(serverId eq 'srv-1') and (active eq true)",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetLicenseKeysByProductAndServerFilter() throws Exception {
+		_licenseKeyService.getLicenseKeys("portal", "srv-1");
+
+		Assertions.assertEquals(
+			"(productExternalId eq 'portal') and (serverId eq 'srv-1')",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetLicenseKeysByTypeOwnerDomainsFilter() throws Exception {
+		_licenseKeyService.getLicenseKeys(
+			"enterprise", "Acme Corp", "example.com");
+
+		Assertions.assertEquals(
+			"(licenseType eq 'enterprise') and (owner eq 'Acme Corp') and " +
+				"(domains eq 'example.com')",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testSearchBuildsFilterAndSkipsNulls() throws Exception {
+		_licenseKeyService.search(
+			"enterprise", null, null, null, null, null, null, "DXP", null,
+			Boolean.TRUE);
+
+		Assertions.assertEquals(
+			"(licenseType eq 'enterprise') and (productName eq 'DXP') and " +
+				"(active eq true)",
+			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testSearchWithNoCriteriaUsesNullFilter() throws Exception {
+		_licenseKeyService.search(
+			null, null, null, null, null, null, null, null, null, null);
+
+		Assertions.assertNull(_filterCaptor.getValue());
+	}
+
+	private ArgumentCaptor<String> _filterCaptor;
+	private LicenseKeyService _licenseKeyService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
@@ -122,6 +122,15 @@ public class LicenseKeyServiceTest {
 	}
 
 	@Test
+	public void testSearchEscapesSingleQuotes() throws Exception {
+		_licenseKeyService.search(
+			null, "O'Connor", null, null, null, null, null, null, null, null);
+
+		Assertions.assertEquals(
+			"(owner eq 'O''Connor')", _filterCaptor.getValue());
+	}
+
+	@Test
 	public void testSearchWithNoCriteriaUsesNullFilter() throws Exception {
 		_licenseKeyService.search(
 			null, null, null, null, null, null, null, null, null, null);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97362

## What is being fixed

The OSB-provisioning `LicenseKeyLocalServiceImpl` (Service Builder) had no
equivalent in the One Liferay Spring Boot client extension. This ports its
public surface, swapping Service Builder persistence and the finder/Indexer
queries to the `LicenseKey` Object headless API (`/o/c/licensekeys`).

## How it is being fixed

`LicenseKeyService` gains the create, update (active / complimentary),
extend, replace, get, and finder operations, each backed by `/o/c/licensekeys`
calls (OData filters for reads, POST/PATCH for writes). Validation runs
through the merged `LicenseKeyValidator`, and the digest key is produced by a
new shared `LicenseKeyGenerator` component extracted from `LicenseKeyExporter`
so both the exporter and the service use one key-generation implementation.
Unit tests cover the finder/search OData-filter construction and key
generation.

## Notes for review (deltas from a literal reading of the ACs)

Out-of-scope method drops (no equivalent in the One model): the product
consumption methods (`addProductConsumption` / `deleteProductConsumption`) —
there is no ProductConsumption object; `reindex` — Objects self-index; and
the Elasticsearch `Indexer` / `Hits`-based `search` variants — replaced by
OData filtering.

Two finders are semantic remaps because their source fields were re-homed:
`findByUuid` maps to `externalReferenceCode` (no `uuid` field on the Object),
and `findByPPK_C_A` maps to `entitlementId` (per Amos, the One equivalent of a
product purchase is the commerce order item, which is one-to-one with the
entitlement).

The create/update JSON bodies are verified against a live instance rather
than by unit tests, since their `post`/`patch` calls live in a different
package and cannot be mocked from the test.

`LicenseKeyService`'s injection of `SubscriptionEntryService` (for
`extendLicenseKey`'s subscription copy) closes a dependency cycle with the
pre-existing `SubscriptionEntryService` to `LicenseKeyService` dependency; it
is broken with `@Lazy`.
