### PR TITLE
LPD-91399 Align GCP deps via google-cloud-pubsub bump

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation group: "com.google.auth", name: "google-auth-library-oauth2-http", version: "1.31.0"
 	implementation group: "com.google.cloud", name: "google-cloud-core", version: "2.50.0"
 	implementation group: "com.google.cloud", name: "google-cloud-core-http", version: "2.50.0"
-	implementation group: "com.google.cloud", name: "google-cloud-pubsub", version: "1.131.0"
+	implementation group: "com.google.cloud", name: "google-cloud-pubsub", version: "1.137.0"
 	implementation group: "com.google.cloud", name: "google-cloud-storage", version: "2.27.0"
 	implementation group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot3", version: "latest.release"
 	implementation group: "com.liferay", name: "com.liferay.headless.admin.user.client", version: "4.0.50"
@@ -78,15 +78,6 @@ dependencies {
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.18"
 	implementation group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.18"
 	testImplementation group: "org.springframework.boot", name: "spring-boot-starter-test", version: "2.7.18"
-}
-
-configurations.all {
-	resolutionStrategy {
-		force "com.google.api:gax:2.50.0"
-		force "com.google.api:gax-httpjson:2.50.0"
-		force "io.grpc:grpc-api:1.62.2"
-		force "io.grpc:grpc-context:1.62.2"
-	}
 }
 
 repositories {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91399

## What is being fixed

The GCP Pub/Sub connection was broken by a transitive dependency skew:
with google-cloud-pubsub at 1.131.0, grpc-api and grpc-context resolved
to 1.69 while grpc-core stayed at 1.62, so every subscriber failed at
client construction with a NoClassDefFoundError. The current fix pins
grpc and gax back down to the older 1.62/2.50 set with a
resolutionStrategy.force block. That restores connectivity, but the pins
are hand-maintained — they have to be re-checked on every dependency
change and they hold grpc and gax at superseded versions with no BOM
keeping the family coherent.

## How it is being fixed

This replaces the force block with a single version bump:
google-cloud-pubsub 1.131.0 to 1.137.0. The newer release resolves a
self-consistent transitive graph — grpc 1.69.0 including grpc-core, and
gax 2.61.0 — so the whole family aligns on its own and the manual pins
are no longer needed. The change was validated end to end against the
is-ops-dev project on the new versions: all four subscribers bind and
establish a StreamingPull, and an okta-users event round-trips
(delivered on the gax thread, parsed, and acked) with no
NoClassDefFoundError.
