### PR TITLE
LPD-90495 Ignore docker-compose.override.yaml for local debug configs

### DIFF
--- a/workspaces/liferay-one-workspace/.gitignore
+++ b/workspaces/liferay-one-workspace/.gitignore
@@ -9,9 +9,10 @@
 /poshi/test-results
 /poshi/tests
 @vite/*
-!@vite/refresh.ts
 bin
 build
 dist
 node_modules
 node_modules_cache
+
+!@vite/refresh.ts

--- a/workspaces/liferay-one-workspace/.gitignore
+++ b/workspaces/liferay-one-workspace/.gitignore
@@ -4,6 +4,7 @@
 /.idea
 /bundles
 /client-extensions/liferay-one-etc-spring-boot/liferay-release-tool-ee
+/docker-compose.override.yaml
 /poshi/poshi-ext.properties
 /poshi/test-results
 /poshi/tests


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90495

## What is being fixed

Local developers need a docker-compose.override.yaml to hold personal
debug configuration (for example, remote JVM debug settings), but the
workspace was not ignoring that file, so local-only overrides risked
being committed and shared.

## How it is being fixed

Add /docker-compose.override.yaml to the workspace .gitignore so the
override file stays local to each developer's machine. The existing
.gitignore entries were also re-sorted into canonical order.
