### PR TITLE
LPD-89889 Fix business events ticket list and event form issues

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsAdd/BusinessEventsAdd.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsAdd/BusinessEventsAdd.tsx
@@ -54,20 +54,22 @@ const BusinessEventsAddPage: React.FC = () => {
 	const businessEvent = values.businessEvent as unknown as IBusinessEvent;
 
 	const setFieldValue = useCallback(
-		(field: string, value: unknown) =>
+		(
+			field: string,
+			value: unknown,
+			options: Parameters<typeof setValue>[2] = {
+				shouldDirty: true,
+				shouldTouch: true,
+				shouldValidate: true,
+			}
+		) =>
 			setValue(
 				field as Parameters<typeof setValue>[0],
 				value as Parameters<typeof setValue>[1],
-				{
-					shouldDirty: true,
-					shouldTouch: true,
-					shouldValidate: true,
-				}
+				options
 			),
 		[setValue]
 	);
-
-	const [baseButtonDisabled, setBaseButtonDisabled] = useState<boolean>(true);
 
 	const {businessEventTypesList, loading: loadingBusinessEventTypesList} =
 		useGetBusinessEventTypesList();
@@ -89,7 +91,7 @@ const BusinessEventsAddPage: React.FC = () => {
 
 	const isDescriptionRequired = useMemo(
 		() => businessEvent.eventType?.key === 'Other Event',
-		[businessEvent.eventType]
+		[businessEvent.eventType?.key]
 	);
 
 	const [isLoadingSubmitButton, setIsLoadingSubmitButton] =
@@ -97,7 +99,7 @@ const BusinessEventsAddPage: React.FC = () => {
 
 	const isNewLiferayVersionRequired = useMemo(
 		() => ['Migration', 'Upgrade'].includes(businessEvent.eventType?.key!),
-		[businessEvent.eventType]
+		[businessEvent.eventType?.key]
 	);
 
 	const {isSaasOnly} = useIsSaasOnly();
@@ -233,54 +235,44 @@ const BusinessEventsAddPage: React.FC = () => {
 		);
 	}, [hasImpactingEvents, selectedTickets, setFieldValue]);
 
-	useEffect(() => {
-		const hasCurrentLiferayVersion =
-			values.businessEvent.currentLiferayVersion.key;
+	const hasCurrentLiferayVersion =
+		values.businessEvent.currentLiferayVersion.key;
 
-		const hasDescription = values.businessEvent.description;
-		const hasError = errors && Object.keys(errors).length;
-		const hasEventName = values.businessEvent.name;
-		const hasEventType = values.businessEvent.eventType.key;
-		const hasNewLiferayVersion = values.businessEvent.newLiferayVersion.key;
-		const hasPlannedEventDate = values.businessEvent.plannedEventDate;
-		const hasTouched = Boolean(Object.keys(touched).length);
+	const hasDescription = values.businessEvent.description;
+	const hasError = errors && Object.keys(errors).length;
+	const hasEventName = values.businessEvent.name;
+	const hasEventType = values.businessEvent.eventType.key;
+	const hasNewLiferayVersion = values.businessEvent.newLiferayVersion.key;
+	const hasPlannedEventDate = values.businessEvent.plannedEventDate;
+	const hasPlannedEventTime = !requiredTimeInput(
+		values.businessEvent.plannedEventTime
+	);
+	const hasTimeZone = values.businessEvent.timeZone.key;
+	const hasTouched = Boolean(Object.keys(touched).length);
 
-		let hasAllRequiredFieldsFilled =
-			Boolean(hasEventName) &&
-			Boolean(hasEventType) &&
-			Boolean(hasPlannedEventDate);
+	let hasAllRequiredFieldsFilled =
+		Boolean(hasEventName) &&
+		Boolean(hasEventType) &&
+		Boolean(hasPlannedEventDate) &&
+		Boolean(hasPlannedEventTime) &&
+		Boolean(hasTimeZone);
 
-		if (isDescriptionRequired) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasDescription;
-		}
+	if (isDescriptionRequired) {
+		hasAllRequiredFieldsFilled = hasAllRequiredFieldsFilled && hasDescription;
+	}
 
-		if (isNewLiferayVersionRequired) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasNewLiferayVersion;
-		}
+	if (isNewLiferayVersionRequired) {
+		hasAllRequiredFieldsFilled =
+			hasAllRequiredFieldsFilled && hasNewLiferayVersion;
+	}
 
-		if (!isSaasOnly) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasCurrentLiferayVersion;
-		}
+	if (!isSaasOnly) {
+		hasAllRequiredFieldsFilled =
+			hasAllRequiredFieldsFilled && hasCurrentLiferayVersion;
+	}
 
-		setBaseButtonDisabled(
-			!hasAllRequiredFieldsFilled || Boolean(hasError) || !hasTouched
-		);
-	}, [
-		errors,
-		isDescriptionRequired,
-		isNewLiferayVersionRequired,
-		isSaasOnly,
-		touched,
-		values.businessEvent.currentLiferayVersion,
-		values.businessEvent.description,
-		values.businessEvent.eventType,
-		values.businessEvent.name,
-		values.businessEvent.newLiferayVersion,
-		values.businessEvent.plannedEventDate,
-	]);
+	const baseButtonDisabled =
+		!hasAllRequiredFieldsFilled || Boolean(hasError) || !hasTouched;
 
 	useEffect(() => {
 		if (productVersions?.length) {
@@ -310,7 +302,11 @@ const BusinessEventsAddPage: React.FC = () => {
 
 	useEffect(() => {
 		if (!isDescriptionRequired) {
-			setFieldValue('businessEvent.description', '');
+			setFieldValue('businessEvent.description', '', {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
 		}
 	}, [isDescriptionRequired, setFieldValue]);
 
@@ -322,7 +318,11 @@ const BusinessEventsAddPage: React.FC = () => {
 				businessEvent.newLiferayVersion?.key
 			)
 		) {
-			setFieldValue('businessEvent.newLiferayVersion.key', '');
+			setFieldValue('businessEvent.newLiferayVersion.key', '', {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
 		}
 	}, [
 		businessEvent.newLiferayVersion?.key,
@@ -551,10 +551,7 @@ const BusinessEventsAddPage: React.FC = () => {
 											);
 										}}
 										options={[
-											{
-												...emptyOption,
-												disabled: false,
-											},
+											emptyOption,
 											...utcTimeZonesList,
 										]}
 										required

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsEdit/BusinessEventsEdit.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsEdit/BusinessEventsEdit.tsx
@@ -65,20 +65,22 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 	const businessEvent = values.businessEvent as unknown as IBusinessEvent;
 
 	const setFieldValue = useCallback(
-		(field: string, value: unknown) =>
+		(
+			field: string,
+			value: unknown,
+			options: Parameters<typeof setValue>[2] = {
+				shouldDirty: true,
+				shouldTouch: true,
+				shouldValidate: true,
+			}
+		) =>
 			setValue(
 				field as Parameters<typeof setValue>[0],
 				value as Parameters<typeof setValue>[1],
-				{
-					shouldDirty: true,
-					shouldTouch: true,
-					shouldValidate: true,
-				}
+				options
 			),
 		[setValue]
 	);
-
-	const [baseButtonDisabled, setBaseButtonDisabled] = useState<boolean>(true);
 
 	const [reason, setReason] = useState('');
 
@@ -104,7 +106,7 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 
 	const isDescriptionRequired = useMemo(
 		() => businessEvent.eventType?.key === 'Other Event',
-		[businessEvent.eventType]
+		[businessEvent.eventType?.key]
 	);
 
 	const [isLoadingSubmitButton, setIsLoadingSubmitButton] =
@@ -114,7 +116,7 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 
 	const isNewLiferayVersionRequired = useMemo(
 		() => ['Migration', 'Upgrade'].includes(businessEvent.eventType?.key!),
-		[businessEvent.eventType]
+		[businessEvent.eventType?.key]
 	);
 
 	const {isSaasOnly} = useIsSaasOnly();
@@ -271,7 +273,11 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 
 	useEffect(() => {
 		if (!isDescriptionRequired) {
-			setFieldValue('businessEvent.description', '');
+			setFieldValue('businessEvent.description', '', {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
 		}
 		else {
 			originalBusinessEvent.description
@@ -279,7 +285,11 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 						'businessEvent.description',
 						originalBusinessEvent.description
 					)
-				: setFieldValue('businessEvent.description', '');
+				: setFieldValue('businessEvent.description', '', {
+						shouldDirty: false,
+						shouldTouch: false,
+						shouldValidate: false,
+					});
 		}
 	}, [
 		isDescriptionRequired,
@@ -289,7 +299,11 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 
 	useEffect(() => {
 		if (!isNewLiferayVersionRequired) {
-			setFieldValue('businessEvent.newLiferayVersion.key', '');
+			setFieldValue('businessEvent.newLiferayVersion.key', '', {
+				shouldDirty: false,
+				shouldTouch: false,
+				shouldValidate: false,
+			});
 
 			return;
 		}
@@ -324,7 +338,11 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 			return;
 		}
 
-		setFieldValue('businessEvent.newLiferayVersion.key', '');
+		setFieldValue('businessEvent.newLiferayVersion.key', '', {
+			shouldDirty: false,
+			shouldTouch: false,
+			shouldValidate: false,
+		});
 	}, [
 		businessEvent.newLiferayVersion?.key,
 		isNewLiferayVersionRequired,
@@ -385,50 +403,42 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 		}
 	}, [originalBusinessEvent, tickets]);
 
-	useEffect(() => {
-		const hasCurrentLiferayVersion =
-			values.businessEvent.currentLiferayVersion.key;
+	const hasCurrentLiferayVersion =
+		values.businessEvent.currentLiferayVersion.key;
 
-		const hasDescription = values.businessEvent.description;
-		const hasError = errors && Object.keys(errors).length;
-		const hasEventName = values.businessEvent.name;
-		const hasEventType = values.businessEvent.eventType.key;
-		const hasNewLiferayVersion = values.businessEvent.newLiferayVersion.key;
-		const hasPlannedEventDate = values.businessEvent.plannedEventDate;
+	const hasDescription = values.businessEvent.description;
+	const hasError = errors && Object.keys(errors).length;
+	const hasEventName = values.businessEvent.name;
+	const hasEventType = values.businessEvent.eventType.key;
+	const hasNewLiferayVersion = values.businessEvent.newLiferayVersion.key;
+	const hasPlannedEventDate = values.businessEvent.plannedEventDate;
+	const hasPlannedEventTime = !requiredTimeInput(
+		values.businessEvent.plannedEventTime
+	);
+	const hasTimeZone = values.businessEvent.timeZone.key;
 
-		let hasAllRequiredFieldsFilled =
-			Boolean(hasEventName) &&
-			Boolean(hasEventType) &&
-			Boolean(hasPlannedEventDate);
+	let hasAllRequiredFieldsFilled =
+		Boolean(hasEventName) &&
+		Boolean(hasEventType) &&
+		Boolean(hasPlannedEventDate) &&
+		Boolean(hasPlannedEventTime) &&
+		Boolean(hasTimeZone);
 
-		if (isDescriptionRequired) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasDescription;
-		}
+	if (isDescriptionRequired) {
+		hasAllRequiredFieldsFilled = hasAllRequiredFieldsFilled && hasDescription;
+	}
 
-		if (isNewLiferayVersionRequired) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasNewLiferayVersion;
-		}
+	if (isNewLiferayVersionRequired) {
+		hasAllRequiredFieldsFilled =
+			hasAllRequiredFieldsFilled && hasNewLiferayVersion;
+	}
 
-		if (!isSaasOnly) {
-			hasAllRequiredFieldsFilled =
-				hasAllRequiredFieldsFilled && hasCurrentLiferayVersion;
-		}
+	if (!isSaasOnly) {
+		hasAllRequiredFieldsFilled =
+			hasAllRequiredFieldsFilled && hasCurrentLiferayVersion;
+	}
 
-		setBaseButtonDisabled(!hasAllRequiredFieldsFilled || Boolean(hasError));
-	}, [
-		errors,
-		isDescriptionRequired,
-		isNewLiferayVersionRequired,
-		isSaasOnly,
-		values.businessEvent.currentLiferayVersion,
-		values.businessEvent.description,
-		values.businessEvent.eventType,
-		values.businessEvent.name,
-		values.businessEvent.newLiferayVersion,
-		values.businessEvent.plannedEventDate,
-	]);
+	const baseButtonDisabled = !hasAllRequiredFieldsFilled || Boolean(hasError);
 
 	return !loading ? (
 		canViewTickets ? (
@@ -768,10 +778,7 @@ const BusinessEventsEditPage: React.FC<IProps> = ({originalBusinessEvent}) => {
 													);
 												}}
 												options={[
-													{
-														...emptyOption,
-														disabled: false,
-													},
+													emptyOption,
 													...utcTimeZonesList,
 												]}
 												required

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsRedirect.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/BusinessEvents/BusinessEventsRedirect.tsx
@@ -76,15 +76,23 @@ const BusinessEventsRedirect = () => {
 
 	if (!projects.length) {
 		return (
-			<RestrictedFeatureMessage
-				message={
-					hasAccountProjects
-						? translate(
-								'login-as-a-user-that-has-access-to-a-project-or-contact-your-project-administrator-to-add-you-to-a-project.'
-							)
-						: undefined
-				}
-			/>
+			<div className="py-4">
+				<div>
+					<h1 className="font-weight-bold text-neutral-10">
+						{translate('business-events')}
+					</h1>
+				</div>
+
+				<RestrictedFeatureMessage
+					message={
+						hasAccountProjects
+							? translate(
+									'login-as-a-user-that-has-access-to-a-project-or-contact-your-project-administrator-to-add-you-to-a-project.'
+								)
+							: undefined
+					}
+				/>
+			</div>
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/TicketAttachments/TicketAttachmentsAdd/TicketAttachmentsAdd.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/TicketAttachments/TicketAttachmentsAdd/TicketAttachmentsAdd.tsx
@@ -64,6 +64,22 @@ const TicketAttachmentsAdd = () => {
 		return () => controller.abort();
 	}, [projectERC]);
 
+	const header = (
+		<>
+			<h1 className="font-weight-bold text-neutral-10">
+				{translate('new-attachment')}
+			</h1>
+
+			{!!projects.length && (
+				<h6 className="font-weight-normal text-neutral-7">
+					{translate(
+						'select-the-project-and-ticket-you-want-to-attach-a-file-to'
+					)}
+				</h6>
+			)}
+		</>
+	);
+
 	if (projectsLoading) {
 		return (
 			<div className="mx-auto">
@@ -75,6 +91,8 @@ const TicketAttachmentsAdd = () => {
 	if (!projects.length) {
 		return (
 			<div className="py-4">
+				{header}
+
 				<RestrictedFeatureMessage
 					message={
 						hasAccountProjects
@@ -90,15 +108,7 @@ const TicketAttachmentsAdd = () => {
 
 	return (
 		<div className="py-4">
-			<h1 className="font-weight-bold text-neutral-10">
-				{translate('new-attachment')}
-			</h1>
-
-			<h6 className="font-weight-normal text-neutral-7">
-				{translate(
-					'select-the-project-and-ticket-you-want-to-attach-a-file-to'
-				)}
-			</h6>
+			{header}
 
 			<div className="mt-4" style={{maxWidth: '32rem'}}>
 				<ClayForm.Group>

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/TicketAttachments/TicketAttachmentsList/TicketAttachmentsList.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/TicketAttachments/TicketAttachmentsList/TicketAttachmentsList.tsx
@@ -141,9 +141,14 @@ const TicketAttachmentsList = () => {
 					/>
 				)}
 
-				<Button displayType="primary" onClick={() => navigate('/new')}>
-					{translate('new-attachment')}
-				</Button>
+				{!!projects.length && (
+					<Button
+						displayType="primary"
+						onClick={() => navigate('/new')}
+					>
+						{translate('new-attachment')}
+					</Button>
+				)}
 			</div>
 		</div>
 	);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraIssueService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraIssueService.java
@@ -148,9 +148,9 @@ public class JiraIssueService extends BaseJiraService {
 
 		StringBundler sb = new StringBundler(12);
 
-		sb.append("Organization in aqlFunction('\"External Key\" = \"");
+		sb.append("Organization in aqlFunction('\\\"External Key\\\" = \\\"");
 		sb.append(externalReferenceCode);
-		sb.append("\"') and (status not in ('");
+		sb.append("\\\"') and (status not in ('");
 		sb.append(
 			StringUtil.merge(IssueConstants.STATUSES_SOLVED_AND_CLOSED, "','"));
 		sb.append("')) and ");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89889

## What is being fixed

The support ticket list on the Business Events page returned empty because Jira Cloud's `/search/jql` endpoint stopped accepting bare double quotes inside `aqlFunction()` arguments. Separately, the Create and Edit Business Event forms had several issues: the submit button stayed disabled after all required fields were filled (only enabling after editing an already-filled field, and never at all when the time was `00:00`), the Time Zone selector allowed re-selecting the empty "Select the Option" placeholder, and the Edit form's Save button stayed enabled after clearing the time or time zone. The restricted-state screens (feature not included in the plan) for Business Events and Ticket Attachments were also missing their page headers, and the Ticket Attachments "New Attachment" button was shown even when the feature was unavailable.

## How it is being fixed

The JQL builder now backslash-escapes the inner double quotes so the runtime query carries the spec-correct `\"` form that the rewritten Jira parser accepts. The button-enable state in both business event forms is now computed during render instead of in a `useEffect` plus `useState`, which removes a react-hook-form staleness bug: RHF mutates both the watched values and the `errors` object in place, so the effect's dependency array never re-fired when the error cleared, leaving the button stuck one render behind — most visibly at `00:00`, where the completing keystroke produces no further distinct change to flush it. The Time Zone empty option is now disabled like the other selectors, the Edit form validation now includes the time and time zone, and the restricted-state screens render their headers while the New Attachment action is hidden when the feature is unavailable.
