### PR TITLE
LPD-90606 Add LDP workspace provisioning backend

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AnalyticsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AnalyticsRestController.java
@@ -1,0 +1,207 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.client.extension.util.spring.boot3.BaseRestController;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.service.AnalyticsService;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * @author Ricardo Mariz
+ */
+@RequestMapping("/analytics")
+@RestController
+public class AnalyticsRestController extends BaseRestController {
+
+	@PostMapping("provisioning/{orderId}")
+	public ResponseEntity<Void> postProvisioningOrder(
+			@PathVariable long orderId)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Provisioning order " + orderId);
+		}
+
+		Order order = _commerceOrderService.fetchCommerceOrder(orderId);
+
+		if (order == null) {
+			throw new IllegalArgumentException(
+				"No order exists with ID " + orderId);
+		}
+
+		if (!Objects.equals(order.getOrderTypeExternalReferenceCode(), "LDP")) {
+			throw new IllegalArgumentException(
+				"Unsupported order type: " +
+					order.getOrderTypeExternalReferenceCode());
+		}
+
+		Integer paymentStatus = order.getPaymentStatus();
+
+		if (!Objects.equals(
+				paymentStatus,
+				CommerceOrderConstants.ORDER_PAYMENT_STATUS_COMPLETED) &&
+			!Objects.equals(
+				paymentStatus,
+				CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED)) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Skipping provisioning for order ", orderId,
+						" with payment status ", paymentStatus));
+			}
+
+			return ResponseEntity.status(
+				HttpStatus.CONFLICT
+			).build();
+		}
+
+		JSONObject ldpSettingsJSONObject = _getLDPSettingsJSONObject(order);
+
+		String workspaceName = ldpSettingsJSONObject.optString("workspaceName");
+
+		if (Validator.isNull(workspaceName)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Order ", orderId,
+					" has no workspace name in the \"ldpSettings\" custom ",
+					"field"));
+		}
+
+		if (order.getOrderStatus() ==
+				CommerceOrderConstants.ORDER_STATUS_OPEN) {
+
+			_commerceOrderService.updateOrder(
+				null, orderId, CommerceOrderConstants.ORDER_STATUS_PENDING);
+		}
+
+		_commerceOrderService.updateOrder(
+			null, orderId, CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		try {
+			JSONObject analyticsProjectJSONObject =
+				_analyticsService.provisionAnalyticsProject(
+					_getAnalyticsFormJSONObject(order, ldpSettingsJSONObject),
+					"internal", order.getAccountExternalReferenceCode());
+
+			_commerceOrderService.updateOrder(
+				HashMapBuilder.put(
+					"ldpAnalyticsProject", analyticsProjectJSONObject.toString()
+				).put(
+					"ldpWorkspaceName", workspaceName
+				).build(),
+				orderId, CommerceOrderConstants.ORDER_STATUS_COMPLETED,
+				paymentStatus);
+
+			return ResponseEntity.ok(
+			).build();
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_cancelOrder(
+				webClientResponseException.getResponseBodyAsString(), orderId);
+
+			throw webClientResponseException;
+		}
+		catch (Exception exception) {
+			_cancelOrder(exception.getMessage(), orderId);
+
+			throw exception;
+		}
+	}
+
+	private void _cancelOrder(String errorMessage, long orderId)
+		throws Exception {
+
+		_log.error(
+			StringBundler.concat(
+				"Unable to provision LDP workspace for order ", orderId, ": \n",
+				errorMessage));
+
+		_commerceOrderService.updateOrder(
+			HashMapBuilder.put(
+				"ldpError", errorMessage
+			).put(
+				"ldpErrorDate",
+				ZonedDateTime.now(
+				).format(
+					DateTimeFormatter.ISO_INSTANT
+				)
+			).build(),
+			orderId, CommerceOrderConstants.ORDER_STATUS_CANCELLED);
+	}
+
+	private JSONObject _getAnalyticsFormJSONObject(
+		Order order, JSONObject ldpSettingsJSONObject) {
+
+		return new JSONObject(
+		).put(
+			"corpProjectName", ldpSettingsJSONObject.getString("workspaceName")
+		).put(
+			"friendlyURL",
+			ldpSettingsJSONObject.optString("friendlyWorkspaceURL")
+		).put(
+			"incidentReportEmailAddresses",
+			ldpSettingsJSONObject.optJSONArray(
+				"incidentReportContacts", new JSONArray())
+		).put(
+			"name", ldpSettingsJSONObject.getString("workspaceName")
+		).put(
+			"ownerEmailAddress",
+			ldpSettingsJSONObject.optString(
+				"workspaceOwnerEmail", order.getCreatorEmailAddress())
+		).put(
+			"serverLocation",
+			ldpSettingsJSONObject.optString("dataCenterLocation", "INTERNAL")
+		);
+	}
+
+	private JSONObject _getLDPSettingsJSONObject(Order order) {
+		Map<String, String> customFields =
+			(Map<String, String>)order.getCustomFields();
+
+		if (customFields == null) {
+			return new JSONObject();
+		}
+
+		return new JSONObject(customFields.getOrDefault("ldpSettings", "{}"));
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		AnalyticsRestController.class);
+
+	@Autowired
+	private AnalyticsService _analyticsService;
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderConstants.java
@@ -10,6 +10,8 @@ package com.liferay.one.constants;
  */
 public class CommerceOrderConstants {
 
+	public static final int ORDER_PAYMENT_STATUS_COMPLETED = 0;
+
 	public static final int ORDER_PAYMENT_STATUS_NOT_REQUIRED = 23;
 
 	public static final int ORDER_STATUS_CANCELLED = 8;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AnalyticsService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AnalyticsService.java
@@ -1,0 +1,214 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Base64;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Caleb Hall
+ * @author Ricardo Mariz
+ */
+@Component
+public class AnalyticsService extends BaseService {
+
+	public JSONObject getAnalyticsContextJSONObject(String environmentName) {
+		if (Objects.equals(environmentName, "internal")) {
+			return new JSONObject(
+			).put(
+				"emailAddress", _analyticsInternalAuthEmailAddress
+			).put(
+				"password", _analyticsInternalAuthPassword
+			).put(
+				"url", _analyticsInternalAuthUrl
+			);
+		}
+
+		return new JSONObject(
+		).put(
+			"emailAddress", _analyticsAuthEmailAddress
+		).put(
+			"password", _analyticsAuthPassword
+		).put(
+			"url", _analyticsAuthUrl
+		);
+	}
+
+	public String getAuthorization(JSONObject analyticsContextJSONObject) {
+		Base64.Encoder encoder = Base64.getEncoder();
+
+		String authorization =
+			analyticsContextJSONObject.getString("emailAddress") + ":" +
+				analyticsContextJSONObject.getString("password");
+
+		return "Basic " + encoder.encodeToString(authorization.getBytes());
+	}
+
+	public JSONObject getCorpProjectUuidJSONObject(
+		JSONObject analyticsContextJSONObject, String corpProjectUuid) {
+
+		try {
+			JSONObject jsonObject = new JSONObject(
+				get(
+					getAuthorization(analyticsContextJSONObject),
+					UriComponentsBuilder.fromUriString(
+						analyticsContextJSONObject.getString("url")
+					).path(
+						"/o/faro/main/project/corpProjectUuid/" +
+							corpProjectUuid
+					).build(
+					).toUri()));
+
+			if (jsonObject.optInt("groupId") == 0) {
+				return null;
+			}
+
+			return jsonObject;
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to get Analytics Cloud project ",
+						corpProjectUuid, ": \n",
+						webClientResponseException.getResponseBodyAsString()));
+			}
+
+			return null;
+		}
+	}
+
+	public String provision(
+			JSONObject analyticsContextJSONObject, JSONObject jsonObject)
+		throws Exception {
+
+		try {
+			String response = WebClient.builder(
+			).baseUrl(
+				analyticsContextJSONObject.getString("url")
+			).defaultHeader(
+				HttpHeaders.AUTHORIZATION,
+				getAuthorization(analyticsContextJSONObject)
+			).build(
+			).post(
+			).uri(
+				"/o/faro/main/project/provisioned"
+			).contentType(
+				MediaType.APPLICATION_FORM_URLENCODED
+			).body(
+				BodyInserters.fromFormData(
+					"corpProjectName", jsonObject.optString("corpProjectName")
+				).with(
+					"corpProjectUuid", jsonObject.optString("corpProjectUuid")
+				).with(
+					"enableAutoConfiguration",
+					String.valueOf(
+						jsonObject.optBoolean("enableAutoConfiguration", true))
+				).with(
+					"friendlyURL", jsonObject.optString("friendlyURL")
+				).with(
+					"incidentReportEmailAddresses",
+					jsonObject.getJSONArray(
+						"incidentReportEmailAddresses"
+					).toString()
+				).with(
+					"name", jsonObject.getString("name")
+				).with(
+					"serverLocation", jsonObject.getString("serverLocation")
+				).with(
+					"sharedCluster", "false"
+				).with(
+					"trial", "false"
+				).with(
+					"ownerEmailAddress",
+					jsonObject.getString("ownerEmailAddress")
+				)
+			).retrieve(
+			).bodyToMono(
+				String.class
+			).block();
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Analytics project created " + response);
+			}
+
+			return response;
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to provision Analytics Cloud project ", jsonObject,
+					": \n",
+					webClientResponseException.getResponseBodyAsString()));
+
+			throw webClientResponseException;
+		}
+	}
+
+	public JSONObject provisionAnalyticsProject(
+			JSONObject analyticsFormJSONObject, String analyticsEnvironment,
+			String corpProjectUuid)
+		throws Exception {
+
+		JSONObject analyticsContextJSONObject = getAnalyticsContextJSONObject(
+			analyticsEnvironment);
+
+		JSONObject analyticsProjectJSONObject = getCorpProjectUuidJSONObject(
+			analyticsContextJSONObject, corpProjectUuid);
+
+		if (analyticsProjectJSONObject == null) {
+			if (Objects.equals(analyticsEnvironment, "internal")) {
+				analyticsFormJSONObject.put(
+					"serverLocation", "us-west1-ac-uat-c1");
+			}
+
+			analyticsFormJSONObject.put("corpProjectUuid", corpProjectUuid);
+
+			analyticsProjectJSONObject = new JSONObject(
+				provision(analyticsContextJSONObject, analyticsFormJSONObject));
+		}
+
+		return analyticsProjectJSONObject;
+	}
+
+	private static final Log _log = LogFactory.getLog(AnalyticsService.class);
+
+	@Value("${liferay.one.analytics.auth.email.address}")
+	private String _analyticsAuthEmailAddress;
+
+	@Value("${liferay.one.analytics.auth.password}")
+	private String _analyticsAuthPassword;
+
+	@Value("${liferay.one.analytics.auth.url}")
+	private String _analyticsAuthUrl;
+
+	@Value("${liferay.one.analytics.internal.auth.email.address}")
+	private String _analyticsInternalAuthEmailAddress;
+
+	@Value("${liferay.one.analytics.internal.auth.password}")
+	private String _analyticsInternalAuthPassword;
+
+	@Value("${liferay.one.analytics.internal.auth.url}")
+	private String _analyticsInternalAuthUrl;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -2,6 +2,12 @@
 # Application
 #
 
+liferay.one.analytics.auth.email.address=${LIFERAY_ONE_ANALYTICS_AUTH_EMAIL_ADDRESS}
+liferay.one.analytics.auth.password=${LIFERAY_ONE_ANALYTICS_AUTH_PASSWORD}
+liferay.one.analytics.auth.url=${LIFERAY_ONE_ANALYTICS_AUTH_URL}
+liferay.one.analytics.internal.auth.email.address=${LIFERAY_ONE_ANALYTICS_INTERNAL_AUTH_EMAIL_ADDRESS}
+liferay.one.analytics.internal.auth.password=${LIFERAY_ONE_ANALYTICS_INTERNAL_AUTH_PASSWORD}
+liferay.one.analytics.internal.auth.url=${LIFERAY_ONE_ANALYTICS_INTERNAL_AUTH_URL}
 liferay.one.console.auth.email.address=${LIFERAY_ONE_CONSOLE_AUTH_EMAIL_ADDRESS}
 liferay.one.console.auth.password=${LIFERAY_ONE_CONSOLE_AUTH_PASSWORD}
 liferay.one.console.auth.url=${LIFERAY_ONE_CONSOLE_AUTH_URL}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
@@ -223,6 +223,58 @@
 	{
 		"dataType": 15,
 		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "ldpAnalyticsProject",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "ldpError",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "ldpErrorDate",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
+		"name": "ldpSettings",
+		"properties": {
+			"hidden": false,
+			"indexType": 2,
+			"localizeField": false,
+			"localizeFieldName": true,
+			"secret": false,
+			"visibleWithUpdatePermission": false
+		}
+	},
+	{
+		"dataType": 15,
+		"modelResource": "com.liferay.commerce.model.CommerceOrder",
 		"name": "ldpWorkspaceName",
 		"properties": {
 			"hidden": false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90606

## What is being fixed

The LDP provisioning flow lived in the old marketplace, where an object action webhook provisioned an Analytics Cloud workspace through the faro API using the analyticsForm order metadata. Liferay One had no LDP provisioning path.

## How it is being fixed

This ports the AnalyticsService faro client and exposes POST /analytics/provisioning/{orderId} on the Spring Boot client extension. The endpoint reads the ldpSettings order custom field, provisions the workspace in the internal environment exactly as the private beta does, records the result on the order, and completes it. Failures cancel the order and record the error. The Koroneiki product purchase recording and the Pub/Sub async path were intentionally left behind, since Koroneiki consumption was replaced by object action webhooks and the Salesforce order sync.

**pr-check: PASS** — tested on `9abc4a0e14c35659356f1e87fb4a2346cfe4a533`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "9abc4a0e14c35659356f1e87fb4a2346cfe4a533"} -->
