### PR TITLE
LPD-90603 Persist SSA SaaS Trial fields and wire the SSA entry point

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
@@ -10,9 +10,11 @@ liferay-one-custom-element:
     name: Liferay One
     portletCategoryName: category.client-extensions
     properties:
+        accountExternalReferenceCode: SSA-ACCOUNT
         jira-fls-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/204
         jira-fls-project: LRFLS
         jira-hc-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/105
+        productId: 42226
     type: customElement
     urls:
         -   index.*.js

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
@@ -15,7 +15,6 @@ liferay-one-custom-element:
         jira-fls-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/204
         jira-fls-project: LRFLS
         jira-hc-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/105
-        productExternalReferenceCode: PRDCT-TRIAL
     type: customElement
     urls:
         -   index.*.js

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
@@ -11,6 +11,7 @@ liferay-one-custom-element:
     portletCategoryName: category.client-extensions
     properties:
         accountExternalReferenceCode: SSA-ACCOUNT
+        cloudConsoleURL: https://console.liferay.cloud
         jira-fls-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/204
         jira-fls-project: LRFLS
         jira-hc-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/105

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/client-extension.yaml
@@ -15,7 +15,7 @@ liferay-one-custom-element:
         jira-fls-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/204
         jira-fls-project: LRFLS
         jira-hc-portal-url: https://liferay.atlassian.net/servicedesk/customer/portal/105
-        productId: 42226
+        productExternalReferenceCode: PRDCT-TRIAL
     type: customElement
     urls:
         -   index.*.js

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useDeliveryProductByExternalReferenceCode.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useDeliveryProductByExternalReferenceCode.ts
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import useSWR from 'swr';
+import HeadlessCommerceDeliveryCatalog from '~/services/headless/HeadlessCommerceDeliveryCatalog';
+import {Liferay} from '~/services/liferay/liferay';
+
+const useDeliveryProductByExternalReferenceCode = (
+	externalReferenceCode: string
+) => {
+	return useSWR(
+		externalReferenceCode
+			? `/delivery-product-by-external-reference-code/${externalReferenceCode}`
+			: null,
+		async () => {
+			const {items} =
+				await HeadlessCommerceDeliveryCatalog.getProductsPage(
+					Liferay.CommerceContext.commerceChannelId,
+					new URLSearchParams({
+						'accountId': '-1',
+						'attachments.accountId': '-1',
+						'filter': `externalReferenceCode eq '${externalReferenceCode}'`,
+						'images.accountId': '-1',
+						'nestedFields':
+							'attachments,categories,images,productSpecifications,skus',
+						'pageSize': '1',
+						'skus.accountId': '-1',
+						'skus.currencyCode':
+							Liferay.CommerceContext.currency.currencyCode,
+					})
+				);
+
+			return items?.[0];
+		}
+	);
+};
+
+export {useDeliveryProductByExternalReferenceCode};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useSSAProduct.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useSSAProduct.ts
@@ -6,22 +6,23 @@
 import useSWR from 'swr';
 import HeadlessCommerceDeliveryCatalog from '~/services/headless/HeadlessCommerceDeliveryCatalog';
 import {Liferay} from '~/services/liferay/liferay';
+import SearchBuilder from '~/utils/SearchBuilder';
 
-const useDeliveryProductByExternalReferenceCode = (
-	externalReferenceCode: string
-) => {
+const useSSAProduct = () => {
+	const commerceChannelId = Liferay.CommerceContext.commerceChannelId;
+
 	return useSWR(
-		externalReferenceCode
-			? `/delivery-product-by-external-reference-code/${externalReferenceCode}`
-			: null,
+		commerceChannelId ? `/ssa-product/${commerceChannelId}` : null,
 		async () => {
 			const {items} =
 				await HeadlessCommerceDeliveryCatalog.getProductsPage(
-					Liferay.CommerceContext.commerceChannelId,
+					commerceChannelId,
 					new URLSearchParams({
 						'accountId': '-1',
 						'attachments.accountId': '-1',
-						'filter': `externalReferenceCode eq '${externalReferenceCode}'`,
+						'filter': new SearchBuilder()
+							.lambda('specificationValues', 'ssa-saas')
+							.build(),
 						'images.accountId': '-1',
 						'nestedFields':
 							'attachments,categories,images,productSpecifications,skus',
@@ -37,4 +38,4 @@ const useDeliveryProductByExternalReferenceCode = (
 	);
 };
 
-export {useDeliveryProductByExternalReferenceCode};
+export {useSSAProduct};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/CreateTrialModalForm.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/CreateTrialModalForm.tsx
@@ -18,7 +18,7 @@ import Loading from '~/components/Loading/Loading';
 import Modal from '~/components/Modal/Modal';
 import Select from '~/components/Select/Select';
 import {useOneContext} from '~/context/OneContextProvider';
-import {useDeliveryProduct} from '~/hooks/useDeliveryProduct';
+import {useDeliveryProductByExternalReferenceCode} from '~/hooks/useDeliveryProductByExternalReferenceCode';
 import i18n from '~/i18n';
 import {useSSADashboardOutlet} from '~/pages/Admin/SSADashboard/hooks/useSSADashboardOutlet';
 import {
@@ -70,7 +70,9 @@ const CreateTrialModalForm: React.FC<CreateTrialModalFormProps> = ({
 }) => {
 	const {ssaAccount} = useSSADashboardOutlet();
 	const {properties} = useOneContext();
-	const {data: product} = useDeliveryProduct(properties.productId);
+	const {data: product} = useDeliveryProductByExternalReferenceCode(
+		properties.productExternalReferenceCode
+	);
 
 	const productPurchase = useMemo(() => {
 		if (!ssaAccount || !product) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/CreateTrialModalForm.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/SSADashboard/components/CreateTrialModalForm.tsx
@@ -18,7 +18,7 @@ import Loading from '~/components/Loading/Loading';
 import Modal from '~/components/Modal/Modal';
 import Select from '~/components/Select/Select';
 import {useOneContext} from '~/context/OneContextProvider';
-import {useDeliveryProductByExternalReferenceCode} from '~/hooks/useDeliveryProductByExternalReferenceCode';
+import {useSSAProduct} from '~/hooks/useSSAProduct';
 import i18n from '~/i18n';
 import {useSSADashboardOutlet} from '~/pages/Admin/SSADashboard/hooks/useSSADashboardOutlet';
 import {
@@ -70,9 +70,7 @@ const CreateTrialModalForm: React.FC<CreateTrialModalFormProps> = ({
 }) => {
 	const {ssaAccount} = useSSADashboardOutlet();
 	const {properties} = useOneContext();
-	const {data: product} = useDeliveryProductByExternalReferenceCode(
-		properties.productExternalReferenceCode
-	);
+	const {data: product} = useSSAProduct();
 
 	const productPurchase = useMemo(() => {
 		if (!ssaAccount || !product) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributeUtils.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributeUtils.ts
@@ -16,7 +16,7 @@ export const baseAttributes = [
 	'lastYearProjectsUsingMarketplaceAppsCount',
 	'marketoFormIdDefault',
 	'marketoFormIdLiferayProduct',
-	'productId',
+	'productExternalReferenceCode',
 	'publisherLicenseAgreement',
 	'ssaProjectPrefix',
 	'trialAccountCheck',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributeUtils.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/attributeUtils.ts
@@ -16,7 +16,6 @@ export const baseAttributes = [
 	'lastYearProjectsUsingMarketplaceAppsCount',
 	'marketoFormIdDefault',
 	'marketoFormIdLiferayProduct',
-	'productExternalReferenceCode',
 	'publisherLicenseAgreement',
 	'ssaProjectPrefix',
 	'trialAccountCheck',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
@@ -404,6 +404,98 @@
 	},
 	{
 		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-end-date",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-error",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-error-date",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-notify-end-date",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"defaultValue": "{}",
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-settings",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-start-date",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "trial-virtual-host",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
 		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
 		"name": "cloudRegion",
 		"properties": {

--- a/workspaces/liferay-one-workspace/scripts/seed/data/01-account.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/01-account.batch-engine-data.json
@@ -127,6 +127,11 @@
 			"externalReferenceCode": "ACCNT-022",
 			"name": "No Project Test Account",
 			"type": "business"
+		},
+		{
+			"externalReferenceCode": "SSA-ACCOUNT",
+			"name": "SSA Account",
+			"type": "business"
 		}
 	]
 }

--- a/workspaces/liferay-one-workspace/scripts/seed/data/06-commerce-product.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/06-commerce-product.batch-engine-data.json
@@ -1992,6 +1992,12 @@
 					}
 				},
 				{
+					"specificationKey": "product-type",
+					"value": {
+						"en_US": "ssa-saas"
+					}
+				},
+				{
 					"specificationKey": "publisher-name",
 					"value": {
 						"en_US": "Liferay, Inc."


### PR DESCRIPTION
Resend of #1249 (closed without merge), rebased onto the current `master-temp`.

Addresses the review feedback about referencing the trial product by a hardcoded identifier in the React app attributes.

The SSA trial product was resolved from a hardcoded `productId` in `client-extension.yaml` / the custom element attributes, embedding a reference to a specific business record into the build configuration (and the numeric id is not portable across environments). Following the original Marketplace approach, the trial product is now tagged with the `ssa-saas` `product-type` specification and resolved at runtime by filtering the delivery catalog (the same `SearchBuilder.lambda('specificationValues', …)` pattern already used in `useKPI`). This removes the product reference from the build configuration.

The `accountExternalReferenceCode` property is intentionally kept as-is: it is a faithful migration of the Marketplace behavior for the SSA singleton account.

Assumes a single `ssa-saas` product exists in the channel.
