### PR TITLE
LPD-89441 Port provisioning sync and assign logic to REST endpoints

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -5,10 +5,29 @@
 
 package com.liferay.one;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.service.AccountService;
+import com.liferay.one.service.EmailAddressValidatorService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProvisioningAssignmentService;
+import com.liferay.one.service.ProvisioningEmailService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.UserAccountUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -19,8 +38,10 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * @author Jenny Chen
@@ -36,8 +57,14 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("userId") long userId)
 		throws Exception {
 
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
 		_accountService.removeAccountUserAccount(
 			externalReferenceCode, jwt, userId);
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			account.getId(), userId);
 	}
 
 	@DeleteMapping(
@@ -53,8 +80,19 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_accountPermission.check(externalReferenceCode, ActionKeys.UPDATE, jwt);
 
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
+		String accountRoleName = _accountService.getAccountRoleName(
+			account.getId(), accountRoleId);
+
 		_accountService.removeAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
+
+		if (accountRoleName != null) {
+			_provisioningAssignmentService.unassignAccountRole(
+				account, userId, accountRoleName);
+		}
 	}
 
 	@GetMapping("/{externalReferenceCode}/jira/object-key")
@@ -77,8 +115,19 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("userId") long userId)
 		throws Exception {
 
-		_accountService.addAccountUserAccount(
-			externalReferenceCode, jwt, userId);
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
+		boolean wasMember = _userAccountService.hasAccountUserAccount(
+			account.getId(), userId);
+
+		_accountService.addAccountUserAccount(account.getId(), jwt, userId);
+
+		_provisioningAssignmentService.assignCustomerGroup(userId);
+
+		if (!wasMember) {
+			_provisioningEmailService.sendAssignedWelcomeEmail(userId, account);
+		}
 	}
 
 	@PostMapping(
@@ -92,8 +141,161 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("accountRoleId") long accountRoleId)
 		throws Exception {
 
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
 		_accountService.addAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
+
+		String accountRoleName = _accountService.getAccountRoleName(
+			account.getId(), accountRoleId);
+
+		if (accountRoleName != null) {
+			_provisioningAssignmentService.assignAccountRole(
+				account, userId, accountRoleName);
+		}
+	}
+
+	@PostMapping(
+		"/{externalReferenceCode}/user-accounts/by-email-address" +
+			"/{emailAddress}/account-roles"
+	)
+	public void postUserAccountsByEmailAddressAccountRoles(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode,
+			@PathVariable("emailAddress") String emailAddress,
+			@RequestBody String json)
+		throws Exception {
+
+		_accountPermission.check(externalReferenceCode, ActionKeys.UPDATE, jwt);
+
+		if (_emailAddressValidatorService.isLiferayDomain(emailAddress)) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST,
+				"Email address uses a reserved Liferay domain");
+		}
+
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
+		JSONObject jsonObject = new JSONObject(json);
+
+		Map<Long, String> accountRoleNames = _getAccountRoleNames(
+			account.getId(), jsonObject.optJSONArray("accountRoleIds"));
+
+		UserAccount userAccount =
+			_userAccountService.fetchUserAccountByEmailAddress(emailAddress);
+
+		if (userAccount != null) {
+			Set<String> currentAccountRoleNames =
+				UserAccountUtil.getAccountRoleNames(
+					userAccount, account.getId());
+
+			for (String accountRoleName : accountRoleNames.values()) {
+				if (currentAccountRoleNames.contains(accountRoleName)) {
+					throw new ResponseStatusException(
+						HttpStatus.CONFLICT,
+						"Account role " + accountRoleName +
+							" is already assigned");
+				}
+			}
+		}
+
+		if (_oktaService.fetchContactByEmailAddress(emailAddress) == null) {
+			_createOktaContact(account, emailAddress, jsonObject);
+		}
+
+		boolean wasMember = false;
+
+		if (userAccount != null) {
+			wasMember = UserAccountUtil.hasAccountMembership(
+				userAccount, account.getId());
+		}
+
+		if (!wasMember) {
+			_accountService.addAccountUserAccountByEmailAddress(
+				account.getId(), emailAddress, jwt);
+		}
+
+		if (userAccount == null) {
+			userAccount = _userAccountService.fetchUserAccountByEmailAddress(
+				emailAddress);
+		}
+
+		long userId = userAccount.getId();
+
+		if (accountRoleNames.isEmpty()) {
+			_provisioningAssignmentService.assignCustomerGroup(userId);
+		}
+
+		for (Map.Entry<Long, String> entry : accountRoleNames.entrySet()) {
+			_accountService.addAccountUserAccountRole(
+				entry.getKey(), externalReferenceCode, jwt, userId);
+
+			_provisioningAssignmentService.assignAccountRole(
+				account, userId, entry.getValue());
+		}
+
+		if (!wasMember) {
+			_provisioningEmailService.sendAssignedWelcomeEmail(userId, account);
+		}
+	}
+
+	private void _createOktaContact(
+			Account account, String emailAddress, JSONObject jsonObject)
+		throws Exception {
+
+		if (!_entitlementService.hasEntitlement(
+				account.getId(), EntitlementConstants.NAMES_SLAS) &&
+			!_entitlementService.hasEntitlement(
+				account.getId(), EntitlementConstants.NAME_PARTNER)) {
+
+			throw new ResponseStatusException(
+				HttpStatus.UNPROCESSABLE_ENTITY,
+				"Unable to create an Okta user for an account without " +
+					"support or partner entitlements");
+		}
+
+		String firstName = jsonObject.optString("firstName");
+		String lastName = jsonObject.optString("lastName");
+
+		if (Validator.isNull(firstName) || Validator.isNull(lastName)) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST,
+				"\"firstName\" and \"lastName\" are required to create a new " +
+					"Okta user");
+		}
+
+		_oktaService.createContact(
+			emailAddress, firstName, StringPool.BLANK, lastName);
+	}
+
+	private Map<Long, String> _getAccountRoleNames(
+			long accountId, JSONArray accountRoleIdsJSONArray)
+		throws Exception {
+
+		Map<Long, String> accountRoleNames = new LinkedHashMap<>();
+
+		if (accountRoleIdsJSONArray == null) {
+			return accountRoleNames;
+		}
+
+		for (int i = 0; i < accountRoleIdsJSONArray.length(); i++) {
+			long accountRoleId = accountRoleIdsJSONArray.getLong(i);
+
+			String accountRoleName = _accountService.getAccountRoleName(
+				accountId, accountRoleId);
+
+			if (accountRoleName == null) {
+				throw new ResponseStatusException(
+					HttpStatus.BAD_REQUEST,
+					"Unable to find account role " + accountRoleId);
+			}
+
+			accountRoleNames.put(accountRoleId, accountRoleName);
+		}
+
+		return accountRoleNames;
 	}
 
 	@Autowired
@@ -104,5 +306,23 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private AccountService _accountService;
+
+	@Autowired
+	private EmailAddressValidatorService _emailAddressValidatorService;
+
+	@Autowired
+	private EntitlementService _entitlementService;
+
+	@Autowired
+	private OktaService _oktaService;
+
+	@Autowired
+	private ProvisioningAssignmentService _provisioningAssignmentService;
+
+	@Autowired
+	private ProvisioningEmailService _provisioningEmailService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -20,6 +20,7 @@ import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.UserAccountUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.LinkedHashMap;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -178,7 +180,7 @@ public class AccountsRestController extends OneBaseRestController {
 		Account account = _accountService.getAccount(
 			externalReferenceCode, jwt);
 
-		JSONObject jsonObject = new JSONObject(json);
+		JSONObject jsonObject = _getJSONObject(json);
 
 		Map<Long, String> accountRoleNames = _getAccountRoleNames(
 			account.getId(), jsonObject.optJSONArray("accountRoleIds"));
@@ -207,9 +209,11 @@ public class AccountsRestController extends OneBaseRestController {
 
 		boolean wasMember = false;
 
-		if (userAccount != null) {
-			wasMember = UserAccountUtil.hasAccountMembership(
-				userAccount, account.getId());
+		if ((userAccount != null) &&
+			UserAccountUtil.hasAccountMembership(
+				userAccount, account.getId())) {
+
+			wasMember = true;
 		}
 
 		if (!wasMember) {
@@ -246,9 +250,10 @@ public class AccountsRestController extends OneBaseRestController {
 		throws Exception {
 
 		if (!_entitlementService.hasEntitlement(
-				account.getId(), EntitlementConstants.NAMES_SLAS) &&
-			!_entitlementService.hasEntitlement(
-				account.getId(), EntitlementConstants.NAME_PARTNER)) {
+				account.getId(),
+				ArrayUtil.append(
+					EntitlementConstants.NAMES_SLAS,
+					EntitlementConstants.NAME_PARTNER))) {
 
 			throw new ResponseStatusException(
 				HttpStatus.UNPROCESSABLE_ENTITY,
@@ -270,6 +275,19 @@ public class AccountsRestController extends OneBaseRestController {
 			emailAddress, firstName, StringPool.BLANK, lastName);
 	}
 
+	private long _getAccountRoleId(
+		JSONArray accountRoleIdsJSONArray, int index) {
+
+		try {
+			return accountRoleIdsJSONArray.getLong(index);
+		}
+		catch (JSONException jsonException) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST, "Unable to parse \"accountRoleIds\"",
+				jsonException);
+		}
+	}
+
 	private Map<Long, String> _getAccountRoleNames(
 			long accountId, JSONArray accountRoleIdsJSONArray)
 		throws Exception {
@@ -280,11 +298,13 @@ public class AccountsRestController extends OneBaseRestController {
 			return accountRoleNames;
 		}
 
-		for (int i = 0; i < accountRoleIdsJSONArray.length(); i++) {
-			long accountRoleId = accountRoleIdsJSONArray.getLong(i);
+		Map<Long, String> allAccountRoleNames =
+			_accountService.getAccountRoleNames(accountId);
 
-			String accountRoleName = _accountService.getAccountRoleName(
-				accountId, accountRoleId);
+		for (int i = 0; i < accountRoleIdsJSONArray.length(); i++) {
+			long accountRoleId = _getAccountRoleId(accountRoleIdsJSONArray, i);
+
+			String accountRoleName = allAccountRoleNames.get(accountRoleId);
 
 			if (accountRoleName == null) {
 				throw new ResponseStatusException(
@@ -296,6 +316,17 @@ public class AccountsRestController extends OneBaseRestController {
 		}
 
 		return accountRoleNames;
+	}
+
+	private JSONObject _getJSONObject(String json) {
+		try {
+			return new JSONObject(json);
+		}
+		catch (JSONException jsonException) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST, "Unable to parse the request body",
+				jsonException);
+		}
 	}
 
 	@Autowired

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.okta.model.OktaUser;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.service.OrganizationService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Ricardo Mariz
+ */
+@RequestMapping("/organizations")
+@RestController
+public class OrganizationsRestController extends OneBaseRestController {
+
+	@PostMapping("/{organizationId}/sync-from-okta")
+	public void postSyncFromOkta(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("organizationId") long organizationId)
+		throws Exception {
+
+		_adminPermission.check(jwt);
+
+		String oktaGroupId = _propertyService.getPropertyValue(
+			Organization.class.getName(), organizationId,
+			PropertyConstants.NAME_OKTA_GROUP);
+
+		if (Validator.isNull(oktaGroupId)) {
+			throw new ResponseStatusException(
+				HttpStatus.NOT_FOUND,
+				"Unable to find an Okta group for organization " +
+					organizationId);
+		}
+
+		Set<String> oktaEmailAddresses = new HashSet<>();
+
+		for (OktaUser oktaUser : _oktaService.getGroupContacts(oktaGroupId)) {
+			String emailAddress = oktaUser.getEmail();
+
+			if (Validator.isNotNull(emailAddress)) {
+				oktaEmailAddresses.add(StringUtil.toLowerCase(emailAddress));
+			}
+		}
+
+		Set<String> organizationEmailAddresses = new HashSet<>();
+
+		for (UserAccount userAccount :
+				_userAccountService.getOrganizationUserAccounts(
+					organizationId)) {
+
+			organizationEmailAddresses.add(
+				StringUtil.toLowerCase(userAccount.getEmailAddress()));
+		}
+
+		for (String emailAddress : oktaEmailAddresses) {
+			if (!organizationEmailAddresses.contains(emailAddress)) {
+				_organizationService.addOrganizationUserAccountByEmailAddress(
+					emailAddress, organizationId);
+			}
+		}
+
+		for (String emailAddress : organizationEmailAddresses) {
+			if (!oktaEmailAddresses.contains(emailAddress)) {
+				_organizationService.
+					removeOrganizationUserAccountByEmailAddress(
+						emailAddress, organizationId);
+			}
+		}
+	}
+
+	@Autowired
+	private AdminPermission _adminPermission;
+
+	@Autowired
+	private OktaService _oktaService;
+
+	@Autowired
+	private OrganizationService _organizationService;
+
+	@Autowired
+	private PropertyService _propertyService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
@@ -72,8 +72,12 @@ public class OrganizationsRestController extends OneBaseRestController {
 				_userAccountService.getOrganizationUserAccounts(
 					organizationId)) {
 
-			organizationEmailAddresses.add(
-				StringUtil.toLowerCase(userAccount.getEmailAddress()));
+			String emailAddress = userAccount.getEmailAddress();
+
+			if (Validator.isNotNull(emailAddress)) {
+				organizationEmailAddresses.add(
+					StringUtil.toLowerCase(emailAddress));
+			}
 		}
 
 		for (String emailAddress : oktaEmailAddresses) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/UserAccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/UserAccountsRestController.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.service.UserAccountService;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Ricardo Mariz
+ */
+@RequestMapping("/user-accounts")
+@RestController
+public class UserAccountsRestController extends OneBaseRestController {
+
+	@PostMapping("/{userId}/sync-with-okta")
+	public void postSyncWithOkta(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("userId") long userId)
+		throws Exception {
+
+		_adminPermission.check(jwt);
+
+		UserAccount userAccount = _userAccountService.getUserAccount(userId);
+
+		_oktaService.syncContact(
+			userAccount.getEmailAddress(), userAccount.getGivenName(),
+			userAccount.getFamilyName(),
+			userAccount.getExternalReferenceCode());
+	}
+
+	@Autowired
+	private AdminPermission _adminPermission;
+
+	@Autowired
+	private OktaService _oktaService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/PropertyConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/PropertyConstants.java
@@ -15,4 +15,6 @@ public class PropertyConstants {
 
 	public static final String NAME_OKTA_APPLICATION = "okta:application";
 
+	public static final String NAME_OKTA_GROUP = "okta:group";
+
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -27,7 +27,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -239,6 +241,24 @@ public class AccountService extends OneBaseService {
 		}
 
 		return null;
+	}
+
+	public Map<Long, String> getAccountRoleNames(long accountId)
+		throws Exception {
+
+		Map<Long, String> accountRoleNames = new HashMap<>();
+
+		AccountRoleResource accountRoleResource = _buildAccountRoleResource();
+
+		Page<AccountRole> accountRolesPage =
+			accountRoleResource.getAccountAccountRolesPage(
+				accountId, null, null, Pagination.of(1, _PAGE_SIZE), null);
+
+		for (AccountRole accountRole : accountRolesPage.getItems()) {
+			accountRoleNames.put(accountRole.getId(), accountRole.getName());
+		}
+
+		return accountRoleNames;
 	}
 
 	public boolean hasDuplicateAccountName(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -90,6 +90,20 @@ public class AccountService extends OneBaseService {
 		addAccountUserAccount(account.getId(), jwt, userId);
 	}
 
+	public void addAccountUserAccountByEmailAddress(
+			long accountId, String emailAddress, Jwt jwt)
+		throws Exception {
+
+		post(
+			getAuthorization(jwt), StringPool.BLANK,
+			UriComponentsBuilder.fromPath(
+				"/o/headless-admin-user/v1.0/accounts/{accountId}" +
+					"/user-accounts/by-email-address/{emailAddress}"
+			).buildAndExpand(
+				accountId, emailAddress
+			).toUri());
+	}
+
 	public void addAccountUserAccountRole(
 			long accountId, long accountRoleId, long userId)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.resource.v1_0.OrganizationResource;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Ricardo Mariz
+ */
+@Component
+public class OrganizationService extends OneBaseService {
+
+	public void addOrganizationUserAccountByEmailAddress(
+			String emailAddress, long organizationId)
+		throws Exception {
+
+		OrganizationResource organizationResource =
+			_buildOrganizationResource();
+
+		organizationResource.postUserAccountByEmailAddress(
+			String.valueOf(organizationId), emailAddress);
+	}
+
+	public void removeOrganizationUserAccountByEmailAddress(
+			String emailAddress, long organizationId)
+		throws Exception {
+
+		OrganizationResource organizationResource =
+			_buildOrganizationResource();
+
+		organizationResource.deleteUserAccountByEmailAddress(
+			String.valueOf(organizationId), emailAddress);
+	}
+
+	private OrganizationResource _buildOrganizationResource() {
+		return OrganizationResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
@@ -72,8 +72,8 @@ public class PropertyService extends OneBaseService {
 		List<Property> properties = getAllItems(
 			"/o/c/properties",
 			StringBundler.concat(
-				"(className eq '", className, "') and (classPK eq '", classPK,
-				"') and (name eq '", name, "')"),
+				"(className eq '", className, "') and (classPK eq ", classPK,
+				") and (name eq '", name, "')"),
 			Property::new);
 
 		if (properties.isEmpty()) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
@@ -66,4 +66,23 @@ public class PropertyService extends OneBaseService {
 		return property.getValue();
 	}
 
+	public String getPropertyValue(String className, long classPK, String name)
+		throws Exception {
+
+		List<Property> properties = getAllItems(
+			"/o/c/properties",
+			StringBundler.concat(
+				"(className eq '", className, "') and (classPK eq '", classPK,
+				"') and (name eq '", name, "')"),
+			Property::new);
+
+		if (properties.isEmpty()) {
+			return null;
+		}
+
+		Property property = properties.get(0);
+
+		return property.getValue();
+	}
+
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -120,6 +120,33 @@ public class UserAccountService extends OneBaseService {
 		return userAccountResource.getMyUserAccount();
 	}
 
+	public List<UserAccount> getOrganizationUserAccounts(long organizationId)
+		throws Exception {
+
+		UserAccountResource userAccountResource = _buildUserAccountResource();
+
+		List<UserAccount> userAccounts = new ArrayList<>();
+
+		int page = 1;
+
+		while (true) {
+			Page<UserAccount> userAccountsPage =
+				userAccountResource.getOrganizationUserAccountsPage(
+					String.valueOf(organizationId), null, null,
+					Pagination.of(page, _PAGE_SIZE), null);
+
+			userAccounts.addAll(userAccountsPage.getItems());
+
+			if (page >= userAccountsPage.getLastPage()) {
+				break;
+			}
+
+			page++;
+		}
+
+		return userAccounts;
+	}
+
 	public UserAccount getUserAccount(long userId) throws Exception {
 		UserAccountResource userAccountResource = _buildUserAccountResource();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -21,6 +21,8 @@ import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringPool;
 
+import java.util.Map;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -173,6 +175,54 @@ public class AccountsRestControllerTest {
 	}
 
 	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesAssignsCustomerGroup()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			_createUserAccount()
+		);
+
+		Mockito.when(
+			_oktaService.fetchContactByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			Mockito.mock(OktaUser.class)
+		);
+
+		accountsRestController.postUserAccountsByEmailAddressAccountRoles(
+			null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS, "{}");
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccountByEmailAddress(
+			_ACCOUNT_ID, _EMAIL_ADDRESS, null
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignCustomerGroup(
+			_USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmail(
+			_USER_ID, account
+		);
+	}
+
+	@Test
 	public void testPostUserAccountsByEmailAddressAccountRolesCreatesOktaUser()
 		throws Exception {
 
@@ -187,9 +237,9 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.when(
-			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+			_accountService.getAccountRoleNames(_ACCOUNT_ID)
 		).thenReturn(
-			"Support Administrator"
+			Map.of(_ACCOUNT_ROLE_ID, "Support Administrator")
 		);
 
 		UserAccount userAccount = _createUserAccount();
@@ -255,9 +305,9 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.when(
-			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+			_accountService.getAccountRoleNames(_ACCOUNT_ID)
 		).thenReturn(
-			"Account Member"
+			Map.of(_ACCOUNT_ROLE_ID, "Account Member")
 		);
 
 		Mockito.when(
@@ -277,6 +327,33 @@ public class AccountsRestControllerTest {
 
 		Assertions.assertEquals(
 			HttpStatus.CONFLICT, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesRejectsMalformedBody()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() ->
+					accountsRestController.
+						postUserAccountsByEmailAddressAccountRoles(
+							null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+							"not json"));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
 
 		Mockito.verifyNoInteractions(_oktaService);
 	}
@@ -356,9 +433,9 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.when(
-			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+			_accountService.getAccountRoleNames(_ACCOUNT_ID)
 		).thenReturn(
-			"Support Administrator"
+			Map.of(_ACCOUNT_ROLE_ID, "Support Administrator")
 		);
 
 		Mockito.when(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -1,0 +1,577 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.okta.model.OktaUser;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.permission.AccountPermission;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.EmailAddressValidatorService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProvisioningAssignmentService;
+import com.liferay.one.service.ProvisioningEmailService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.petra.string.StringPool;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Ricardo Mariz
+ */
+public class AccountsRestControllerTest {
+
+	@Test
+	public void testDeleteUserAccountsAccountRoleResolvesRoleNameBeforeRemoving()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+		).thenReturn(
+			"Partner Manager"
+		);
+
+		accountsRestController.deleteUserAccountsAccountRole(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID, _ACCOUNT_ROLE_ID);
+
+		InOrder inOrder = Mockito.inOrder(_accountService);
+
+		inOrder.verify(
+			_accountService
+		).getAccountRoleName(
+			_ACCOUNT_ID, _ACCOUNT_ROLE_ID
+		);
+
+		inOrder.verify(
+			_accountService
+		).removeAccountUserAccountRole(
+			_ACCOUNT_ROLE_ID, _EXTERNAL_REFERENCE_CODE, null, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).unassignAccountRole(
+			account, _USER_ID, "Partner Manager"
+		);
+	}
+
+	@Test
+	public void testDeleteUserAccountsAccountRoleSkipsSideEffectsForUnknownRole()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		accountsRestController.deleteUserAccountsAccountRole(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID, _ACCOUNT_ROLE_ID);
+
+		Mockito.verify(
+			_accountService
+		).removeAccountUserAccountRole(
+			_ACCOUNT_ROLE_ID, _EXTERNAL_REFERENCE_CODE, null, _USER_ID
+		);
+
+		Mockito.verifyNoInteractions(_provisioningAssignmentService);
+	}
+
+	@Test
+	public void testDeleteUserAccountsUnassignsAccountMembership()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		accountsRestController.deleteUserAccounts(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
+
+		Mockito.verify(
+			_accountService
+		).removeAccountUserAccount(
+			_EXTERNAL_REFERENCE_CODE, null, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).unassignAccountMembership(
+			_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsAccountRoleAssignsAccountRole()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+		).thenReturn(
+			"Support Administrator"
+		);
+
+		accountsRestController.postUserAccountsAccountRole(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID, _ACCOUNT_ROLE_ID);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccountRole(
+			_ACCOUNT_ROLE_ID, _EXTERNAL_REFERENCE_CODE, null, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignAccountRole(
+			account, _USER_ID, "Support Administrator"
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesCreatesOktaUser()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+		).thenReturn(
+			"Support Administrator"
+		);
+
+		UserAccount userAccount = _createUserAccount();
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			null, userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				Mockito.eq(_ACCOUNT_ID), ArgumentMatchers.<String>any())
+		).thenReturn(
+			true
+		);
+
+		accountsRestController.postUserAccountsByEmailAddressAccountRoles(
+			null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+			_createBodyJSON(_ACCOUNT_ROLE_ID, "Jane", "Doe"));
+
+		Mockito.verify(
+			_oktaService
+		).createContact(
+			_EMAIL_ADDRESS, "Jane", StringPool.BLANK, "Doe"
+		);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccountByEmailAddress(
+			_ACCOUNT_ID, _EMAIL_ADDRESS, null
+		);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccountRole(
+			_ACCOUNT_ROLE_ID, _EXTERNAL_REFERENCE_CODE, null, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignAccountRole(
+			account, _USER_ID, "Support Administrator"
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmail(
+			_USER_ID, account
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesRejectsAssignedRole()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		Mockito.when(
+			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+		).thenReturn(
+			"Account Member"
+		);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			_createUserAccount(_ACCOUNT_ID, "Account Member")
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() ->
+					accountsRestController.
+						postUserAccountsByEmailAddressAccountRoles(
+							null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+							_createBodyJSON(_ACCOUNT_ROLE_ID, null, null)));
+
+		Assertions.assertEquals(
+			HttpStatus.CONFLICT, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesRejectsReservedDomain()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_emailAddressValidatorService.isLiferayDomain(_EMAIL_ADDRESS)
+		).thenReturn(
+			true
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() ->
+					accountsRestController.
+						postUserAccountsByEmailAddressAccountRoles(
+							null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+							"{}"));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_accountService);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesRequiresEntitlement()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() ->
+					accountsRestController.
+						postUserAccountsByEmailAddressAccountRoles(
+							null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+							"{}"));
+
+		Assertions.assertEquals(
+			HttpStatus.UNPROCESSABLE_ENTITY,
+			responseStatusException.getStatusCode());
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).createContact(
+			Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+			Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsByEmailAddressAccountRolesSkipsEmailForMember()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_accountService.getAccountRoleName(_ACCOUNT_ID, _ACCOUNT_ROLE_ID)
+		).thenReturn(
+			"Support Administrator"
+		);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			_createUserAccount(_ACCOUNT_ID, "Account Member")
+		);
+
+		Mockito.when(
+			_oktaService.fetchContactByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			Mockito.mock(OktaUser.class)
+		);
+
+		accountsRestController.postUserAccountsByEmailAddressAccountRoles(
+			null, _EXTERNAL_REFERENCE_CODE, _EMAIL_ADDRESS,
+			_createBodyJSON(_ACCOUNT_ROLE_ID, null, null));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).addAccountUserAccountByEmailAddress(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignAccountRole(
+			account, _USER_ID, "Support Administrator"
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	@Test
+	public void testPostUserAccountsSendsWelcomeEmailForNewMember()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		accountsRestController.postUserAccounts(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccount(
+			_ACCOUNT_ID, null, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignCustomerGroup(
+			_USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmail(
+			_USER_ID, account
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsSkipsWelcomeEmailForExistingMember()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		Mockito.when(
+			_userAccountService.hasAccountUserAccount(_ACCOUNT_ID, _USER_ID)
+		).thenReturn(
+			true
+		);
+
+		accountsRestController.postUserAccounts(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignCustomerGroup(
+			_USER_ID
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	private Account _createAccount() {
+		Account account = new Account();
+
+		account.setId(_ACCOUNT_ID);
+
+		return account;
+	}
+
+	private String _createBodyJSON(
+		long accountRoleId, String firstName, String lastName) {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"accountRoleIds",
+			new JSONArray(
+			).put(
+				accountRoleId
+			)
+		);
+
+		if (firstName != null) {
+			jsonObject.put("firstName", firstName);
+		}
+
+		if (lastName != null) {
+			jsonObject.put("lastName", lastName);
+		}
+
+		return jsonObject.toString();
+	}
+
+	private AccountsRestController _createController() {
+		AccountsRestController accountsRestController =
+			new AccountsRestController();
+
+		ReflectionTestUtils.setField(
+			accountsRestController, "_accountAssetService",
+			_accountAssetService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_accountPermission", _accountPermission);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_emailAddressValidatorService",
+			_emailAddressValidatorService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_entitlementService", _entitlementService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_provisioningAssignmentService",
+			_provisioningAssignmentService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_provisioningEmailService",
+			_provisioningEmailService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_userAccountService", _userAccountService);
+
+		return accountsRestController;
+	}
+
+	private UserAccount _createUserAccount() {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		userAccount.setId(_USER_ID);
+
+		return userAccount;
+	}
+
+	private UserAccount _createUserAccount(long accountId, String roleName) {
+		UserAccount userAccount = _createUserAccount();
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setId(accountId);
+
+		RoleBrief roleBrief = new RoleBrief();
+
+		roleBrief.setName(roleName);
+
+		accountBrief.setRoleBriefs(new RoleBrief[] {roleBrief});
+
+		userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
+
+		return userAccount;
+	}
+
+	private static final long _ACCOUNT_ID = 11111;
+
+	private static final long _ACCOUNT_ROLE_ID = 33333;
+
+	private static final String _EMAIL_ADDRESS = "jane@example.com";
+
+	private static final String _EXTERNAL_REFERENCE_CODE = "ACC-1";
+
+	private static final long _USER_ID = 22222;
+
+	private final AccountAssetService _accountAssetService = Mockito.mock(
+		AccountAssetService.class);
+	private final AccountPermission _accountPermission = Mockito.mock(
+		AccountPermission.class);
+	private final AccountService _accountService = Mockito.mock(
+		AccountService.class);
+	private final EmailAddressValidatorService _emailAddressValidatorService =
+		Mockito.mock(EmailAddressValidatorService.class);
+	private final EntitlementService _entitlementService = Mockito.mock(
+		EntitlementService.class);
+	private final OktaService _oktaService = Mockito.mock(OktaService.class);
+	private final ProvisioningAssignmentService _provisioningAssignmentService =
+		Mockito.mock(ProvisioningAssignmentService.class);
+	private final ProvisioningEmailService _provisioningEmailService =
+		Mockito.mock(ProvisioningEmailService.class);
+	private final UserAccountService _userAccountService = Mockito.mock(
+		UserAccountService.class);
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
@@ -1,0 +1,221 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.okta.model.OktaUser;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.service.OrganizationService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Ricardo Mariz
+ */
+public class OrganizationsRestControllerTest {
+
+	@Test
+	public void testPostSyncFromOktaChecksAdminPermission() throws Exception {
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		Mockito.doThrow(
+			new PrincipalException()
+		).when(
+			_adminPermission
+		).check(
+			null
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> organizationsRestController.postSyncFromOkta(
+				null, _ORGANIZATION_ID));
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testPostSyncFromOktaIgnoresEmailAddressCase() throws Exception {
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		_setUpOktaGroup("Ana@Example.com");
+		_setUpOrganizationUserAccounts("ana@example.com");
+
+		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
+
+		Mockito.verifyNoInteractions(_organizationService);
+	}
+
+	@Test
+	public void testPostSyncFromOktaReconcilesMembership() throws Exception {
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		_setUpOktaGroup("ana@example.com", "carla@example.com");
+		_setUpOrganizationUserAccounts("ana@example.com", "daniel@example.com");
+
+		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
+
+		Mockito.verify(
+			_organizationService
+		).addOrganizationUserAccountByEmailAddress(
+			"carla@example.com", _ORGANIZATION_ID
+		);
+
+		Mockito.verify(
+			_organizationService
+		).removeOrganizationUserAccountByEmailAddress(
+			"daniel@example.com", _ORGANIZATION_ID
+		);
+
+		Mockito.verifyNoMoreInteractions(_organizationService);
+	}
+
+	@Test
+	public void testPostSyncFromOktaRejectsOrganizationWithoutOktaGroup()
+		throws Exception {
+
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> organizationsRestController.postSyncFromOkta(
+					null, _ORGANIZATION_ID));
+
+		Assertions.assertEquals(
+			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testPostSyncFromOktaSkipsOktaUsersWithoutEmailAddress()
+		throws Exception {
+
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		_setUpOktaGroup("ana@example.com", null);
+		_setUpOrganizationUserAccounts("ana@example.com");
+
+		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
+
+		Mockito.verifyNoInteractions(_organizationService);
+	}
+
+	private OrganizationsRestController _createController() {
+		OrganizationsRestController organizationsRestController =
+			new OrganizationsRestController();
+
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_adminPermission", _adminPermission);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_organizationService",
+			_organizationService);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_propertyService", _propertyService);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_userAccountService",
+			_userAccountService);
+
+		return organizationsRestController;
+	}
+
+	private OktaUser _createOktaUser(String emailAddress) {
+		OktaUser oktaUser = Mockito.mock(OktaUser.class);
+
+		Mockito.when(
+			oktaUser.getEmail()
+		).thenReturn(
+			emailAddress
+		);
+
+		return oktaUser;
+	}
+
+	private UserAccount _createUserAccount(String emailAddress) {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(emailAddress);
+
+		return userAccount;
+	}
+
+	private void _setUpOktaGroup(String... emailAddresses) throws Exception {
+		Mockito.when(
+			_propertyService.getPropertyValue(
+				Organization.class.getName(), _ORGANIZATION_ID,
+				PropertyConstants.NAME_OKTA_GROUP)
+		).thenReturn(
+			_OKTA_GROUP_ID
+		);
+
+		List<OktaUser> oktaUsers = Arrays.stream(
+			emailAddresses
+		).map(
+			this::_createOktaUser
+		).toList();
+
+		Mockito.when(
+			_oktaService.getGroupContacts(_OKTA_GROUP_ID)
+		).thenReturn(
+			oktaUsers
+		);
+	}
+
+	private void _setUpOrganizationUserAccounts(String... emailAddresses)
+		throws Exception {
+
+		List<UserAccount> userAccounts = Arrays.stream(
+			emailAddresses
+		).map(
+			this::_createUserAccount
+		).toList();
+
+		Mockito.when(
+			_userAccountService.getOrganizationUserAccounts(_ORGANIZATION_ID)
+		).thenReturn(
+			userAccounts
+		);
+	}
+
+	private static final String _OKTA_GROUP_ID = "00g1abcd2efGHIJK3l4m";
+
+	private static final long _ORGANIZATION_ID = 44444;
+
+	private final AdminPermission _adminPermission = Mockito.mock(
+		AdminPermission.class);
+	private final OktaService _oktaService = Mockito.mock(OktaService.class);
+	private final OrganizationService _organizationService = Mockito.mock(
+		OrganizationService.class);
+	private final PropertyService _propertyService = Mockito.mock(
+		PropertyService.class);
+	private final UserAccountService _userAccountService = Mockito.mock(
+		UserAccountService.class);
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/UserAccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/UserAccountsRestControllerTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Ricardo Mariz
+ */
+public class UserAccountsRestControllerTest {
+
+	@Test
+	public void testPostSyncWithOktaChecksAdminPermission() throws Exception {
+		UserAccountsRestController userAccountsRestController =
+			_createController();
+
+		Mockito.doThrow(
+			new PrincipalException()
+		).when(
+			_adminPermission
+		).check(
+			null
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> userAccountsRestController.postSyncWithOkta(null, _USER_ID));
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testPostSyncWithOktaSyncsContact() throws Exception {
+		UserAccountsRestController userAccountsRestController =
+			_createController();
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress("jane@example.com");
+		userAccount.setExternalReferenceCode("uuid-1234");
+		userAccount.setFamilyName("Doe");
+		userAccount.setGivenName("Jane");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		userAccountsRestController.postSyncWithOkta(null, _USER_ID);
+
+		Mockito.verify(
+			_oktaService
+		).syncContact(
+			"jane@example.com", "Jane", "Doe", "uuid-1234"
+		);
+	}
+
+	private UserAccountsRestController _createController() {
+		UserAccountsRestController userAccountsRestController =
+			new UserAccountsRestController();
+
+		ReflectionTestUtils.setField(
+			userAccountsRestController, "_adminPermission", _adminPermission);
+		ReflectionTestUtils.setField(
+			userAccountsRestController, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			userAccountsRestController, "_userAccountService",
+			_userAccountService);
+
+		return userAccountsRestController;
+	}
+
+	private static final long _USER_ID = 42;
+
+	private final AdminPermission _adminPermission = Mockito.mock(
+		AdminPermission.class);
+	private final OktaService _oktaService = Mockito.mock(OktaService.class);
+	private final UserAccountService _userAccountService = Mockito.mock(
+		UserAccountService.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89441

## What is being fixed

The osb-provisioning-web portlet UI is being dropped, but part of its `MVCActionCommand` logic must survive as REST endpoints: pushing a user to Okta (`SyncWithOktaMVCActionCommand`), reconciling a team's membership from its Okta group (`SyncFromOktaMVCActionCommand`), and the on-assign behaviors of `AssignAccountContactRolesMVCActionCommand` — creating the Okta user on invite and sending the welcome email. On top of that, the services already ported by LPD-89433/LPD-89436/LPD-89439 (`OktaService`, `ProvisioningEmailService`, `ProvisioningAssignmentService`) lost their only caller when `UserAccountsRestController` was removed, so account membership and role changes stopped triggering any Okta or email side effects.

## How it is being fixed

Three pieces. First, `POST /user-accounts/{userId}/sync-with-okta` pushes a single user to Okta via `OktaService.syncContact`, gated by `AdminPermission`. Second, `POST /organizations/{organizationId}/sync-from-okta` ports the team reconciliation to the post-migration model agreed on the ticket: the Okta group ID is read from a Property row on the Organization and the organization membership is reconciled against the group members, adding missing users (the headless by-email add creates missing Liferay users synchronously) and removing stale ones. Third, the account member endpoints in `AccountsRestController` now fire the provisioning side effects after each headless write, and a new `POST /accounts/{erc}/user-accounts/by-email-address/{emailAddress}/account-roles` endpoint ports the invite flow: reserved-domain validation, a role-already-assigned guard (409), Okta user creation gated on the account holding an SLA or Partner entitlement (422 otherwise — the replacement for the retired Koroneiki subscription state), and the welcome email for new members only, preserving both legacy firing paths.

## Property contract for the okta:group migration

The sync endpoint expects one Property row per synced Organization, following the `{domain}:{entityName}` convention from LPD-89235:

```json
{
  "className": "com.liferay.portal.kernel.model.Organization",
  "classPK": <organizationId>,
  "name": "okta:group",
  "value": "<Okta group ID>"
}
```

The team external-link migration (the three `CustomerPortalReleaseImpl` teams — `accountAccessEUOktaId`, `accountAccessUSOktaId`, `provisioningOktaId` — becoming Organizations per LPD-89037) needs to write this shape. Until that data exists the endpoint returns 404 by design.

## Notes for reviewers

Side effects run after the committed headless write without rollback, matching the pattern of the removed `UserAccountsRestController`. They are wired at the controller layer, so other `AccountService` callers (for example the opportunity subscriber from LPD-89686 and `ProjectMembershipService`) do not fire them — if we want the side effects at the service layer instead, that is a follow-up discussion. The frontend still calls headless directly, so repointing the My Account member flows at these endpoints is a separate follow-up. `POST /teams/{id}/sync-from-okta` from the original AC is intentionally not a `/teams` path — teams become Organizations per the ticket discussion.
