### PR TITLE
LPD-91399 Port the Okta-side PubSub subscribers to Spring Boot

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -80,6 +80,15 @@ dependencies {
 	testImplementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: "2.7.18"
 }
 
+configurations.all {
+	resolutionStrategy {
+		force "com.google.api:gax:2.50.0"
+		force "com.google.api:gax-httpjson:2.50.0"
+		force "io.grpc:grpc-api:1.62.2"
+		force "io.grpc:grpc-context:1.62.2"
+	}
+}
+
 repositories {
 	maven {
 		url new File(rootProject.projectDir, "../../.m2-tmp")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/okta/pubsub/OktaAppCreatedPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/okta/pubsub/OktaAppCreatedPubsubSubscriber.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.okta.pubsub;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.portal.kernel.util.Validator;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kyle Bischof
+ */
+@Component
+@ConditionalOnProperty(
+	havingValue = "true",
+	name = "liferay.one.okta.app.created.pubsub.subscriber.enabled"
+)
+public class OktaAppCreatedPubsubSubscriber extends BasePubsubSubscriber {
+
+	@Override
+	public String getTopic() {
+		return _topic;
+	}
+
+	@Override
+	public void receive(Message message) throws Exception {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Parsing message: " + message.getPayload());
+		}
+
+		try {
+			JSONObject jsonObject = new JSONObject(message.getPayload());
+
+			String accountKey = jsonObject.optString("accountKey");
+			String appId = jsonObject.optString("appId");
+
+			if (Validator.isNull(accountKey) || Validator.isNull(appId)) {
+				return;
+			}
+
+			Account account =
+				_accountService.fetchAccountByExternalReferenceCode(accountKey);
+
+			if (account == null) {
+				return;
+			}
+
+			String oktaApplicationId = _propertyService.getPropertyValue(
+				account.getId(), PropertyConstants.NAME_OKTA_APPLICATION);
+
+			if (Validator.isNotNull(oktaApplicationId)) {
+				return;
+			}
+
+			_propertyService.addProperty(
+				account.getId(), PropertyConstants.NAME_OKTA_APPLICATION,
+				appId);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to process Okta app created message " +
+					message.getPayload(),
+				exception);
+		}
+	}
+
+	@Override
+	protected String getProjectId() {
+		return _projectId;
+	}
+
+	@Override
+	protected String getSubscriptionName() {
+		return _subscription;
+	}
+
+	@Override
+	protected boolean isAutoCreateTopic() {
+		return false;
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OktaAppCreatedPubsubSubscriber.class);
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Value("${liferay.one.okta.app.created.pubsub.subscriber.project.id}")
+	private String _projectId;
+
+	@Autowired
+	private PropertyService _propertyService;
+
+	@Value("${liferay.one.okta.app.created.pubsub.subscriber.subscription}")
+	private String _subscription;
+
+	@Value("${liferay.one.okta.app.created.pubsub.subscriber.topic}")
+	private String _topic;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/okta/pubsub/OktaUsersPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/okta/pubsub/OktaUsersPubsubSubscriber.java
@@ -1,0 +1,216 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.okta.pubsub;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.okta.model.OktaUser;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.ProvisioningAssignmentService;
+import com.liferay.one.service.ProvisioningEmailService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.UserAccountUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Kyle Bischof
+ */
+@Component
+@ConditionalOnProperty(
+	havingValue = "true",
+	name = "liferay.one.okta.users.pubsub.subscriber.enabled"
+)
+public class OktaUsersPubsubSubscriber extends BasePubsubSubscriber {
+
+	@Override
+	public String getTopic() {
+		return _topic;
+	}
+
+	@Override
+	public void receive(Message message) throws Exception {
+		if (_log.isDebugEnabled()) {
+			_log.debug("Parsing message: " + message.getPayload());
+		}
+
+		try {
+			JSONObject jsonObject = new JSONObject(message.getPayload());
+
+			String eventType = jsonObject.optString("eventType");
+
+			OktaUser oktaUser = new OktaUser(
+				jsonObject.optJSONObject("user", new JSONObject()));
+
+			if (Objects.equals(eventType, _EVENT_TYPE_LIFECYCLE_ACTIVATE) ||
+				Objects.equals(eventType, _EVENT_TYPE_LIFECYCLE_CREATE)) {
+
+				_syncContact(oktaUser);
+			}
+			else if (Objects.equals(
+						eventType, _EVENT_TYPE_LIFECYCLE_DEACTIVATE)) {
+
+				_unassignAllMemberships(oktaUser);
+			}
+			else if (Objects.equals(
+						eventType, _EVENT_TYPE_ACCOUNT_UPDATE_PASSWORD) ||
+					 Objects.equals(
+						 eventType, _EVENT_TYPE_ACCOUNT_UPDATE_PROFILE)) {
+
+				_updateContact(oktaUser);
+			}
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to process Okta users message " + message.getPayload(),
+				exception);
+		}
+	}
+
+	@Override
+	protected String getProjectId() {
+		return _projectId;
+	}
+
+	@Override
+	protected String getSubscriptionName() {
+		return _subscription;
+	}
+
+	@Override
+	protected boolean isAutoCreateTopic() {
+		return false;
+	}
+
+	private UserAccount _fetchUserAccount(String emailAddress)
+		throws Exception {
+
+		if (Validator.isNull(emailAddress)) {
+			return null;
+		}
+
+		return _userAccountService.fetchUserAccountByEmailAddress(emailAddress);
+	}
+
+	private void _removeAccountUserAccount(
+			long accountEntryId, UserAccount userAccount)
+		throws Exception {
+
+		_accountService.removeAccountUserAccount(
+			accountEntryId, userAccount.getId());
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			accountEntryId, userAccount.getId());
+	}
+
+	private void _syncContact(OktaUser oktaUser) throws Exception {
+		UserAccount userAccount = _fetchUserAccount(oktaUser.getEmail());
+
+		if (userAccount == null) {
+			return;
+		}
+
+		if (oktaUser.isEmailAddressVerified() &&
+			!UserAccountUtil.isVerified(userAccount)) {
+
+			_userAccountService.setVerified(userAccount.getId());
+		}
+	}
+
+	private void _unassignAllMemberships(OktaUser oktaUser) throws Exception {
+		UserAccount userAccount = _fetchUserAccount(oktaUser.getEmail());
+
+		if (userAccount == null) {
+			return;
+		}
+
+		AccountBrief[] accountBriefs = userAccount.getAccountBriefs();
+
+		if (accountBriefs == null) {
+			return;
+		}
+
+		for (AccountBrief accountBrief : accountBriefs) {
+			try {
+				_removeAccountUserAccount(accountBrief.getId(), userAccount);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to unassign membership for " + oktaUser.getEmail(),
+					exception);
+			}
+		}
+	}
+
+	private void _updateContact(OktaUser oktaUser) throws Exception {
+		UserAccount userAccount = _fetchUserAccount(oktaUser.getEmail());
+
+		if (userAccount == null) {
+			return;
+		}
+
+		if (oktaUser.isEmailAddressVerified() &&
+			!UserAccountUtil.isVerified(userAccount)) {
+
+			_provisioningEmailService.sendVerifiedWelcomeEmail(userAccount);
+
+			_userAccountService.setVerified(userAccount.getId());
+		}
+	}
+
+	private static final String _EVENT_TYPE_ACCOUNT_UPDATE_PASSWORD =
+		"user.account.update_password";
+
+	private static final String _EVENT_TYPE_ACCOUNT_UPDATE_PROFILE =
+		"user.account.update_profile";
+
+	private static final String _EVENT_TYPE_LIFECYCLE_ACTIVATE =
+		"user.lifecycle.activate";
+
+	private static final String _EVENT_TYPE_LIFECYCLE_CREATE =
+		"user.lifecycle.create";
+
+	private static final String _EVENT_TYPE_LIFECYCLE_DEACTIVATE =
+		"user.lifecycle.deactivate";
+
+	private static final Log _log = LogFactory.getLog(
+		OktaUsersPubsubSubscriber.class);
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Value("${liferay.one.okta.users.pubsub.subscriber.project.id}")
+	private String _projectId;
+
+	@Autowired
+	private ProvisioningAssignmentService _provisioningAssignmentService;
+
+	@Autowired
+	private ProvisioningEmailService _provisioningEmailService;
+
+	@Value("${liferay.one.okta.users.pubsub.subscriber.subscription}")
+	private String _subscription;
+
+	@Value("${liferay.one.okta.users.pubsub.subscriber.topic}")
+	private String _topic;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -251,6 +251,19 @@ public class AccountService extends OneBaseService {
 		return false;
 	}
 
+	public void removeAccountUserAccount(long accountId, long userId)
+		throws Exception {
+
+		delete(
+			getAuthorization(), StringPool.BLANK,
+			UriComponentsBuilder.fromPath(
+				"/o/headless-admin-user/v1.0/accounts/{accountId}" +
+					"/user-accounts/{userId}"
+			).buildAndExpand(
+				accountId, userId
+			).toUri());
+	}
+
 	public void removeAccountUserAccount(
 			String externalReferenceCode, Jwt jwt, long userId)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -5,6 +5,8 @@
 
 package com.liferay.one.service;
 
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
@@ -165,6 +167,25 @@ public class UserAccountService extends OneBaseService {
 		}
 
 		return false;
+	}
+
+	public void setVerified(long userId) throws Exception {
+		UserAccountResource userAccountResource = _buildUserAccountResource();
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(() -> Boolean.TRUE);
+
+		CustomField customField = new CustomField();
+
+		customField.setCustomValue(() -> customValue);
+		customField.setName(() -> "verified");
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setCustomFields(() -> new CustomField[] {customField});
+
+		userAccountResource.patchUserAccount(userId, userAccount);
 	}
 
 	private UserAccountResource _buildUserAccountResource(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -80,8 +80,16 @@ liferay.oauth.urls.excludes=/ready
 #
 
 liferay.one.okta.api.token=${LIFERAY_ONE_OKTA_API_TOKEN}
+liferay.one.okta.app.created.pubsub.subscriber.enabled=${LIFERAY_ONE_OKTA_APP_CREATED_PUBSUB_SUBSCRIBER_ENABLED}
+liferay.one.okta.app.created.pubsub.subscriber.project.id=${LIFERAY_ONE_OKTA_APP_CREATED_PUBSUB_SUBSCRIBER_PROJECT_ID}
+liferay.one.okta.app.created.pubsub.subscriber.subscription=${LIFERAY_ONE_OKTA_APP_CREATED_PUBSUB_SUBSCRIBER_SUBSCRIPTION}
+liferay.one.okta.app.created.pubsub.subscriber.topic=${LIFERAY_ONE_OKTA_APP_CREATED_PUBSUB_SUBSCRIBER_TOPIC}
 liferay.one.okta.host=${LIFERAY_ONE_OKTA_HOST}
 liferay.one.okta.pubsub.publisher.project.id=${LIFERAY_ONE_OKTA_PUBSUB_PUBLISHER_PROJECT_ID}
+liferay.one.okta.users.pubsub.subscriber.enabled=${LIFERAY_ONE_OKTA_USERS_PUBSUB_SUBSCRIBER_ENABLED}
+liferay.one.okta.users.pubsub.subscriber.project.id=${LIFERAY_ONE_OKTA_USERS_PUBSUB_SUBSCRIBER_PROJECT_ID}
+liferay.one.okta.users.pubsub.subscriber.subscription=${LIFERAY_ONE_OKTA_USERS_PUBSUB_SUBSCRIBER_SUBSCRIPTION}
+liferay.one.okta.users.pubsub.subscriber.topic=${LIFERAY_ONE_OKTA_USERS_PUBSUB_SUBSCRIBER_TOPIC}
 
 #
 # Salesforce


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91399

## What is being fixed

The two legacy OSB-provisioning Okta-side GCP Pub/Sub subscribers —
OktaUsersMessageSubscriber (topic okta-users) and
OktaAppCreatedMessageSubscriber (topic okta-app-created) — had not yet
been ported into the liferay-one-etc-spring-boot client extension as
part of the Salesforce and provisioning flow migration. Their
subscription IDs must be preserved so the new application takes over
from the legacy consumer without missing or re-processing messages.

Separately, a gRPC and gax dependency version skew — introduced around
June 18 by a transitive bump through the google-http-client and
gax-httpjson chain, with no BOM to keep the family aligned — pulled
grpc-api and grpc-context up to 1.69.0 and gax up to 2.60.0 while
grpc-core stayed pinned at 1.62.2 (via google-cloud-pubsub). That left
io.grpc.InternalGlobalInterceptors missing at runtime and broke the GCP
connection for every Pub/Sub subscriber, Okta and Salesforce alike. It
regressed after the Salesforce subscribers had already been verified
against real GCP on the previously consistent versions, and went
unnoticed because the subsequent testing used the internal dispatch
endpoint, which never constructs the GCP client.

## How it is being fixed

The first commit adds two Spring subscribers that extend
BasePubsubSubscriber, mirroring the existing Salesforce subscribers.
OktaAppCreatedPubsubSubscriber stores the Okta application id as an
account Property, with de-duplication. OktaUsersPubsubSubscriber handles
the user lifecycle events: activate and create reconcile the portal
verified custom field, update_password and update_profile send the
verified welcome email and reconcile the flag, and deactivate unassigns
the user's account memberships along with the ported
ProvisioningAssignmentService side effects. The Okta group-membership
events are intentionally not handled here — Okta group to Liferay role
assignment is owned by the SAML integration at login (LPD-95372), so a
pub/sub path would be redundant. Subscription names are
configuration-driven so the legacy connector subscription IDs can be
reused for a clean cutover. Two small net-new service methods support
this (AccountService.removeAccountUserAccount and
UserAccountService.setVerified) alongside the subscriber configuration
keys.

The second commit resolves the gRPC and gax version skew by pinning both
back to the consistent versions google-cloud-pubsub declares, restoring
GCP connectivity for all subscribers. The whole flow was validated
end-to-end against the is-ops-dev project and the Okta sandbox.
