### PR TITLE
LPD-88257 Fix New Trial modal selection and availability fallback

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
@@ -137,7 +137,7 @@ const NewTrialModal: React.FC<NewTrialModalProps> = ({onClose, revalidate}) => {
 		<div className="pb-8">
 			<BaseWrapper boldLabel label="Cloud App" required>
 				<Autocomplete
-					filterKey="productName"
+					filterKey="name"
 					items={apps?.items || []}
 					loadingState={isValidating ? 1 : 4}
 					messages={{
@@ -150,7 +150,6 @@ const NewTrialModal: React.FC<NewTrialModalProps> = ({onClose, revalidate}) => {
 				>
 					{(product) => (
 						<Autocomplete.Item
-							disabled
 							key={product.productId}
 							onClick={() => {
 								setValue('product', product as never);
@@ -158,7 +157,7 @@ const NewTrialModal: React.FC<NewTrialModalProps> = ({onClose, revalidate}) => {
 								trigger();
 							}}
 						>
-							{product.name.en_US}
+							{product.name as unknown as string}
 						</Autocomplete.Item>
 					)}
 				</Autocomplete>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/components/NewTrialModal.tsx
@@ -157,7 +157,7 @@ const NewTrialModal: React.FC<NewTrialModalProps> = ({onClose, revalidate}) => {
 								trigger();
 							}}
 						>
-							{product.name as unknown as string}
+							{product.name}
 						</Autocomplete.Item>
 					)}
 				</Autocomplete>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/hooks/useTrialProducts.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/Trials/hooks/useTrialProducts.ts
@@ -9,7 +9,7 @@ import SearchBuilder from '~/utils/SearchBuilder';
 
 export function useTrialProducts(channelId: number, name: string) {
 	return useSWR(`administrator-dashboard/trial/products/${name}`, () =>
-		HeadlessCommerceDeliveryCatalog.getProductsByChannelId(
+		HeadlessCommerceDeliveryCatalog.getProductsPage(
 			channelId,
 			new URLSearchParams({
 				'accountId': '-1',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/headless/HeadlessCommerceDeliveryCatalog.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/headless/HeadlessCommerceDeliveryCatalog.ts
@@ -7,7 +7,7 @@ import fetcher from '~/services/fetcher/fetcher';
 
 import type {APIResponse} from '~/types/api';
 import type {Channel} from '~/types/commerce';
-import type {DeliveryProduct, Product} from '~/types/product';
+import type {DeliveryProduct} from '~/types/product';
 
 export default class HeadlessCommerceDeliveryCatalog {
 	static async getProduct(
@@ -25,15 +25,6 @@ export default class HeadlessCommerceDeliveryCatalog {
 		searchParams = new URLSearchParams()
 	) {
 		return fetcher<APIResponse<DeliveryProduct>>(
-			`o/headless-commerce-delivery-catalog/v1.0/channels/${channelId}/products?${searchParams.toString()}`
-		);
-	}
-
-	static async getProductsByChannelId(
-		channelId: number,
-		searchParams = new URLSearchParams()
-	) {
-		return fetcher<APIResponse<Product>>(
 			`o/headless-commerce-delivery-catalog/v1.0/channels/${channelId}/products?${searchParams.toString()}`
 		);
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/Trial.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/Trial.ts
@@ -31,7 +31,7 @@ class TrialOAuth2 extends OneSpringBootOAuth2 {
 
 	async getAvailability(): Promise<Availability> {
 		try {
-			return this.get('/availability');
+			return await this.get('/availability');
 		}
 		catch {
 			return {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-global-css/assets/global.css
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-global-css/assets/global.css
@@ -1132,3 +1132,8 @@ html body:not(.has-edit-mode-menu) .content #main-content.layout-content {
 	}
 }
 
+/* ---------- The Clay autocomplete dropdown is portaled to the body with z-index 1000 ($zindex-dropdown), so it renders behind Clay modals (z-index 1050). Raise it above the modal so dropdowns opened inside a modal, such as the new trial modal cloud app field, are visible. ---------- */
+
+.dropdown-menu.dropdown-menu-select {
+	z-index: 1060;
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88257

## What Is Being Fixed

The New Trial modal in the admin area was unusable. The cloud app autocomplete dropdown rendered behind the modal (Clay portals it to the body with z-index 1000, below the modal's 1050), the items that did render were disabled and filtered by the wrong key, and the item label read `name.en_US` when the endpoint returns a plain string. On top of that, `getAvailability` returned the request promise without awaiting it, so a failing availability endpoint bypassed the catch block and the inactive fallback never applied.

## How It Is Being Fixed

A global-css rule raises `.dropdown-menu.dropdown-menu-select` above the modal (z-index 1060). The autocomplete now filters by `name`, the items are selectable, and the label renders the plain string name. `getAvailability` now awaits the request so a failure lands in the catch block and returns the inactive availability fallback.

## Why Are There No Tests?

These are UI-level fixes (a CSS z-index rule, autocomplete selection wiring, and an awaited fallback) verified manually in the New Trial modal flow; the workspace has no unit test surface for these points.

## PR Check

**pr-check: PASS** — tested on `28c2508d1da1446a3eafa80c6bbba3858a7621ff`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "28c2508d1da1446a3eafa80c6bbba3858a7621ff"} -->
