### PR TITLE
LPD-90455 LPD-94194 Project-scope business events and attachments API

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -6,7 +6,7 @@
 package com.liferay.one;
 
 import com.liferay.one.jira.service.AccountAssetService;
-import com.liferay.one.permission.BusinessEventPermission;
+import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.service.AccountService;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
@@ -51,8 +51,7 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("accountRoleId") long accountRoleId)
 		throws Exception {
 
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
+		_accountPermission.check(externalReferenceCode, ActionKeys.UPDATE, jwt);
 
 		_accountService.removeAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
@@ -64,8 +63,7 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("externalReferenceCode") String externalReferenceCode)
 		throws Exception {
 
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
+		_accountPermission.check(externalReferenceCode, ActionKeys.VIEW, jwt);
 
 		return new ResponseEntity<>(
 			_accountAssetService.getAccountObjectKey(externalReferenceCode),
@@ -102,9 +100,9 @@ public class AccountsRestController extends OneBaseRestController {
 	private AccountAssetService _accountAssetService;
 
 	@Autowired
-	private AccountService _accountService;
+	private AccountPermission _accountPermission;
 
 	@Autowired
-	private BusinessEventPermission _businessEventPermission;
+	private AccountService _accountService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/BusinessEventsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/BusinessEventsRestController.java
@@ -40,69 +40,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class BusinessEventsRestController extends OneBaseRestController {
 
-	@DeleteMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> deleteAccountsBusinessEvents(
+	@DeleteMapping("/projects/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> deleteProjectsBusinessEvents(
 			@AuthenticationPrincipal Jwt jwt,
 			@PathVariable("externalReferenceCode") String externalReferenceCode,
 			@PathVariable("id") String id)
 		throws Exception {
 
 		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
+			ActionKeys.UPDATE, jwt, externalReferenceCode);
 
 		_businessEventService.deleteBusinessEvent(id);
 
 		return new ResponseEntity<>(HttpStatus.OK);
-	}
-
-	@GetMapping("/accounts/{externalReferenceCode}/business-events")
-	public ResponseEntity<String> getAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		return getResponseEntity(
-			_businessEventService.getBusinessEvents(externalReferenceCode),
-			BusinessEvent::toJSONObject);
-	}
-
-	@GetMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> getAccountsBusinessEvents(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		BusinessEvent businessEvent = _businessEventService.getBusinessEvent(
-			id);
-
-		return new ResponseEntity<>(
-			businessEvent.toJSONObject(
-			).toString(),
-			HttpStatus.OK);
-	}
-
-	@GetMapping(
-		"/accounts/{externalReferenceCode}/business-events/{id}/versions"
-	)
-	public ResponseEntity<String> getAccountsBusinessEventsVersions(
-			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@PathVariable("id") String id)
-		throws Exception {
-
-		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
-
-		return getResponseEntity(
-			_businessEventService.getBusinessEventVersions(id),
-			BusinessEventVersion::toJSONObject);
 	}
 
 	@GetMapping("/business-events/fields/{fieldName}/options")
@@ -122,29 +72,79 @@ public class BusinessEventsRestController extends OneBaseRestController {
 			ProductVersion::toJSONObject);
 	}
 
-	@PostMapping("/accounts/{externalReferenceCode}/business-events")
-	public ResponseEntity<String> postAccountsBusinessEvents(
+	@GetMapping("/projects/{externalReferenceCode}/business-events")
+	public ResponseEntity<String> getProjectsBusinessEvents(
 			@AuthenticationPrincipal Jwt jwt,
-			@PathVariable("externalReferenceCode") String externalReferenceCode,
-			@RequestBody String json)
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
 		throws Exception {
 
 		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
-
-		UserAccount userAccount = getMyUserAccount(jwt);
-
-		_businessEventService.createBusinessEvent(
-			_businessEventConverter.toBusinessEvent(
-				externalReferenceCode, json, userAccount.getEmailAddress()));
+			ActionKeys.VIEW, jwt, externalReferenceCode);
 
 		return getResponseEntity(
 			_businessEventService.getBusinessEvents(externalReferenceCode),
 			BusinessEvent::toJSONObject);
 	}
 
-	@PutMapping("/accounts/{externalReferenceCode}/business-events/{id}")
-	public ResponseEntity<String> putAccountsBusinessEvents(
+	@GetMapping("/projects/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> getProjectsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id)
+		throws Exception {
+
+		_businessEventPermission.check(
+			ActionKeys.VIEW, jwt, externalReferenceCode);
+
+		BusinessEvent businessEvent = _businessEventService.getBusinessEvent(
+			id);
+
+		return new ResponseEntity<>(
+			businessEvent.toJSONObject(
+			).toString(),
+			HttpStatus.OK);
+	}
+
+	@GetMapping(
+		"/projects/{externalReferenceCode}/business-events/{id}/versions"
+	)
+	public ResponseEntity<String> getProjectsBusinessEventsVersions(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("id") String id)
+		throws Exception {
+
+		_businessEventPermission.check(
+			ActionKeys.VIEW, jwt, externalReferenceCode);
+
+		return getResponseEntity(
+			_businessEventService.getBusinessEventVersions(id),
+			BusinessEventVersion::toJSONObject);
+	}
+
+	@PostMapping("/projects/{externalReferenceCode}/business-events")
+	public ResponseEntity<String> postProjectsBusinessEvents(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@RequestBody String json)
+		throws Exception {
+
+		_businessEventPermission.check(
+			ActionKeys.UPDATE, jwt, externalReferenceCode);
+
+		UserAccount userAccount = getMyUserAccount(jwt);
+
+		_businessEventService.createBusinessEvent(
+			_businessEventConverter.toBusinessEvent(
+				json, userAccount.getEmailAddress(), externalReferenceCode));
+
+		return getResponseEntity(
+			_businessEventService.getBusinessEvents(externalReferenceCode),
+			BusinessEvent::toJSONObject);
+	}
+
+	@PutMapping("/projects/{externalReferenceCode}/business-events/{id}")
+	public ResponseEntity<String> putProjectsBusinessEvents(
 			@AuthenticationPrincipal Jwt jwt,
 			@PathVariable("externalReferenceCode") String externalReferenceCode,
 			@PathVariable("id") String id, @RequestBody String json)
@@ -155,12 +155,12 @@ public class BusinessEventsRestController extends OneBaseRestController {
 		}
 
 		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.UPDATE, jwt);
+			ActionKeys.UPDATE, jwt, externalReferenceCode);
 
 		UserAccount userAccount = getMyUserAccount(jwt);
 
 		BusinessEvent businessEvent = _businessEventConverter.toBusinessEvent(
-			externalReferenceCode, json, userAccount.getEmailAddress());
+			json, userAccount.getEmailAddress(), externalReferenceCode);
 
 		businessEvent = _businessEventService.updateBusinessEvent(
 			businessEvent, id);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/JiraRestController.java
@@ -28,8 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class JiraRestController extends OneBaseRestController {
 
-	@GetMapping("/accounts/{externalReferenceCode}/tickets")
-	public ResponseEntity<String> getAccountsTickets(
+	@GetMapping("/projects/{externalReferenceCode}/tickets")
+	public ResponseEntity<String> getProjectsTickets(
 			@AuthenticationPrincipal Jwt jwt,
 			@PathVariable("externalReferenceCode") String externalReferenceCode,
 			@RequestParam(defaultValue = StringPool.BLANK, required = false)
@@ -37,7 +37,7 @@ public class JiraRestController extends OneBaseRestController {
 		throws Exception {
 
 		_businessEventPermission.check(
-			externalReferenceCode, ActionKeys.VIEW, jwt);
+			ActionKeys.VIEW, jwt, externalReferenceCode);
 
 		return getResponseEntity(
 			_jiraIssueService.getSupportIssues(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -5,12 +5,18 @@
 
 package com.liferay.one;
 
+import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.permission.BusinessEventPermission;
 import com.liferay.one.service.ProjectMembershipService;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +43,20 @@ public class ProjectRestController extends OneBaseRestController {
 			jwt, projectId, accountRoleExternalReferenceCode, userId);
 	}
 
+	@GetMapping("/{externalReferenceCode}/jira/object-key")
+	public ResponseEntity<String> getJiraObjectKey(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_businessEventPermission.check(
+			ActionKeys.VIEW, jwt, externalReferenceCode);
+
+		return new ResponseEntity<>(
+			_accountAssetService.getAccountObjectKey(externalReferenceCode),
+			HttpStatus.OK);
+	}
+
 	@PostMapping(
 		"/{projectId}/user-accounts/{userId}/account-roles" +
 			"/{accountRoleExternalReferenceCode}"
@@ -50,6 +70,12 @@ public class ProjectRestController extends OneBaseRestController {
 		_projectMembershipService.addProjectMembership(
 			jwt, projectId, accountRoleExternalReferenceCode, userId);
 	}
+
+	@Autowired
+	private AccountAssetService _accountAssetService;
+
+	@Autowired
+	private BusinessEventPermission _businessEventPermission;
 
 	@Autowired
 	private ProjectMembershipService _projectMembershipService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketAttachmentsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketAttachmentsRestController.java
@@ -19,6 +19,7 @@ import com.liferay.one.jira.service.JiraIssueService;
 import com.liferay.one.model.TicketAttachment;
 import com.liferay.one.service.GoogleCloudStorageService;
 import com.liferay.one.service.NotificationQueueEntryService;
+import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.TicketAttachmentService;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
@@ -268,7 +269,10 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 
 		Organization organization = supportIssue.getOrganization();
 
-		String accountKey = organization.getExternalKey();
+		String projectERC = organization.getExternalKey();
+
+		String accountERC = _projectService.fetchAccountExternalReferenceCode(
+			projectERC);
 
 		TicketAttachment ticketAttachment =
 			_ticketAttachmentService.fetchTicketAttachment(
@@ -282,16 +286,16 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 		}
 		else {
 			ticketAttachment = _ticketAttachmentService.addTicketAttachment(
-				accountKey, "Bearer " + jwt.getTokenValue(),
+				accountERC, "Bearer " + jwt.getTokenValue(),
 				jsonObject.optString("externalReferenceCode"), fileName,
-				fileSize, ticketId, md5Checksum, TicketAttachment.STATUS_DRAFT,
-				jsonObject.optString("type"));
+				fileSize, ticketId, md5Checksum, projectERC,
+				TicketAttachment.STATUS_DRAFT, jsonObject.optString("type"));
 		}
 
 		JSONObject responseJSONObject = new JSONObject();
 
 		responseJSONObject.put(
-			"accountKey", accountKey
+			"projectKey", projectERC
 		).put(
 			"ticketAttachmentId", ticketAttachment.getTicketAttachmentId()
 		);
@@ -655,6 +659,9 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 
 	@Value("${liferay.one.portal.url}")
 	private String _onePortalURL;
+
+	@Autowired
+	private ProjectService _projectService;
 
 	@Autowired
 	private TicketAttachmentService _ticketAttachmentService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketsTicketAttachmentsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketsTicketAttachmentsRestController.java
@@ -5,9 +5,6 @@
 
 package com.liferay.one;
 
-import com.liferay.headless.admin.user.client.dto.v1_0.Account;
-import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
-import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.RoleConstants;
@@ -15,10 +12,11 @@ import com.liferay.one.jira.exception.OrganizationNotFoundException;
 import com.liferay.one.jira.model.Organization;
 import com.liferay.one.jira.model.SupportIssue;
 import com.liferay.one.jira.service.JiraIssueService;
-import com.liferay.one.service.AccountService;
+import com.liferay.one.permission.ProjectMembershipPermission;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -78,6 +76,33 @@ public class TicketsTicketAttachmentsRestController
 			"JIRA_ORGANIZATION_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
+	@ExceptionHandler(PrincipalException.class)
+	public ResponseEntity<String> handleException(
+		PrincipalException principalException) {
+
+		_log.error(principalException);
+
+		return new ResponseEntity<>("FORBIDDEN_ACCESS", HttpStatus.FORBIDDEN);
+	}
+
+	private void _checkViewPermission(
+			Jwt jwt, String projectExternalReferenceCode)
+		throws Exception {
+
+		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
+
+		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
+			String roleBriefName = roleBrief.getName();
+
+			if (roleBriefName.equals(RoleConstants.NAME_PROVISIONING_MEMBER)) {
+				return;
+			}
+		}
+
+		_projectMembershipPermission.check(
+			ActionKeys.UPDATE, jwt, projectExternalReferenceCode);
+	}
+
 	private ResponseEntity<String> _getResponseEntity(
 			boolean allowClosedTicket, Jwt jwt, String ticketId)
 		throws Exception {
@@ -96,69 +121,19 @@ public class TicketsTicketAttachmentsRestController
 
 		Organization organization = supportIssue.getOrganization();
 
-		if (!_hasViewPermission(organization.getExternalKey(), jwt)) {
-			return new ResponseEntity<>(
-				"FORBIDDEN_ACCESS", HttpStatus.FORBIDDEN);
-		}
+		_checkViewPermission(jwt, organization.getExternalKey());
 
 		return new ResponseEntity<>(StringPool.BLANK, HttpStatus.OK);
-	}
-
-	private boolean _hasViewPermission(
-			String accountExternalReferenceCode, Jwt jwt)
-		throws Exception {
-
-		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
-
-		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
-			String roleBriefName = roleBrief.getName();
-
-			if (roleBriefName.equals(RoleConstants.NAME_PROVISIONING_MEMBER)) {
-				return true;
-			}
-		}
-
-		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {
-			if (!accountExternalReferenceCode.equals(
-					accountBrief.getExternalReferenceCode())) {
-
-				continue;
-			}
-
-			for (RoleBrief roleBrief : accountBrief.getRoleBriefs()) {
-				if (ArrayUtil.contains(
-						RoleConstants.NAMES_SUPPORT_ACCOUNT_TICKET,
-						roleBrief.getName())) {
-
-					return true;
-				}
-			}
-		}
-
-		Account account = _accountService.getAccount(
-			accountExternalReferenceCode, jwt);
-
-		for (OrganizationBrief organizationBrief :
-				userAccount.getOrganizationBriefs()) {
-
-			if (ArrayUtil.contains(
-					account.getOrganizationIds(), organizationBrief.getId())) {
-
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private static final Log _log = LogFactory.getLog(
 		TicketsTicketAttachmentsRestController.class);
 
 	@Autowired
-	private AccountService _accountService;
+	private JiraIssueService _jiraIssueService;
 
 	@Autowired
-	private JiraIssueService _jiraIssueService;
+	private ProjectMembershipPermission _projectMembershipPermission;
 
 	@Autowired
 	private UserAccountService _userAccountService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
@@ -11,6 +11,20 @@ package com.liferay.one.constants;
  */
 public class RoleConstants {
 
+	public static final String ERC_PROJECT_ADMIN = "C_PROJECT_ADMIN";
+
+	public static final String ERC_PROJECT_REQUESTER = "C_PROJECT_REQUESTER";
+
+	public static final String ERC_PROJECT_USER = "C_PROJECT_USER";
+
+	public static final String[] ERCS_SUPPORT_PROJECT = {
+		ERC_PROJECT_ADMIN, ERC_PROJECT_REQUESTER, ERC_PROJECT_USER
+	};
+
+	public static final String[] ERCS_SUPPORT_PROJECT_TICKET = {
+		ERC_PROJECT_ADMIN, ERC_PROJECT_REQUESTER
+	};
+
 	public static final String NAME_ACCOUNT_ADMINISTRATOR =
 		"Account Administrator";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BusinessEventConverter.java
@@ -76,14 +76,13 @@ public class BusinessEventConverter extends BaseAssetObjectConverter {
 	}
 
 	public BusinessEvent toBusinessEvent(
-		String accountExternalReferenceCode,
-		JSONObject jiraAssetObjectJSONObject) {
+		JSONObject jiraAssetObjectJSONObject,
+		String projectExternalReferenceCode) {
 
 		JiraAssetObject jiraAssetObject = new JiraAssetObject(
 			jiraAssetObjectJSONObject, getAttributeIds());
 
 		return new BusinessEvent(
-			accountExternalReferenceCode,
 			jiraAssetObject.getAttributeValue(
 				BusinessEventConstants.ATTRIBUTE_NAME_ACTUAL_EVENT_DATE),
 			jiraAssetObject.getAttributeDisplayValue(
@@ -113,18 +112,18 @@ public class BusinessEventConverter extends BaseAssetObjectConverter {
 				BusinessEventConstants.ATTRIBUTE_NAME_NEW_VERSION),
 			jiraAssetObject.getAttributeValue(
 				BusinessEventConstants.ATTRIBUTE_NAME_PLANNED_EVENT_DATE),
+			projectExternalReferenceCode,
 			jiraAssetObject.getAttributeDisplayValue(
 				BusinessEventConstants.ATTRIBUTE_NAME_TIME_ZONE));
 	}
 
 	public BusinessEvent toBusinessEvent(
-		String accountExternalReferenceCode, String attributesJSON,
-		String authorEmailAddress) {
+		String attributesJSON, String authorEmailAddress,
+		String projectExternalReferenceCode) {
 
 		JSONObject attributesJSONObject = new JSONObject(attributesJSON);
 
 		return new BusinessEvent(
-			accountExternalReferenceCode,
 			attributesJSONObject.optString("actualEventDate"),
 			attributesJSONObject.optString("associatedTickets"),
 			authorEmailAddress, StringPool.BLANK,
@@ -137,6 +136,7 @@ public class BusinessEventConverter extends BaseAssetObjectConverter {
 			attributesJSONObject.optString("newLiferayVersion"),
 			StringPool.BLANK,
 			attributesJSONObject.optString("plannedEventDate"),
+			projectExternalReferenceCode,
 			attributesJSONObject.optString("timeZone"));
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/BusinessEvent.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/BusinessEvent.java
@@ -15,16 +15,15 @@ import org.json.JSONObject;
 public class BusinessEvent {
 
 	public BusinessEvent(
-		String accountExternalReferenceCode, String actualEventDate,
-		String associatedTickets, String authorEmailAddress,
-		String businessEventId, String currentLiferayVersionKey,
-		String currentLiferayVersionName, String description,
-		String eventStatusName, String eventTypeName, String lastComment,
-		String lastUpdatedAuthorEmailAddress, String name,
+		String actualEventDate, String associatedTickets,
+		String authorEmailAddress, String businessEventId,
+		String currentLiferayVersionKey, String currentLiferayVersionName,
+		String description, String eventStatusName, String eventTypeName,
+		String lastComment, String lastUpdatedAuthorEmailAddress, String name,
 		String newLiferayVersionKey, String newLiferayVersionName,
-		String plannedEventDate, String timeZoneName) {
+		String plannedEventDate, String projectExternalReferenceCode,
+		String timeZoneName) {
 
-		_accountExternalReferenceCode = accountExternalReferenceCode;
 		_actualEventDate = actualEventDate;
 		_associatedTickets = associatedTickets;
 		_authorEmailAddress = authorEmailAddress;
@@ -40,11 +39,8 @@ public class BusinessEvent {
 		_newLiferayVersionKey = newLiferayVersionKey;
 		_newLiferayVersionName = newLiferayVersionName;
 		_plannedEventDate = plannedEventDate;
+		_projectExternalReferenceCode = projectExternalReferenceCode;
 		_timeZoneName = timeZoneName;
-	}
-
-	public String getAccountExternalReferenceCode() {
-		return _accountExternalReferenceCode;
 	}
 
 	public String getActivityHistoryURL(String onePortalURL) {
@@ -115,6 +111,10 @@ public class BusinessEvent {
 		return _plannedEventDate;
 	}
 
+	public String getProjectExternalReferenceCode() {
+		return _projectExternalReferenceCode;
+	}
+
 	public String getTimeZoneName() {
 		return _timeZoneName;
 	}
@@ -124,7 +124,7 @@ public class BusinessEvent {
 
 		sb.append(onePortalURL);
 		sb.append("/support/business-events/#/");
-		sb.append(_accountExternalReferenceCode);
+		sb.append(_projectExternalReferenceCode);
 		sb.append("/business-events/");
 		sb.append(_businessEventId);
 
@@ -191,7 +191,6 @@ public class BusinessEvent {
 		return jsonObject;
 	}
 
-	private final String _accountExternalReferenceCode;
 	private final String _actualEventDate;
 	private final String _associatedTickets;
 	private final String _authorEmailAddress;
@@ -207,6 +206,7 @@ public class BusinessEvent {
 	private final String _newLiferayVersionKey;
 	private final String _newLiferayVersionName;
 	private final String _plannedEventDate;
+	private final String _projectExternalReferenceCode;
 	private final String _timeZoneName;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/BusinessEventService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/BusinessEventService.java
@@ -42,7 +42,7 @@ public class BusinessEventService {
 			_businessEventConverter.getObjectTypeId(),
 			_businessEventConverter.toAssetObject(
 				_accountAssetService.getAccountObjectKey(
-					businessEvent.getAccountExternalReferenceCode()),
+					businessEvent.getProjectExternalReferenceCode()),
 				businessEvent));
 	}
 
@@ -52,21 +52,21 @@ public class BusinessEventService {
 
 	public BusinessEvent getBusinessEvent(String id) throws Exception {
 		return _businessEventConverter.toBusinessEvent(
-			StringPool.BLANK, _jiraAssetService.getObject(id));
+			_jiraAssetService.getObject(id), StringPool.BLANK);
 	}
 
 	public List<BusinessEvent> getBusinessEvents(
-			String accountExternalReferenceCode)
+			String projectExternalReferenceCode)
 		throws Exception {
 
 		return _jiraAssetService.searchObjects(
 			_businessEventConverter.getAQLWithBuilder(
 				aqlBuilder -> aqlBuilder.andEquals(
-					accountExternalReferenceCode,
+					projectExternalReferenceCode,
 					BusinessEventConstants.ATTRIBUTE_NAME_ACCOUNT,
 					"External Key")),
 			jsonObject -> _businessEventConverter.toBusinessEvent(
-				accountExternalReferenceCode, jsonObject));
+				jsonObject, projectExternalReferenceCode));
 	}
 
 	public List<BusinessEventVersion> getBusinessEventVersions(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/TicketAttachment.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/TicketAttachment.java
@@ -28,6 +28,7 @@ public class TicketAttachment {
 		_gcsBucketName = jsonObject.getString("gcsBucketName");
 		_jiraIssueKey = jsonObject.optString("jiraIssueKey");
 		_md5Checksum = jsonObject.optString("md5Checksum");
+		_projectKey = jsonObject.optString("projectKey");
 
 		JSONObject statusJSONObject = jsonObject.getJSONObject("status");
 
@@ -83,6 +84,10 @@ public class TicketAttachment {
 		return _md5Checksum;
 	}
 
+	public String getProjectKey() {
+		return _projectKey;
+	}
+
 	public int getStatus() {
 		return _status;
 	}
@@ -118,6 +123,7 @@ public class TicketAttachment {
 	private final String _gcsBucketName;
 	private final String _jiraIssueKey;
 	private final String _md5Checksum;
+	private final String _projectKey;
 	private final int _status;
 	private final String _storageProvider;
 	private final long _ticketAttachmentId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/AccountPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/AccountPermission.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Jenny Chen
+ */
+@Component
+public class AccountPermission {
+
+	public void check(
+			String accountExternalReferenceCode, String actionId, Jwt jwt)
+		throws Exception {
+
+		if (!_contains(accountExternalReferenceCode, actionId, jwt)) {
+			throw new PrincipalException();
+		}
+	}
+
+	private boolean _contains(
+			String accountExternalReferenceCode, String actionId, Jwt jwt)
+		throws Exception {
+
+		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
+
+		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
+			String roleBriefName = roleBrief.getName();
+
+			if (roleBriefName.equals(RoleConstants.NAME_ADMINISTRATOR) ||
+				roleBriefName.equals(RoleConstants.NAME_LIFERAY_STAFF)) {
+
+				return true;
+			}
+		}
+
+		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {
+			if (!accountExternalReferenceCode.equals(
+					accountBrief.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			for (RoleBrief roleBrief : accountBrief.getRoleBriefs()) {
+				if (ArrayUtil.contains(
+						RoleConstants.NAMES_SUPPORT_ACCOUNT,
+						roleBrief.getName()) &&
+					actionId.equals(ActionKeys.VIEW)) {
+
+					return true;
+				}
+
+				if (ArrayUtil.contains(
+						RoleConstants.NAMES_SUPPORT_ACCOUNT_TICKET,
+						roleBrief.getName()) &&
+					actionId.equals(ActionKeys.UPDATE)) {
+
+					return true;
+				}
+			}
+		}
+
+		Account account = _accountService.getAccount(
+			accountExternalReferenceCode, jwt);
+
+		for (OrganizationBrief organizationBrief :
+				userAccount.getOrganizationBriefs()) {
+
+			if (ArrayUtil.contains(
+					account.getOrganizationIds(), organizationBrief.getId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/BusinessEventPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/BusinessEventPermission.java
@@ -5,17 +5,10 @@
 
 package com.liferay.one.permission;
 
-import com.liferay.headless.admin.user.client.dto.v1_0.Account;
-import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
-import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.RoleConstants;
-import com.liferay.one.service.AccountService;
 import com.liferay.one.service.UserAccountService;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
-import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.util.ArrayUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -28,16 +21,7 @@ import org.springframework.stereotype.Component;
 public class BusinessEventPermission {
 
 	public void check(
-			String accountExternalReferenceCode, String actionId, Jwt jwt)
-		throws Exception {
-
-		if (!_contains(accountExternalReferenceCode, actionId, jwt)) {
-			throw new PrincipalException();
-		}
-	}
-
-	private boolean _contains(
-			String accountExternalReferenceCode, String actionId, Jwt jwt)
+			String actionId, Jwt jwt, String projectExternalReferenceCode)
 		throws Exception {
 
 		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
@@ -48,54 +32,16 @@ public class BusinessEventPermission {
 			if (roleBriefName.equals(RoleConstants.NAME_ADMINISTRATOR) ||
 				roleBriefName.equals(RoleConstants.NAME_LIFERAY_STAFF)) {
 
-				return true;
+				return;
 			}
 		}
 
-		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {
-			if (!accountExternalReferenceCode.equals(
-					accountBrief.getExternalReferenceCode())) {
-
-				continue;
-			}
-
-			for (RoleBrief roleBrief : accountBrief.getRoleBriefs()) {
-				if (ArrayUtil.contains(
-						RoleConstants.NAMES_SUPPORT_ACCOUNT,
-						roleBrief.getName()) &&
-					actionId.equals(ActionKeys.VIEW)) {
-
-					return true;
-				}
-
-				if (ArrayUtil.contains(
-						RoleConstants.NAMES_SUPPORT_ACCOUNT_TICKET,
-						roleBrief.getName()) &&
-					actionId.equals(ActionKeys.UPDATE)) {
-
-					return true;
-				}
-			}
-		}
-
-		Account account = _accountService.getAccount(
-			accountExternalReferenceCode, jwt);
-
-		for (OrganizationBrief organizationBrief :
-				userAccount.getOrganizationBriefs()) {
-
-			if (ArrayUtil.contains(
-					account.getOrganizationIds(), organizationBrief.getId())) {
-
-				return true;
-			}
-		}
-
-		return false;
+		_projectMembershipPermission.check(
+			actionId, jwt, projectExternalReferenceCode);
 	}
 
 	@Autowired
-	private AccountService _accountService;
+	private ProjectMembershipPermission _projectMembershipPermission;
 
 	@Autowired
 	private UserAccountService _userAccountService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/ProjectMembershipPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/ProjectMembershipPermission.java
@@ -1,0 +1,156 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.ProjectMembershipService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Felipe Franca
+ */
+@Component
+public class ProjectMembershipPermission {
+
+	public void check(
+			String actionId, Jwt jwt, String projectExternalReferenceCode)
+		throws Exception {
+
+		if (!_contains(actionId, jwt, projectExternalReferenceCode)) {
+			throw new PrincipalException();
+		}
+	}
+
+	private boolean _belongsToAccountOrganization(
+			Jwt jwt, String projectExternalReferenceCode,
+			UserAccount userAccount)
+		throws Exception {
+
+		String accountExternalReferenceCode =
+			_projectService.fetchAccountExternalReferenceCode(
+				projectExternalReferenceCode);
+
+		if (Validator.isNull(accountExternalReferenceCode)) {
+			return false;
+		}
+
+		Account account = _accountService.getAccount(
+			accountExternalReferenceCode, jwt);
+
+		for (OrganizationBrief organizationBrief :
+				userAccount.getOrganizationBriefs()) {
+
+			if (ArrayUtil.contains(
+					account.getOrganizationIds(), organizationBrief.getId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _contains(
+			String actionId, Jwt jwt, String projectExternalReferenceCode)
+		throws Exception {
+
+		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
+
+		if (_isAccountAdministrator(
+				projectExternalReferenceCode, userAccount)) {
+
+			return true;
+		}
+
+		String membershipRoleExternalReferenceCode =
+			_projectMembershipService.getMembershipRole(
+				projectExternalReferenceCode, userAccount.getId());
+
+		if (Validator.isNotNull(membershipRoleExternalReferenceCode)) {
+			if (ArrayUtil.contains(
+					RoleConstants.ERCS_SUPPORT_PROJECT,
+					membershipRoleExternalReferenceCode) &&
+				actionId.equals(ActionKeys.VIEW)) {
+
+				return true;
+			}
+
+			if (ArrayUtil.contains(
+					RoleConstants.ERCS_SUPPORT_PROJECT_TICKET,
+					membershipRoleExternalReferenceCode) &&
+				actionId.equals(ActionKeys.UPDATE)) {
+
+				return true;
+			}
+		}
+
+		return _belongsToAccountOrganization(
+			jwt, projectExternalReferenceCode, userAccount);
+	}
+
+	private boolean _isAccountAdministrator(
+			String projectExternalReferenceCode, UserAccount userAccount)
+		throws Exception {
+
+		String accountExternalReferenceCode =
+			_projectService.fetchAccountExternalReferenceCode(
+				projectExternalReferenceCode);
+
+		if (Validator.isNull(accountExternalReferenceCode)) {
+			return false;
+		}
+
+		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {
+			if (!Objects.equals(
+					accountExternalReferenceCode,
+					accountBrief.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			for (RoleBrief roleBrief : accountBrief.getRoleBriefs()) {
+				if (Objects.equals(
+						RoleConstants.NAME_ACCOUNT_ADMINISTRATOR,
+						roleBrief.getName())) {
+
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Autowired
+	private ProjectMembershipService _projectMembershipService;
+
+	@Autowired
+	private ProjectService _projectService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
@@ -9,9 +9,11 @@ import com.liferay.one.model.Project;
 import com.liferay.one.model.ProjectMembership;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,6 +91,48 @@ public class ProjectMembershipService extends OneBaseService {
 					projectMembership.getExternalReferenceCode()
 				).toUri());
 		}
+	}
+
+	public String getMembershipRole(
+			String projectExternalReferenceCode, long userId)
+		throws Exception {
+
+		String filterString = StringBundler.concat(
+			"(r_projectToProjectMembership_c_projectERC eq '",
+			projectExternalReferenceCode,
+			"') and (r_userToProjectMembership_userId eq '", userId, "')");
+
+		String response = get(
+			getAuthorization(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/projectmemberships"
+			).queryParam(
+				"fields", "roleExternalReferenceCode"
+			).queryParam(
+				"filter", filterString
+			).queryParam(
+				"page", 1
+			).queryParam(
+				"pageSize", 1
+			).build(
+			).toUri());
+
+		if (Validator.isNull(response)) {
+			return null;
+		}
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		JSONArray jsonArray = jsonObject.optJSONArray("items");
+
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return null;
+		}
+
+		JSONObject membershipJSONObject = jsonArray.getJSONObject(0);
+
+		return membershipJSONObject.optString(
+			"roleExternalReferenceCode", null);
 	}
 
 	public List<ProjectMembership> getProjectMemberships(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
@@ -6,6 +6,7 @@
 package com.liferay.one.service;
 
 import com.liferay.one.model.Project;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -13,6 +14,7 @@ import java.net.URI;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.http.HttpStatus;
@@ -26,6 +28,46 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @Component
 public class ProjectService extends OneBaseService {
+
+	public String fetchAccountExternalReferenceCode(
+			String projectExternalReferenceCode)
+		throws Exception {
+
+		String filterString = StringBundler.concat(
+			"externalReferenceCode eq '", projectExternalReferenceCode, "'");
+
+		String response = get(
+			getAuthorization(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/projects"
+			).queryParam(
+				"fields", "r_accountEntryToProject_accountEntryERC"
+			).queryParam(
+				"filter", filterString
+			).queryParam(
+				"page", 1
+			).queryParam(
+				"pageSize", 1
+			).build(
+			).toUri());
+
+		if (Validator.isNull(response)) {
+			return null;
+		}
+
+		JSONObject jsonObject = new JSONObject(response);
+
+		JSONArray jsonArray = jsonObject.optJSONArray("items");
+
+		if ((jsonArray == null) || (jsonArray.length() == 0)) {
+			return null;
+		}
+
+		JSONObject projectJSONObject = jsonArray.getJSONObject(0);
+
+		return projectJSONObject.optString(
+			"r_accountEntryToProject_accountEntryERC", null);
+	}
 
 	public Project fetchProject(String externalReferenceCode) throws Exception {
 		return _fetchProject(getAuthorization(), externalReferenceCode);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/TicketAttachmentService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/TicketAttachmentService.java
@@ -39,16 +39,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class TicketAttachmentService extends OneBaseService {
 
 	public TicketAttachment addTicketAttachment(
-			String accountKey, String authorization,
+			String accountERC, String authorization,
 			String externalReferenceCode, String fileName, String fileSize,
-			String jiraIssueKey, String md5Checksum, int statusCode,
-			String type)
+			String jiraIssueKey, String md5Checksum, String projectERC,
+			int statusCode, String type)
 		throws Exception {
 
 		JSONObject requestJSONObject = new JSONObject();
 
 		requestJSONObject.put(
-			"accountKey", accountKey
+			"accountKey", accountERC
 		).put(
 			"externalReferenceCode", externalReferenceCode
 		).put(
@@ -60,7 +60,9 @@ public class TicketAttachmentService extends OneBaseService {
 		).put(
 			"jiraIssueKey", jiraIssueKey
 		).put(
-			"r_accountEntryToTicketAttachment_accountEntryERC", accountKey
+			"projectKey", projectERC
+		).put(
+			"r_accountEntryToTicketAttachment_accountEntryERC", accountERC
 		).put(
 			"storageProvider", TicketAttachment.STORAGE_PROVIDER_GCS
 		).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90455
https://liferay.atlassian.net/browse/LPD-94194

## What is being fixed

The Spring Boot REST endpoints backing Business Events and Ticket
Attachments were scoped by account. To match the project-scoped frontend
(liferay-one/liferay-portal#1267), these features must resolve and
authorize by project, so a user only reaches the events and attachments
of the projects they belong to.

## How it is being fixed

The business events, tickets, and ticket-attachment endpoints move from
/accounts/{accountERC}/... to /projects/{projectERC}/..., and the JSM
lookups resolve the project's account so they keep querying the Account
asset by external key. Ticket attachments now store the project key
alongside the account, resolving the project to its account on create.

Authorization is reworked around project membership. A single
ProjectMembershipPermission.check grants access to account
administrators, to holders of the project support roles (the
ticket-level roles being required for updates), and — as before — to
members of an organization that owns the account. BusinessEventPermission
keeps the Administrator and Liferay Staff bypass and delegates to it, and
the ticket-attachment view check delegates to it as well, mapping a
denial to FORBIDDEN_ACCESS. The account-scoped logic that other account
features still rely on is preserved as a dedicated AccountPermission, and
AccountsRestController is restored to use it. The single project-scoped
object-key endpoint the frontend needs is added to ProjectRestController,
and RoleConstants carries the project support-role external reference
codes.
