### PR TITLE
LPD-97630 Add the DXP Free Tier activation key purchase flow

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/AccountSelection/AccountSelection.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/AccountSelection/AccountSelection.tsx
@@ -19,6 +19,7 @@ import {
 	getProductImageFallback,
 	getProductPriceModel,
 	getProductSpecificationValue,
+	isDXPFreeTierProduct,
 } from '~/utils/productUtils';
 import {normalizeURLProtocol} from '~/utils/stringUtils';
 
@@ -39,13 +40,29 @@ const AccountSelection = () => {
 
 	const {isPaidApp} = getProductPriceModel(product);
 
+	const isDXPFree = isDXPFreeTierProduct(product);
+
 	useEffect(() => {
 		if (isSingleAccount) {
 			setSelectedAccount(accounts[0]);
 
-			navigate(isPaidApp ? '/license' : '/summary', {replace: true});
+			navigate(
+				isPaidApp
+					? '/license'
+					: isDXPFree
+						? '/activation-key-form'
+						: '/summary',
+				{replace: true}
+			);
 		}
-	}, [accounts, isPaidApp, isSingleAccount, navigate, setSelectedAccount]);
+	}, [
+		accounts,
+		isDXPFree,
+		isPaidApp,
+		isSingleAccount,
+		navigate,
+		setSelectedAccount,
+	]);
 
 	if (isLoadingAccounts || isSingleAccount) {
 		return (

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ActivationKeyForm/ActivationKeyForm.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ActivationKeyForm/ActivationKeyForm.tsx
@@ -1,0 +1,204 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayCheckbox} from '@clayui/form';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {Controller, useForm} from 'react-hook-form';
+import {Navigate} from 'react-router-dom';
+import {Input} from '~/components/Input/Input';
+import Select from '~/components/Select/Select';
+import i18n from '~/i18n';
+import LicenseTermsCheckbox from '~/pages/ProductPurchase/components/LicenseTermsCheckbox/LicenseTermsCheckbox';
+import {useProductPurchaseLayoutContext} from '~/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout';
+import ProductPurchaseShell from '~/pages/ProductPurchase/components/ProductPurchaseShell/ProductPurchaseShell';
+import commerceSchemas from '~/schema/commerceSchemas';
+import FetcherError from '~/services/fetcher/FetcherError';
+import {Liferay} from '~/services/liferay/liferay';
+import LicenseKeys from '~/services/spring-boot/LicenseKeys';
+
+import type {ActivationKeyFormData} from '~/services/commerce/ProductPurchaseDXPFree';
+
+const PURPOSE_OPTIONS = [
+	{key: 'personal-learning-education', name: 'Personal Learning / Education'},
+	{key: 'proof-of-concept', name: 'Proof of Concept (POC)'},
+	{key: 'development-and-testing', name: 'Development & Testing'},
+	{key: 'internal-side-project', name: 'Internal Side Project'},
+	{key: 'small-business-production', name: 'Small Business Production Use'},
+];
+
+const ActivationKeyForm = () => {
+	const {
+		actions: {previousStep},
+		handlePurchase,
+		product,
+		selectedAccount,
+	} = useProductPurchaseLayoutContext();
+
+	const {
+		control,
+		formState: {errors, isValid},
+		handleSubmit,
+		register,
+		setError,
+		setValue,
+		watch,
+	} = useForm<ActivationKeyFormData>({
+		defaultValues: {
+			businessEmailAddress: Liferay.ThemeDisplay.getUserEmailAddress(),
+			companyName: '',
+			country: '',
+			domain: '',
+			extension: '',
+			fullName: '',
+			jobTitle: '',
+			notifyMeAboutProducts: false,
+			phoneNumber: '',
+			purpose: '',
+			termsAndConditions: false,
+			userAgreement: false,
+		},
+		mode: 'onChange',
+		resolver: zodResolver(commerceSchemas.activationKey),
+	});
+
+	if (!selectedAccount?.id) {
+		return <Navigate replace to="/" />;
+	}
+
+	const acceptedTerms =
+		Boolean(watch('termsAndConditions')) && Boolean(watch('userAgreement'));
+
+	const onSubmit = async (formFields: ActivationKeyFormData) => {
+		const owner = formFields.businessEmailAddress;
+
+		try {
+			await LicenseKeys.licenseKeyTypeFreeDomainsCheck({
+				domains: formFields.domain,
+				owner,
+			});
+		}
+		catch (error) {
+			if (error instanceof FetcherError && error.status === 409) {
+				setError('domain', {
+					message: i18n.translate(
+						'a-license-key-for-the-entered-domain-already-exists'
+					),
+				});
+
+				return;
+			}
+
+			throw error;
+		}
+
+		await handlePurchase(formFields);
+	};
+
+	return (
+		<ProductPurchaseShell
+			footerProps={{
+				backButtonProps: {
+					onClick: () => previousStep(),
+				},
+				continueButtonProps: {
+					children: i18n.translate('get-activation-key'),
+					disabled: !isValid,
+					onClick: () => handleSubmit(onSubmit)(),
+				},
+			}}
+			title={i18n.translate('activation-key-creation')}
+		>
+			<Input
+				{...register('fullName')}
+				errorMessage={errors.fullName?.message}
+				label={i18n.translate('full-name')}
+				required
+			/>
+
+			<Input
+				{...register('businessEmailAddress')}
+				errorMessage={errors.businessEmailAddress?.message}
+				label={i18n.translate('business-email-address')}
+				required
+			/>
+
+			<Input
+				{...register('companyName')}
+				errorMessage={errors.companyName?.message}
+				label={i18n.translate('company-name')}
+			/>
+
+			<Input
+				{...register('jobTitle')}
+				errorMessage={errors.jobTitle?.message}
+				label={i18n.translate('job-title')}
+			/>
+
+			<Input
+				{...register('country')}
+				errorMessage={errors.country?.message}
+				label={i18n.translate('country')}
+				required
+			/>
+
+			<Input
+				{...register('phoneNumber')}
+				errorMessage={errors.phoneNumber?.message}
+				label={i18n.translate('phone-number')}
+			/>
+
+			<Select
+				defaultOptionLabel={i18n.translate('select-an-option')}
+				errors={errors as {[key: string]: {message?: string}}}
+				label={i18n.translate('purpose')}
+				name="purpose"
+				onChange={({target: {value}}) =>
+					setValue('purpose', value, {shouldValidate: true})
+				}
+				options={PURPOSE_OPTIONS}
+				required
+				value={watch('purpose')}
+			/>
+
+			<Input
+				{...register('domain')}
+				errorMessage={errors.domain?.message}
+				helpMessage={i18n.translate('input-one-domain-name-per-instance')}
+				label={i18n.translate('domain')}
+				required
+			/>
+
+			<Controller
+				control={control}
+				name="notifyMeAboutProducts"
+				render={({field}) => (
+					<ClayCheckbox
+						checked={Boolean(field.value)}
+						className="mt-3"
+						label={i18n.translate(
+							'notify-me-about-products-services-and-events'
+						)}
+						onChange={() => field.onChange(!field.value)}
+					/>
+				)}
+			/>
+
+			<LicenseTermsCheckbox
+				checked={acceptedTerms}
+				onChange={() => {
+					const value = !acceptedTerms;
+
+					setValue('termsAndConditions', value, {
+						shouldValidate: true,
+					});
+					setValue('userAgreement', value, {shouldValidate: true});
+				}}
+				product={product}
+			/>
+		</ProductPurchaseShell>
+	);
+};
+
+export default ActivationKeyForm;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/ProductPurchaseRouter.tsx
@@ -10,7 +10,11 @@ import Loading from '~/components/Loading/Loading';
 import {useDeliveryProduct} from '~/hooks/useDeliveryProduct';
 import useRequireSignIn from '~/hooks/useRequireSignIn';
 import i18n from '~/i18n';
-import {getProductPriceModel, isLDPProduct} from '~/utils/productUtils';
+import {
+	getProductPriceModel,
+	isDXPFreeTierProduct,
+	isLDPProduct,
+} from '~/utils/productUtils';
 import {AppRoute, toRouteObjects} from '~/utils/routeUtils';
 
 import ProductPurchaseLayout from './components/ProductPurchaseLayout/ProductPurchaseLayout';
@@ -35,6 +39,7 @@ const ProductPurchaseRoutes = ({product}: {product: DeliveryProduct}) => {
 	const {isPaidApp} = getProductPriceModel(product);
 
 	const steps = getProductPurchaseSteps({
+		isDXPFree: isDXPFreeTierProduct(product),
 		isLDP: isLDPProduct(product),
 		isPaidApp,
 	});

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PurchaseCompleted/PurchaseCompleted.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/PurchaseCompleted/PurchaseCompleted.tsx
@@ -17,7 +17,10 @@ import ProductPurchaseHeaderCards from '~/pages/ProductPurchase/components/Produ
 import HeadlessAdminUser from '~/services/headless/HeadlessAdminUser';
 import {Liferay} from '~/services/liferay/liferay';
 import {PaymentStatus} from '~/utils/orderUtils';
-import {getProductPriceModel} from '~/utils/productUtils';
+import {
+	getProductPriceModel,
+	isDXPFreeTierProduct,
+} from '~/utils/productUtils';
 import {getSiteURL} from '~/utils/siteUtils';
 
 import type {Account} from '~/types/accounts';
@@ -135,6 +138,16 @@ const PurchaseCompleted = ({product}: PurchaseCompletedProps) => {
 
 	const installTab = isPaidApp ? 'activation' : 'download';
 
+	const isDXPFree = isDXPFreeTierProduct(product);
+
+	const myItemsURL = isDXPFree
+		? `${getSiteURL()}/my-account#/project/products`
+		: `${getSiteURL()}/my-account#/project/applications`;
+
+	const itemDetailURL = isDXPFree
+		? `${getSiteURL()}/my-account#/project/products/${product.externalReferenceCode}?tab=activation`
+		: `${getSiteURL()}/my-account#/project/applications/${orderId}?tab=${installTab}`;
+
 	const showCardIcon = !isFreeApp && hasVatId;
 
 	return (
@@ -155,7 +168,11 @@ const PurchaseCompleted = ({product}: PurchaseCompletedProps) => {
 			</div>
 
 			<h1 className="mt-4 product-purchase-shell-title text-center">
-				{i18n.translate('purchase-completed')}
+				{isDXPFree
+					? i18n.translate(
+							'your-free-activation-key-has-been-generated'
+						)
+					: i18n.translate('purchase-completed')}
 			</h1>
 
 			<p className="mt-3 text-center text-muted">
@@ -176,24 +193,18 @@ const PurchaseCompleted = ({product}: PurchaseCompletedProps) => {
 			<div className="d-flex justify-content-center">
 				<ClayButton
 					displayType="secondary"
-					onClick={() =>
-						Liferay.Util.navigate(
-							`${getSiteURL()}/my-account#/project/applications`
-						)
-					}
+					onClick={() => Liferay.Util.navigate(myItemsURL)}
 				>
-					{i18n.translate('go-to-my-apps')}
+					{i18n.translate(isDXPFree ? 'products' : 'go-to-my-apps')}
 				</ClayButton>
 
 				<ClayButton
 					className="ml-3"
-					onClick={() =>
-						Liferay.Util.navigate(
-							`${getSiteURL()}/my-account#/project/applications/${orderId}?tab=${installTab}`
-						)
-					}
+					onClick={() => Liferay.Util.navigate(itemDetailURL)}
 				>
-					{i18n.translate('continue-to-install')}
+					{i18n.translate(
+						isDXPFree ? 'activation-key' : 'continue-to-install'
+					)}
 				</ClayButton>
 			</div>
 		</div>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/components/ProductPurchaseLayout/ProductPurchaseLayout.tsx
@@ -14,12 +14,19 @@ import AccountAvatar from '~/components/AccountAvatar/AccountAvatar';
 import Loading from '~/components/Loading/Loading';
 import i18n from '~/i18n';
 import ProductPurchaseApp from '~/services/commerce/ProductPurchaseApp';
+import ProductPurchaseDXPFree, {
+	ActivationKeyFormData,
+} from '~/services/commerce/ProductPurchaseDXPFree';
 import ProductPurchaseLDP, {
 	LDPSettings,
 } from '~/services/commerce/ProductPurchaseLDP';
 import HeadlessCommerceDeliveryCart from '~/services/headless/HeadlessCommerceDeliveryCart';
 import {Liferay} from '~/services/liferay/liferay';
-import {getProductPriceModel, isLDPProduct} from '~/utils/productUtils';
+import {
+	getProductPriceModel,
+	isDXPFreeTierProduct,
+	isLDPProduct,
+} from '~/utils/productUtils';
 
 import useAccounts from '../../hooks/useAccounts';
 import useProductPurchaseCart from '../../hooks/useProductPurchaseCart';
@@ -43,7 +50,7 @@ export type ProductPurchaseLayoutContext = {
 		nextStep: () => void;
 		previousStep: () => void;
 	};
-	handlePurchase: () => Promise<void>;
+	handlePurchase: (dxpFreeForm?: ActivationKeyFormData) => Promise<void>;
 	isLoadingAccounts: boolean;
 	isSingleAccount: boolean;
 	isSubmitting: boolean;
@@ -106,18 +113,32 @@ const ProductPurchaseLayout = ({
 		}
 	};
 
-	const handlePurchase = async () => {
+	const handlePurchase = async (dxpFreeForm?: ActivationKeyFormData) => {
 		setSubmitting(true);
 
 		try {
-			const productPurchase =
-				isLDPProduct(product) && ldpSettings
-					? new ProductPurchaseLDP(
-							selectedAccount,
-							product,
-							ldpSettings
-						)
-					: new ProductPurchaseApp(selectedAccount, product);
+			let productPurchase;
+
+			if (isDXPFreeTierProduct(product) && dxpFreeForm) {
+				productPurchase = new ProductPurchaseDXPFree(
+					selectedAccount,
+					product,
+					dxpFreeForm
+				);
+			}
+			else if (isLDPProduct(product) && ldpSettings) {
+				productPurchase = new ProductPurchaseLDP(
+					selectedAccount,
+					product,
+					ldpSettings
+				);
+			}
+			else {
+				productPurchase = new ProductPurchaseApp(
+					selectedAccount,
+					product
+				);
+			}
 
 			if (isPaidApp) {
 				const cart = await productPurchase.createOrder({

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/ProductPurchase/productPurchaseRoutes.tsx
@@ -10,6 +10,9 @@ import {AppRoute} from '~/utils/routeUtils';
 const AccountSelection = lazy(
 	() => import('./AccountSelection/AccountSelection')
 );
+const ActivationKeyForm = lazy(
+	() => import('./ActivationKeyForm/ActivationKeyForm')
+);
 const LDPProvisioning = lazy(() => import('./LDPProvisioning/LDPProvisioning'));
 const License = lazy(() => import('./License/License'));
 const PaymentMethod = lazy(() => import('./PaymentMethod/PaymentMethod'));
@@ -17,7 +20,9 @@ const Summary = lazy(() => import('./Summary/Summary'));
 
 export type ProductPurchaseStep = {
 	element: ReactNode;
+	excludeForDXPFree?: boolean;
 	index?: boolean;
+	isDXPFreeOnly?: boolean;
 	isLDPOnly?: boolean;
 	isPaidOnly?: boolean;
 	path?: string;
@@ -30,9 +35,11 @@ export type ProductPurchaseStepItem = {
 };
 
 export function getProductPurchaseSteps({
+	isDXPFree,
 	isLDP,
 	isPaidApp,
 }: {
+	isDXPFree: boolean;
 	isLDP: boolean;
 	isPaidApp: boolean;
 }): ProductPurchaseStep[] {
@@ -49,6 +56,12 @@ export function getProductPurchaseSteps({
 			title: i18n.translate('license-selection'),
 		},
 		{
+			element: <ActivationKeyForm />,
+			isDXPFreeOnly: true,
+			path: 'activation-key-form',
+			title: i18n.translate('activation-key'),
+		},
+		{
 			element: <PaymentMethod />,
 			isPaidOnly: true,
 			path: 'payment-method',
@@ -62,13 +75,18 @@ export function getProductPurchaseSteps({
 		},
 		{
 			element: <Summary />,
+			excludeForDXPFree: true,
 			path: 'summary',
 			title: i18n.translate('summary'),
 		},
 	];
 
 	return steps.filter(
-		(step) => (isPaidApp || !step.isPaidOnly) && (isLDP || !step.isLDPOnly)
+		(step) =>
+			(isPaidApp || !step.isPaidOnly) &&
+			(isLDP || !step.isLDPOnly) &&
+			(isDXPFree || !step.isDXPFreeOnly) &&
+			(!isDXPFree || !step.excludeForDXPFree)
 	);
 }
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/commerceSchemas.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/schema/commerceSchemas.ts
@@ -44,6 +44,25 @@ export const commerceSchemas = {
 			.string()
 			.min(1, {message: 'Please enter a Tax/VAT number to continue'}),
 	}),
+	activationKey: z.object({
+		businessEmailAddress: z
+			.string()
+			.email(i18n.translate('please-fill-in-a-valid-email')),
+		companyName: z.string().optional().or(z.literal('')),
+		country: z
+			.string()
+			.min(2, {message: 'Please select the country to continue'}),
+		domain: z.string().min(3, {message: 'Domain is required'}),
+		extension: z.string().optional(),
+		fullName: z.string().min(3, {message: 'Full name is required'}),
+		intlCode: z.object({code: z.string(), flag: z.string()}).optional(),
+		jobTitle: z.string().optional().or(z.literal('')),
+		notifyMeAboutProducts: z.boolean().optional(),
+		phoneNumber: z.string().optional(),
+		purpose: z.string().min(3, {message: 'Purpose is required'}),
+		termsAndConditions: z.boolean().refine((value) => value === true),
+		userAgreement: z.boolean().refine((value) => value === true),
+	}),
 	billingAddress,
 	contactSales: z.object({
 		accountName: z

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/commerce/ProductPurchaseDXPFree.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/commerce/ProductPurchaseDXPFree.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {z} from 'zod';
+import commerceSchemas from '~/schema/commerceSchemas';
+import DXPFreeActivationKeyRequests from '~/services/objects/DXPFreeActivationKeyRequests';
+import LicenseKeys from '~/services/spring-boot/LicenseKeys';
+
+import ProductPurchase from './ProductPurchase';
+
+import type {Account} from '~/types/accounts';
+import type {Cart, OrderTypes} from '~/types/orders';
+import type {DeliveryProduct} from '~/types/product';
+
+export type ActivationKeyFormData = z.infer<
+	typeof commerceSchemas.activationKey
+>;
+
+export default class ProductPurchaseDXPFree extends ProductPurchase {
+	protected orderTypeExternalReferenceCode: OrderTypes = 'DXP';
+
+	constructor(
+		account: Account,
+		product: DeliveryProduct,
+		private readonly form: ActivationKeyFormData
+	) {
+		super(account, product);
+	}
+
+	public async createOrder(cart?: Cart): Promise<Cart> {
+		const order = await super.createOrder(cart);
+
+		const owner = this.form.businessEmailAddress;
+
+		await LicenseKeys.createLicenseKeyTypeFree({
+			domains: this.form.domain,
+			orderId: String(order.id),
+			owner,
+		});
+
+		await DXPFreeActivationKeyRequests.createDXPFreeActivationKeyRequest({
+			businessEmailAddress: this.form.businessEmailAddress,
+			companyName: this.form.companyName,
+			country: this.form.country,
+			domain: this.form.domain,
+			extension: this.form.extension,
+			fullName: this.form.fullName,
+			intlCode: this.form.intlCode?.code,
+			jobTitle: this.form.jobTitle,
+			notifyMe: this.form.notifyMeAboutProducts,
+			phoneNumber: this.form.phoneNumber,
+			purpose: this.form.purpose,
+			r_orderToDXPFreeActivationKeyRequest_commerceOrderId: String(
+				order.id
+			),
+		}).catch(console.error);
+
+		return order;
+	}
+
+	public async getNextStepsLink(cart: Cart) {
+		return `/purchase-completed?orderId=${cart.id}`;
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/objects/DXPFreeActivationKeyRequests.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/objects/DXPFreeActivationKeyRequests.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fetcher from '~/services/fetcher/fetcher';
+
+export type DXPFreeActivationKeyRequest = {
+	businessEmailAddress: string;
+	companyName?: string;
+	country: string;
+	domain: string;
+	extension?: string;
+	fullName: string;
+	intlCode?: string;
+	jobTitle?: string;
+	notifyMe?: boolean;
+	phoneNumber?: string;
+	purpose: string;
+	r_orderToDXPFreeActivationKeyRequest_commerceOrderId?: string;
+};
+
+export default class DXPFreeActivationKeyRequests {
+	static async createDXPFreeActivationKeyRequest(
+		body: DXPFreeActivationKeyRequest
+	) {
+		return fetcher.post('/o/c/dxpfreeactivationkeyrequests', body);
+	}
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/LicenseKeys.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/LicenseKeys.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {OneSpringBootOAuth2} from './OAuth2Client';
+
+export type LicenseKey = {
+	active: boolean;
+	customExpirationDate: string;
+	domains: string;
+	id: number;
+	name: string;
+	orderId: string;
+	owner: string;
+	productName: string;
+	startDate: string;
+};
+
+class LicenseKeysOAuth2 extends OneSpringBootOAuth2 {
+	createLicenseKeyTypeFree({
+		domains,
+		orderId,
+		owner,
+	}: {
+		domains: string;
+		orderId: string;
+		owner: string;
+	}): Promise<LicenseKey> {
+		return this.post('/type-free', {domains, orderId, owner});
+	}
+
+	async licenseKeyTypeFreeDomainsCheck({
+		domains,
+		owner,
+	}: {
+		domains: string;
+		owner: string;
+	}) {
+		await this.post('/type-free-domains-check', {domains, owner});
+	}
+}
+
+const LicenseKeys = new LicenseKeysOAuth2('/license-keys');
+
+export default LicenseKeys;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/productUtils.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/productUtils.ts
@@ -257,3 +257,15 @@ export function isLDPProduct(product: DeliveryProduct) {
 		) === 'liferay-data-platform'
 	);
 }
+
+export function isDXPFreeTierProduct(product: DeliveryProduct) {
+	const {isFreeApp} = getProductPriceModel(product);
+
+	return (
+		isFreeApp &&
+		getProductSpecificationValue(
+			ProductSpecificationKey.SOLUTION_TYPE,
+			product
+		) === 'dxp'
+	);
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/productUtils.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/utils/productUtils.ts
@@ -260,12 +260,7 @@ export function isLDPProduct(product: DeliveryProduct) {
 
 export function isDXPFreeTierProduct(product: DeliveryProduct) {
 	const {isFreeApp} = getProductPriceModel(product);
+	const {isDXP} = getProductType(product);
 
-	return (
-		isFreeApp &&
-		getProductSpecificationValue(
-			ProductSpecificationKey.SOLUTION_TYPE,
-			product
-		) === 'dxp'
-	);
+	return isFreeApp && isDXP;
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97630

## What is being fixed

Buying the "Liferay DXP - Free Tier" product in Liferay One went through the generic app checkout, so there was no way to request the free activation key that the old Marketplace offered: no activation key form, no domain validation, and no path to the activation keys tab after the purchase.

## How it is being fixed

The purchase wizard detects DXP Free Tier products by the type and price-model specifications and routes them to a new activation key form instead of the summary step. The form validates the requester details, checks the domain for an existing key before submitting (surfacing the duplicate as a field error), and hands off to a new ProductPurchaseDXPFree class that creates the commerce order with the DXP order type, requests the license key from the backend, and records the submission as a DXPFreeActivationKeyRequest object entry. The purchase completed page then routes to the product's activation keys tab, where the generated key is listed.

This depends on the backend endpoints from the companion pull request https://github.com/liferay-one/liferay-portal/pull/1281; downloading and renewing the key follow in LPD-89422.
