### PR TITLE
LPD-89686 Trim dates instead of canceling realigned orders

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/specs/data-model.md
+++ b/workspaces/liferay-one-workspace/.agents/specs/data-model.md
@@ -289,6 +289,8 @@ Materialized grant records derived from CommerceOrderItems via EntitlementDefini
 | `startDate` | datetime | |
 | `endDate` | datetime | |
 
+The `endDate` is the grant's effective end. After a realignment amendment it may be earlier than the granting CommerceOrderItem's frozen `endDate`, in which case it equals that item's `effectiveEndDate`. Realignment expresses supersession through dates only; no status transition occurs at processing time.
+
 ---
 
 #### EntitlementDefinition (`C_ENTITLEMENT_DEFINITION`)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ObjectActionCommerceOrderItemUpdateRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ObjectActionCommerceOrderItemUpdateRestController.java
@@ -18,6 +18,9 @@ import com.liferay.one.util.OrderItemUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -68,12 +71,89 @@ public class ObjectActionCommerceOrderItemUpdateRestController
 		Order order = _commerceOrderService.getCommerceOrder(
 			GetterUtil.getLong(orderItem.getOrderId()));
 
+		if (_hasOtherActivePaasExperience(
+				order.getAccountId(), GetterUtil.getLong(orderItem.getId()))) {
+
+			return;
+		}
+
 		String oktaApplicationId = _propertyService.getPropertyValue(
 			order.getAccountId(), PropertyConstants.NAME_OKTA_APPLICATION);
 
 		if (Validator.isNotNull(oktaApplicationId)) {
 			_oktaService.deleteApplication(oktaApplicationId);
 		}
+	}
+
+	private boolean _hasOtherActivePaasExperience(
+			long accountId, long commerceOrderItemId)
+		throws Exception {
+
+		String todayString = LocalDate.now(
+			ZoneOffset.UTC
+		).toString();
+
+		for (Order order : _commerceOrderService.getAccountOrders(accountId)) {
+			OrderItem[] orderItems = order.getOrderItems();
+
+			if (orderItems == null) {
+				continue;
+			}
+
+			for (OrderItem orderItem : orderItems) {
+				if (Objects.equals(orderItem.getId(), commerceOrderItemId)) {
+					continue;
+				}
+
+				Map<String, String> nameMap = orderItem.getName();
+
+				String name = null;
+
+				if (nameMap != null) {
+					name = nameMap.get("en_US");
+				}
+
+				if (Objects.equals(
+						name, CommerceProductConstants.NAME_PAAS_EXPERIENCE) &&
+					_isActiveOrderItem(
+						GetterUtil.getLong(orderItem.getId()), todayString)) {
+
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isActiveOrderItem(
+			long commerceOrderItemId, String todayString)
+		throws Exception {
+
+		OrderItem orderItem = _commerceOrderItemService.fetchCommerceOrderItem(
+			commerceOrderItemId);
+
+		if ((orderItem == null) ||
+			!Objects.equals(
+				OrderItemUtil.getStatus(orderItem),
+				CommerceOrderItemConstants.STATUS_APPROVED)) {
+
+			return false;
+		}
+
+		String endDate = OrderItemUtil.getEffectiveEndDate(orderItem);
+
+		if (Validator.isNull(endDate)) {
+			endDate = OrderItemUtil.getEndDate(orderItem);
+		}
+
+		if (Validator.isNull(endDate) ||
+			(endDate.compareTo(todayString) >= 0)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Autowired

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriber.java
@@ -440,23 +440,10 @@ public class SalesforceOpportunityPubsubSubscriber
 				}
 			}
 			else {
-				Order parentOrder =
-					_commerceOrderService.fetchOrderByExternalReferenceCode(
-						opportunity.getAmendedContractOpportunityId());
-
-				if (parentOrder == null) {
-					_addWarning(
-						warningMessages,
-						StringBundler.concat(
-							"Unable to find the parent order ",
-							opportunity.getAmendedContractOpportunityId(),
-							" for amended opportunity ", opportunity.getId()));
-				}
-				else {
-					_provisioningOrderService.cancelRealignedOrder(
-						parentOrder, realignmentOpportunityLineItems,
-						warningMessages);
-				}
+				_provisioningOrderService.trimRealignedOrderItems(
+					account.getId(), opportunity.getId(),
+					opportunity.getAmendedContractOpportunityId(),
+					realignmentOpportunityLineItems, warningMessages);
 			}
 		}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
@@ -11,7 +11,9 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.headless.commerce.admin.order.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderItemResource;
+import com.liferay.one.constants.CommerceOrderItemConstants;
 import com.liferay.one.salesforce.model.OpportunityLineItem;
+import com.liferay.one.util.OrderItemUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.math.BigDecimal;
@@ -124,13 +126,35 @@ public class CommerceOrderItemService extends OneBaseService {
 			orderItem.setFinalPrice(() -> finalPrice);
 		}
 
-		CustomField[] customFields = _toCustomFields(
-			_getCustomFieldValues(opportunityLineItem, stageName));
-
-		orderItem.setCustomFields(() -> customFields);
+		Map<String, Object> customFieldValues = _getCustomFieldValues(
+			opportunityLineItem, stageName);
 
 		OrderItem existingOrderItem = _getExistingOrderItem(
 			order, opportunityLineItem.getId());
+
+		if (existingOrderItem != null) {
+			OrderItem commerceOrderItem = fetchCommerceOrderItem(
+				existingOrderItem.getId());
+
+			if ((commerceOrderItem == null) ||
+				CommerceOrderItemConstants.STATUS_CANCELED.equals(
+					OrderItemUtil.getStatus(commerceOrderItem))) {
+
+				customFieldValues.remove("customStatus");
+			}
+
+			if ((commerceOrderItem == null) ||
+				Objects.equals(
+					OrderItemUtil.getEndDate(commerceOrderItem),
+					_toDateTime(opportunityLineItem.getEndDate()))) {
+
+				customFieldValues.remove("effectiveEndDate");
+			}
+		}
+
+		CustomField[] customFields = _toCustomFields(customFieldValues);
+
+		orderItem.setCustomFields(() -> customFields);
 
 		OrderItemResource orderItemResource = _buildOrderItemResource();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -94,17 +94,6 @@ public class CommerceOrderService extends OneBaseService {
 		}
 	}
 
-	public void cancelOrder(long commerceOrderId) throws Exception {
-		OrderResource orderResource = _buildOrderResource();
-
-		Order order = new Order();
-
-		order.setOrderStatus(
-			() -> CommerceOrderConstants.ORDER_STATUS_CANCELLED);
-
-		orderResource.patchOrder(commerceOrderId, order);
-	}
-
 	public void completeOrder(long orderId, int paymentStatus)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -13,11 +13,15 @@ import com.liferay.one.model.Entitlement;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.util.OrderItemUtil;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -90,22 +94,6 @@ public class EntitlementService extends OneBaseService {
 			).toUri());
 
 		return new Entitlement(new JSONObject(response));
-	}
-
-	public void deleteEntitlements(long commerceOrderItemId) throws Exception {
-		List<Entitlement> entitlements = getEntitlements(
-			StringBundler.concat(
-				"r_commerceOrderItemToEntitlement_commerceOrderItemId eq '",
-				commerceOrderItemId, "'"));
-
-		for (Entitlement entitlement : entitlements) {
-			delete(
-				getAuthorization(), StringPool.BLANK,
-				UriComponentsBuilder.fromPath(
-					"/o/c/entitlements/" + entitlement.getEntitlementId()
-				).build(
-				).toUri());
-		}
 	}
 
 	public Entitlement fetchEntitlement(
@@ -220,9 +208,67 @@ public class EntitlementService extends OneBaseService {
 
 		sb.append(")");
 
-		return !getEntitlements(
-			sb.toString()
-		).isEmpty();
+		List<Entitlement> entitlements = getEntitlements(sb.toString());
+
+		String todayString = LocalDate.now(
+			ZoneOffset.UTC
+		).toString();
+
+		for (Entitlement entitlement : entitlements) {
+			String endDate = entitlement.getEndDate();
+
+			if (Validator.isNull(endDate) ||
+				(endDate.compareTo(todayString) >= 0)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public void trimEntitlements(long commerceOrderItemId, String endDate)
+		throws Exception {
+
+		List<Entitlement> entitlements = getEntitlements(
+			StringBundler.concat(
+				"r_commerceOrderItemToEntitlement_commerceOrderItemId eq '",
+				commerceOrderItemId, "'"));
+
+		for (Entitlement entitlement : entitlements) {
+			String entitlementEndDate = entitlement.getEndDate();
+
+			if (Validator.isNotNull(entitlementEndDate) &&
+				(entitlementEndDate.compareTo(endDate) <= 0)) {
+
+				continue;
+			}
+
+			String trimmedEndDate = endDate;
+
+			String startDate = entitlement.getStartDate();
+
+			if (Validator.isNotNull(startDate) &&
+				(startDate.compareTo(endDate) > 0)) {
+
+				trimmedEndDate = startDate;
+			}
+
+			if (Objects.equals(entitlementEndDate, trimmedEndDate)) {
+				continue;
+			}
+
+			patch(
+				getAuthorization(),
+				new JSONObject(
+				).put(
+					"endDate", trimmedEndDate
+				).toString(),
+				UriComponentsBuilder.fromPath(
+					"/o/c/entitlements/" + entitlement.getEntitlementId()
+				).build(
+				).toUri());
+		}
 	}
 
 	public void updateEntitlementContract(long entitlementId, long contractId)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningOrderService.java
@@ -14,6 +14,9 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,78 +35,105 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProvisioningOrderService {
 
-	public void cancelRealignedOrder(
-			Order parentOrder,
+	public void trimRealignedOrderItems(
+			long accountId, String opportunityId, String parentOpportunityId,
 			List<OpportunityLineItem> realignmentOpportunityLineItems,
 			List<String> warningMessages)
 		throws Exception {
 
-		OrderItem[] parentOrderItems = parentOrder.getOrderItems();
-
-		if (parentOrderItems == null) {
-			return;
-		}
+		List<Order> orders = _commerceOrderService.getAccountOrders(accountId);
 
 		for (OpportunityLineItem realignmentOpportunityLineItem :
 				realignmentOpportunityLineItems) {
 
 			boolean matched = false;
 
-			for (OrderItem parentOrderItem : parentOrderItems) {
-				if (!Objects.equals(
-						parentOrderItem.getSkuExternalReferenceCode(),
-						realignmentOpportunityLineItem.getProduct2Id())) {
-
-					continue;
-				}
-
-				matched = true;
-
-				OrderItem orderItem =
-					_commerceOrderItemService.fetchCommerceOrderItem(
-						parentOrderItem.getId());
-
-				if ((orderItem == null) ||
-					!Objects.equals(
-						OrderItemUtil.getStatus(orderItem),
-						CommerceOrderItemConstants.STATUS_APPROVED)) {
-
-					continue;
-				}
-
-				String endDate = _toDateTime(
-					realignmentOpportunityLineItem.getEndDate());
-				String startDate = _toDateTime(
-					realignmentOpportunityLineItem.getServiceDate());
-
+			for (Order order : orders) {
 				if (Objects.equals(
-						OrderItemUtil.getEndDate(orderItem), endDate) &&
-					Objects.equals(
-						OrderItemUtil.getStartDate(orderItem), startDate)) {
+						order.getExternalReferenceCode(), opportunityId) ||
+					(order.getOrderItems() == null) ||
+					!_isFamilyOrder(order, parentOpportunityId)) {
 
 					continue;
 				}
 
-				_commerceOrderItemService.patchOrderItemCustomFields(
-					GetterUtil.getLong(orderItem.getId()),
-					Map.of(
-						"customStatus",
-						CommerceOrderItemConstants.STATUS_CANCELED));
+				for (OrderItem parentOrderItem : order.getOrderItems()) {
+					if (!Objects.equals(
+							parentOrderItem.getSkuExternalReferenceCode(),
+							realignmentOpportunityLineItem.getProduct2Id())) {
 
-				_entitlementService.deleteEntitlements(
-					GetterUtil.getLong(orderItem.getId()));
+						continue;
+					}
 
-				if (Validator.isNotNull(endDate) &&
-					!Objects.equals(
-						OrderItemUtil.getEndDate(orderItem), endDate)) {
+					matched = true;
 
-					_addWarning(
-						warningMessages,
-						StringBundler.concat(
-							"End date mismatch for order item ",
-							parentOrderItem.getExternalReferenceCode(),
-							". Amended date: ", endDate, ", original date: ",
-							OrderItemUtil.getEndDate(orderItem)));
+					OrderItem orderItem =
+						_commerceOrderItemService.fetchCommerceOrderItem(
+							parentOrderItem.getId());
+
+					if ((orderItem == null) ||
+						!Objects.equals(
+							OrderItemUtil.getStatus(orderItem),
+							CommerceOrderItemConstants.STATUS_APPROVED)) {
+
+						continue;
+					}
+
+					String endDate = _toDateTime(
+						realignmentOpportunityLineItem.getEndDate());
+					String startDate = _toDateTime(
+						realignmentOpportunityLineItem.getServiceDate());
+
+					if (Objects.equals(
+							OrderItemUtil.getEndDate(orderItem), endDate) &&
+						Objects.equals(
+							OrderItemUtil.getStartDate(orderItem), startDate)) {
+
+						continue;
+					}
+
+					String effectiveEndDate = endDate;
+
+					if (Validator.isNull(effectiveEndDate)) {
+						effectiveEndDate = startDate;
+					}
+
+					if (Validator.isNull(effectiveEndDate)) {
+						effectiveEndDate = _toDateTime(
+							LocalDate.now(
+								ZoneOffset.UTC
+							).toString());
+					}
+
+					String orderItemEffectiveEndDate =
+						OrderItemUtil.getEffectiveEndDate(orderItem);
+
+					if (Validator.isNull(orderItemEffectiveEndDate) ||
+						(orderItemEffectiveEndDate.compareTo(effectiveEndDate) >
+							0)) {
+
+						_commerceOrderItemService.patchOrderItemCustomFields(
+							GetterUtil.getLong(orderItem.getId()),
+							Map.of("effectiveEndDate", effectiveEndDate));
+
+						if (Validator.isNotNull(endDate) &&
+							!Objects.equals(
+								OrderItemUtil.getEndDate(orderItem), endDate)) {
+
+							_addWarning(
+								warningMessages,
+								StringBundler.concat(
+									"End date mismatch for order item ",
+									parentOrderItem.getExternalReferenceCode(),
+									". Amended date: ", endDate,
+									", original date: ",
+									OrderItemUtil.getEndDate(orderItem)));
+						}
+					}
+
+					_entitlementService.trimEntitlements(
+						GetterUtil.getLong(orderItem.getId()),
+						effectiveEndDate);
 				}
 			}
 
@@ -114,22 +144,6 @@ public class ProvisioningOrderService {
 						realignmentOpportunityLineItem.getProductName());
 			}
 		}
-
-		for (OrderItem parentOrderItem : parentOrder.getOrderItems()) {
-			OrderItem orderItem =
-				_commerceOrderItemService.fetchCommerceOrderItem(
-					parentOrderItem.getId());
-
-			if ((orderItem != null) &&
-				!Objects.equals(
-					OrderItemUtil.getStatus(orderItem),
-					CommerceOrderItemConstants.STATUS_CANCELED)) {
-
-				return;
-			}
-		}
-
-		_commerceOrderService.cancelOrder(parentOrder.getId());
 	}
 
 	public void trimRenewedOrderItems(
@@ -218,6 +232,25 @@ public class ProvisioningOrderService {
 		if (_log.isWarnEnabled()) {
 			_log.warn(warningMessage);
 		}
+	}
+
+	private boolean _isFamilyOrder(Order order, String parentOpportunityId) {
+		if (Objects.equals(
+				order.getExternalReferenceCode(), parentOpportunityId)) {
+
+			return true;
+		}
+
+		Map<String, Object> customFields =
+			(Map<String, Object>)order.getCustomFields();
+
+		if (customFields == null) {
+			return false;
+		}
+
+		return Objects.equals(
+			Objects.toString(customFields.get("parentOpportunityId"), null),
+			parentOpportunityId);
 	}
 
 	private String _toDateTime(String value) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89686

## What is being fixed

When a Salesforce opportunity realignment arrived, the provisioning
subscriber canceled the superseded order items, hard-deleted their
entitlements, and canceled the order once every item was canceled. That
destroyed entitlement records other systems may still reference and lost
the as-sold order history. It also only inspected the originating order,
so a realignment landing after an earlier amendment never trimmed the
item that amendment had made active, and it could delete an account's
Okta application on a canceled PaaS Experience item even when the
customer still had another active one.

## How it is being fixed

Realignment now trims dates instead of deleting. The superseded item's
effective end date and its entitlements' end dates are moved earlier
(only ever earlier, floored to the start date) while the item stays
Approved and the order keeps its status; end-of-life transitions are
deferred to a future expiry sweep. The match now scans the account's
whole order family through the parent opportunity id, so a later
amendment correctly trims the active item an earlier amendment created.
Order-item writes gained replay guards so a redelivered message never
resurrects a canceled item or resets a trimmed date, and hasEntitlement
now ignores already-expired grants. Finally, before the order-item
object action deletes an account's Okta application on a canceled PaaS
Experience item, it first confirms no other active PaaS Experience item
remains, so cancel-and-replace no longer tears down the customer's app.
