### PR TITLE
LPD-90606 Add LDP purchase flow with a dedicated LDP order type

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/12-commerce-order-type.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/12-commerce-order-type.batch-engine-data.json
@@ -120,6 +120,18 @@
 		{
 			"active": true,
 			"description": {
+				"en_US": "Designates that the order contains a Liferay Data Platform workspace."
+			},
+			"displayOrder": 13,
+			"externalReferenceCode": "LDP",
+			"name": {
+				"en_US": "Liferay Data Platform"
+			},
+			"neverExpire": true
+		},
+		{
+			"active": true,
+			"description": {
 				"en_US": "Designates that the order contains a free or paid low code configuration."
 			},
 			"displayOrder": 9,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -445,6 +445,7 @@ export default {
 	'fragment': 'Fragment',
 	'fragment-collection-of-fragments': 'Fragment/Collection of Fragments',
 	'free': 'Free',
+	'friendly-workspace-url': 'Friendly Workspace URL',
 	'fulfillment-date': 'Fulfillment Date',
 	'full-name': 'Full Name',
 	'general-info': 'General Info',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/constants.ts
@@ -109,6 +109,7 @@ export const TAB_VISIBILITY: Partial<Record<OrderTypes, ProjectTabKey[]>> = {
 		'orders',
 		'help-and-support',
 	],
+	LDP: ['details', 'environment', 'orders'],
 	LOW_CODE_CONFIGURATION: [
 		'details',
 		'download',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/LDPProvisioning/LDPProvisioning.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/LDPProvisioning/LDPProvisioning.tsx
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayForm from '@clayui/form';
+import ClayMultiSelect from '@clayui/multi-select';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {Controller, useForm} from 'react-hook-form';
+import {Navigate} from 'react-router-dom';
+import {z} from 'zod';
+import {Input} from '~/components/Input/Input';
+import i18n from '~/i18n';
+import LicenseTermsCheckbox from '~/pages/ProductPurchase/components/LicenseTermsCheckbox/LicenseTermsCheckbox';
+import {useProductPurchaseLayoutContext} from '~/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout';
+import ProductPurchaseShell from '~/pages/ProductPurchase/components/ProductPurchaseShell/ProductPurchaseShell';
+import adminSchemas from '~/schema/adminSchemas';
+import {Liferay} from '~/services/liferay/liferay';
+
+type FormFields = z.infer<typeof adminSchemas.ldpProvisioning>;
+
+type MultiSelectItem = {
+	label: string;
+	value: string;
+};
+
+const toValues = (items: MultiSelectItem[]) =>
+	items.map((item) => item.value.trim()).filter(Boolean);
+
+const LDPProvisioning = () => {
+	const {
+		actions: {nextStep, previousStep},
+		product,
+		selectedAccount,
+		setLDPSettings,
+	} = useProductPurchaseLayoutContext();
+
+	const {
+		control,
+		formState: {errors, isValid},
+		handleSubmit,
+		register,
+		setValue,
+	} = useForm<FormFields>({
+		defaultValues: {
+			_refAllowedEmailDomains: [],
+			_refIncidentReportContacts: [],
+			acceptTerms: false,
+			allowedEmailDomains: [],
+			dataCenterLocation: 'INTERNAL',
+			friendlyWorkspaceURL: '',
+			incidentReportContacts: [],
+			workspaceName: '',
+			workspaceOwnerEmail: Liferay.ThemeDisplay.getUserEmailAddress(),
+		},
+		mode: 'onChange',
+		resolver: zodResolver(adminSchemas.ldpProvisioning),
+	});
+
+	if (!selectedAccount?.id) {
+		return <Navigate replace to="/" />;
+	}
+
+	const onSubmit = (formFields: FormFields) => {
+		setLDPSettings({
+			allowedEmailDomains: formFields.allowedEmailDomains,
+			dataCenterLocation: formFields.dataCenterLocation,
+			friendlyWorkspaceURL: formFields.friendlyWorkspaceURL,
+			incidentReportContacts: formFields.incidentReportContacts,
+			workspaceName: formFields.workspaceName,
+			workspaceOwnerEmail: formFields.workspaceOwnerEmail,
+		});
+
+		nextStep();
+	};
+
+	return (
+		<ProductPurchaseShell
+			footerProps={{
+				backButtonProps: {
+					onClick: () => previousStep(),
+				},
+				continueButtonProps: {
+					disabled: !isValid,
+					onClick: () => handleSubmit(onSubmit)(),
+				},
+			}}
+			title={i18n.translate('provisioning-details')}
+		>
+			<Input
+				{...register('workspaceName')}
+				errorMessage={errors.workspaceName?.message}
+				label={i18n.translate('workspace-name')}
+				required
+			/>
+
+			<Input
+				{...register('workspaceOwnerEmail')}
+				errorMessage={errors.workspaceOwnerEmail?.message}
+				label={i18n.translate('workspace-owner-email')}
+				required
+			/>
+
+			<Input
+				{...register('friendlyWorkspaceURL')}
+				errorMessage={errors.friendlyWorkspaceURL?.message}
+				label={i18n.translate('friendly-workspace-url')}
+				prependGroupItemSymbol="/"
+			/>
+
+			<Input
+				disabled
+				label={i18n.translate('data-center-location')}
+				name="dataCenterLocation"
+				value="INTERNAL"
+			/>
+
+			<Controller
+				control={control}
+				name="_refIncidentReportContacts"
+				render={({field}) => (
+					<ClayForm.Group
+						className={
+							errors.incidentReportContacts ? 'has-error' : ''
+						}
+					>
+						<label>
+							{i18n.translate('incident-report-contacts')}
+						</label>
+
+						<ClayMultiSelect
+							items={field.value as MultiSelectItem[]}
+							onItemsChange={(items: MultiSelectItem[]) => {
+								field.onChange(items);
+
+								setValue(
+									'incidentReportContacts',
+									toValues(items),
+									{shouldValidate: true}
+								);
+							}}
+						/>
+					</ClayForm.Group>
+				)}
+			/>
+
+			<Controller
+				control={control}
+				name="_refAllowedEmailDomains"
+				render={({field}) => (
+					<ClayForm.Group
+						className={errors.allowedEmailDomains ? 'has-error' : ''}
+					>
+						<label>{i18n.translate('allowed-email-domains')}</label>
+
+						<ClayMultiSelect
+							items={field.value as MultiSelectItem[]}
+							onItemsChange={(items: MultiSelectItem[]) => {
+								field.onChange(items);
+
+								setValue(
+									'allowedEmailDomains',
+									toValues(items),
+									{shouldValidate: true}
+								);
+							}}
+						/>
+					</ClayForm.Group>
+				)}
+			/>
+
+			<Controller
+				control={control}
+				name="acceptTerms"
+				render={({field}) => (
+					<LicenseTermsCheckbox
+						checked={field.value}
+						onChange={() => field.onChange(!field.value)}
+						product={product}
+					/>
+				)}
+			/>
+		</ProductPurchaseShell>
+	);
+};
+
+export default LDPProvisioning;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
@@ -10,7 +10,11 @@ import Loading from '~/components/Loading/Loading';
 import {useDeliveryProduct} from '~/hooks/useDeliveryProduct';
 import useRequireSignIn from '~/hooks/useRequireSignIn';
 import i18n from '~/i18n';
-import {getProductPriceModel} from '~/utils/productUtils';
+import {
+	ProductSpecificationKey,
+	getProductPriceModel,
+	getProductSpecificationValue,
+} from '~/utils/productUtils';
 import {AppRoute, toRouteObjects} from '~/utils/routeUtils';
 
 import ProductPurchaseLayout from './components/ProductPurchaseLayout/ProductPurchaseLayout';
@@ -34,7 +38,13 @@ const PurchaseCompleted = lazy(
 const ProductPurchaseRoutes = ({product}: {product: DeliveryProduct}) => {
 	const {isPaidApp} = getProductPriceModel(product);
 
-	const steps = getProductPurchaseSteps(isPaidApp);
+	const isLDP =
+		getProductSpecificationValue(
+			ProductSpecificationKey.SOLUTION_TYPE,
+			product
+		) === 'liferay-data-platform';
+
+	const steps = getProductPurchaseSteps({isLDP, isPaidApp});
 
 	const routes: AppRoute[] = [
 		{

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout.tsx
@@ -14,9 +14,16 @@ import AccountAvatar from '~/components/AccountAvatar/AccountAvatar';
 import Loading from '~/components/Loading/Loading';
 import i18n from '~/i18n';
 import ProductPurchaseApp from '~/services/commerce/ProductPurchaseApp';
+import ProductPurchaseLDP, {
+	LDPSettings,
+} from '~/services/commerce/ProductPurchaseLDP';
 import HeadlessCommerceDeliveryCart from '~/services/headless/HeadlessCommerceDeliveryCart';
 import {Liferay} from '~/services/liferay/liferay';
-import {getProductPriceModel} from '~/utils/productUtils';
+import {
+	ProductSpecificationKey,
+	getProductPriceModel,
+	getProductSpecificationValue,
+} from '~/utils/productUtils';
 
 import useAccounts from '../../hooks/useAccounts';
 import useProductPurchaseCart from '../../hooks/useProductPurchaseCart';
@@ -48,6 +55,7 @@ export type ProductPurchaseLayoutContext = {
 	product: DeliveryProduct;
 	productPurchaseCart: ReturnType<typeof useProductPurchaseCart>;
 	selectedAccount: Account;
+	setLDPSettings: React.Dispatch<React.SetStateAction<LDPSettings | null>>;
 	setPayment: React.Dispatch<React.SetStateAction<ProductPurchasePayment>>;
 	setSelectedAccount: React.Dispatch<React.SetStateAction<Account>>;
 };
@@ -57,6 +65,7 @@ const ProductPurchaseLayout = ({
 	steps: stepItems,
 }: ProductPurchaseLayoutProps) => {
 	const [isSubmitting, setSubmitting] = useState(false);
+	const [ldpSettings, setLDPSettings] = useState<LDPSettings | null>(null);
 	const [payment, setPayment] = useState<ProductPurchasePayment>({
 		billingAddress: {} as BillingAddress,
 		invoice: {email: '', purchaseOrderNumber: ''},
@@ -105,10 +114,20 @@ const ProductPurchaseLayout = ({
 		setSubmitting(true);
 
 		try {
-			const productPurchase = new ProductPurchaseApp(
-				selectedAccount,
-				product
-			);
+			const isLDP =
+				getProductSpecificationValue(
+					ProductSpecificationKey.SOLUTION_TYPE,
+					product
+				) === 'liferay-data-platform';
+
+			const productPurchase =
+				isLDP && ldpSettings
+					? new ProductPurchaseLDP(
+							selectedAccount,
+							product,
+							ldpSettings
+						)
+					: new ProductPurchaseApp(selectedAccount, product);
 
 			if (isPaidApp) {
 				const cart = await productPurchase.createOrder({
@@ -173,6 +192,7 @@ const ProductPurchaseLayout = ({
 		product,
 		productPurchaseCart,
 		selectedAccount,
+		setLDPSettings,
 		setPayment,
 		setSelectedAccount,
 	};

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
@@ -10,6 +10,9 @@ import {AppRoute} from '~/utils/routeUtils';
 const AccountSelection = lazy(
 	() => import('./AccountSelection/AccountSelection')
 );
+const LDPProvisioning = lazy(
+	() => import('./LDPProvisioning/LDPProvisioning')
+);
 const License = lazy(() => import('./License/License'));
 const PaymentMethod = lazy(() => import('./PaymentMethod/PaymentMethod'));
 const Summary = lazy(() => import('./Summary/Summary'));
@@ -17,6 +20,7 @@ const Summary = lazy(() => import('./Summary/Summary'));
 export type ProductPurchaseStep = {
 	element: ReactNode;
 	index?: boolean;
+	isLDPOnly?: boolean;
 	isPaidOnly?: boolean;
 	path?: string;
 	title: string;
@@ -27,9 +31,13 @@ export type ProductPurchaseStepItem = {
 	title: string;
 };
 
-export function getProductPurchaseSteps(
-	isPaidApp: boolean
-): ProductPurchaseStep[] {
+export function getProductPurchaseSteps({
+	isLDP,
+	isPaidApp,
+}: {
+	isLDP: boolean;
+	isPaidApp: boolean;
+}): ProductPurchaseStep[] {
 	const steps: ProductPurchaseStep[] = [
 		{
 			element: <AccountSelection />,
@@ -49,13 +57,21 @@ export function getProductPurchaseSteps(
 			title: i18n.translate('payment-method'),
 		},
 		{
+			element: <LDPProvisioning />,
+			isLDPOnly: true,
+			path: 'provisioning',
+			title: i18n.translate('provisioning'),
+		},
+		{
 			element: <Summary />,
 			path: 'summary',
 			title: i18n.translate('summary'),
 		},
 	];
 
-	return steps.filter((step) => (isPaidApp ? true : !step.isPaidOnly));
+	return steps.filter(
+		(step) => (isPaidApp || !step.isPaidOnly) && (isLDP || !step.isLDPOnly)
+	);
 }
 
 export function getStepKey(step: Pick<ProductPurchaseStep, 'index' | 'path'>) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/commerce/ProductPurchaseLDP.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/commerce/ProductPurchaseLDP.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import analyticsOAuth2 from '~/services/spring-boot/Analytics';
+
+import ProductPurchase from './ProductPurchase';
+
+import type {Account} from '~/types/accounts';
+import type {Cart, OrderTypes} from '~/types/orders';
+import type {DeliveryProduct} from '~/types/product';
+
+export type LDPSettings = {
+	allowedEmailDomains: string[];
+	dataCenterLocation: string;
+	friendlyWorkspaceURL?: string;
+	incidentReportContacts: string[];
+	workspaceName: string;
+	workspaceOwnerEmail: string;
+};
+
+export default class ProductPurchaseLDP extends ProductPurchase {
+	protected orderTypeExternalReferenceCode: OrderTypes = 'LDP';
+
+	constructor(
+		account: Account,
+		product: DeliveryProduct,
+		private readonly ldpSettings: LDPSettings
+	) {
+		super(account, product);
+	}
+
+	public async createOrder(cart?: Cart): Promise<Cart> {
+		const order = await super.createOrder({
+			...cart,
+			customFields: {
+				...cart?.customFields,
+				ldpSettings: JSON.stringify(this.ldpSettings),
+			},
+		} as Cart);
+
+		analyticsOAuth2.provisioningOrder(order.id).catch(console.error);
+
+		return order;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/Analytics.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/Analytics.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {OneSpringBootOAuth2} from './OAuth2Client';
+
+class AnalyticsOAuth2 extends OneSpringBootOAuth2 {
+	async provisioningOrder(orderId: number): Promise<void> {
+		await this.post(`/provisioning/${orderId}`);
+	}
+}
+
+const Analytics = new AnalyticsOAuth2('/analytics');
+
+export default Analytics;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/orders.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/types/orders.ts
@@ -217,6 +217,7 @@ export type OrderTypes =
 	| 'DSR'
 	| 'DXP'
 	| 'DXP_APP'
+	| 'LDP'
 	| 'LOW_CODE_CONFIGURATION'
 	| 'OTHER'
 	| 'SOLUTIONS30'

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/orderUtils.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/orderUtils.ts
@@ -84,6 +84,7 @@ export const LIFERAY_PRODUCT_ORDER_TYPES: readonly OrderTypes[] = [
 	'AI_HUB',
 	'CMP_BETA',
 	'DXP',
+	'LDP',
 ];
 
 export const orderTypeLabel = {
@@ -96,6 +97,7 @@ export const orderTypeLabel = {
 	DSR: 'Digital Sales Room',
 	DXP: 'DXP Free',
 	DXP_APP: 'DXP',
+	LDP: 'Liferay Data Platform',
 	LOW_CODE_CONFIGURATION: 'Low-Code Configuration',
 	OTHER: 'Other',
 	SOLUTIONS7: 'Solutions 7',

--- a/workspaces/liferay-one-workspace/scripts/seed/data/06-commerce-product.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/06-commerce-product.batch-engine-data.json
@@ -693,6 +693,12 @@
 					}
 				},
 				{
+					"specificationKey": "solution-type",
+					"value": {
+						"en_US": "liferay-data-platform"
+					}
+				},
+				{
 					"specificationKey": "support-email-address",
 					"value": {
 						"en_US": "support@liferay.com"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90606

Companion of https://github.com/liferay-one/liferay-portal/pull/1269, which delivers the provisioning endpoint this flow calls at runtime. The two PRs are independent and can merge in any order.

## What is being fixed

Customers had no way to purchase and request provisioning of a Liferay Data Platform workspace in Liferay One.

## How it is being fixed

The purchase flow gains a provisioning step, shown only when the product carries the liferay-data-platform solution type, that collects the workspace details with the existing ldpProvisioning schema. ProductPurchaseLDP stores the form as the ldpSettings order custom field and calls the analytics provisioning endpoint after checkout, following the trial flow pattern. LDP orders carry a dedicated LDP order type instead of the old marketplace ADDONS type, so the project detail page can expose the environment tab without leaking it to other add-ons.

**pr-check: PASS** — tested on `a81f4fe3fb04cc5c78a4140088ec59166a56c88e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "a81f4fe3fb04cc5c78a4140088ec59166a56c88e"} -->
