### PR TITLE
LPD-97365 Record license key changes with object entry history

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
@@ -2871,7 +2871,7 @@
 			"className": "com.liferay.object.model.ObjectDefinition#C_LICENSE_KEY",
 			"enableCategorization": false,
 			"enableComments": false,
-			"enableObjectEntryHistory": false,
+			"enableObjectEntryHistory": true,
 			"externalReferenceCode": "C_LICENSE_KEY",
 			"friendlyURLSeparator": "l",
 			"label": {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97365

## What is being fixed

The legacy LicenseKeyModelListener had two side effects on every license
key create and update: it reindexed the key, and it built a field-level
old-versus-new diff and posted it as an audit entry to Koroneiki. Neither
was carried over when the license key backend was ported to a custom
Object, so license key changes were no longer audited.

## How it is being fixed

Both side effects are provided natively by the platform once object entry
history is enabled on the license key object, so no hand-written listener,
Spring Boot component, or external audit sink is needed. With the flag on,
the platform snapshots each version of the entry and routes a field-level
change audit through the built-in audit framework on create and update,
and object entries are indexed automatically, making the reindex step
obsolete. This change turns that flag on for the C_LICENSE_KEY object
definition in the batch provisioning data.

There is no code and no test because the behavior is entirely
platform-provided; it is verified at runtime by confirming audit records
appear when a license key changes.

## Note for reviewers

Two things worth confirming:

Did anything downstream consume the old Koroneiki audit entries — a report
or an external system — or is the in-platform audit trail sufficient? If a
consumer still needs the stream, enabling history alone will not feed it.

Only C_LICENSE_KEY is flipped here, mirroring the legacy listener, which
was bound to the provisioning LicenseKey model. C_COMMON_LICENSE_KEY is
left unchanged; enable it too if customer-facing license keys should be
audited.
