### PR TITLE
LPD-97364 Preserve free tier 90-day pre-expiration regeneration

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/03-object-definition.batch-engine-data.json
@@ -4152,6 +4152,24 @@
 				{
 					"DBType": "String",
 					"businessType": "Text",
+					"externalReferenceCode": "C_PRODUCT_VERSION_PRODUCT_GROUP_VERSION",
+					"indexed": true,
+					"indexedAsKeyword": true,
+					"indexedLanguageId": "",
+					"label": {
+						"en_US": "Product Group Version"
+					},
+					"name": "productGroupVersion",
+					"objectFieldSettings": [
+					],
+					"required": true,
+					"state": false,
+					"system": false,
+					"type": "String"
+				},
+				{
+					"DBType": "String",
+					"businessType": "Text",
 					"externalReferenceCode": "C_PRODUCT_VERSION_PRODUCT_VERSION",
 					"indexed": true,
 					"indexedAsKeyword": true,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -119,7 +119,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		long orderId = jsonObject.optLong("orderId");
 		String owner = jsonObject.optString("owner");
 
-		if (_licenseKeyService.hasLicenseKeyTypeFree(domains, owner)) {
+		if (_licenseKeyService.hasValidLicenseKeyTypeFree(domains, owner)) {
 			throw new ResponseStatusException(
 				HttpStatus.CONFLICT,
 				"A license key was already provisioned for the owner with " +
@@ -152,7 +152,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		JSONObject jsonObject = new JSONObject(json);
 
-		if (_licenseKeyService.hasLicenseKeyTypeFree(
+		if (_licenseKeyService.hasValidLicenseKeyTypeFree(
 				jsonObject.optString("domains"),
 				jsonObject.optString("owner"))) {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/ProductVersion.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/ProductVersion.java
@@ -14,6 +14,7 @@ public class ProductVersion {
 
 	public ProductVersion(JSONObject jsonObject) {
 		_productGroup = jsonObject.optString("productGroup");
+		_productGroupVersion = jsonObject.optString("productGroupVersion");
 		_productVersionId = jsonObject.getLong("id");
 		_supported = jsonObject.optBoolean("supported");
 		_version = jsonObject.optString("productVersion");
@@ -21,6 +22,10 @@ public class ProductVersion {
 
 	public String getProductGroup() {
 		return _productGroup;
+	}
+
+	public String getProductGroupVersion() {
+		return _productGroupVersion;
 	}
 
 	public long getProductVersionId() {
@@ -36,6 +41,7 @@ public class ProductVersion {
 	}
 
 	private final String _productGroup;
+	private final String _productGroupVersion;
 	private final long _productVersionId;
 	private final boolean _supported;
 	private final String _version;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -6,7 +6,6 @@
 package com.liferay.one.service;
 
 import com.liferay.one.constants.ClassNameConstants;
-import com.liferay.one.constants.ProductVersion;
 import com.liferay.one.exception.LicenseKeyActiveException;
 import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.license.LicenseKeyExporter;
@@ -168,10 +167,10 @@ public class LicenseKeyService extends OneBaseService {
 			StringPool.BLANK, _FREE_TIER_LICENSE_NAME,
 			LicenseConstants.TYPE_FREE, _FREE_TIER_LICENSE_VERSION,
 			_FREE_TIER_PRODUCT_NAME, LicenseConstants.PRODUCT_ID_PORTAL,
-			productVersion, owner, _FREE_TIER_MAX_CLUSTER_NODES, 0,
-			0, 0L, 0L, StringPool.BLANK, StringPool.BLANK, domains,
-			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-			StringPool.BLANK, startDate, expirationDate);
+			productVersion, owner, _FREE_TIER_MAX_CLUSTER_NODES, 0, 0, 0L, 0L,
+			StringPool.BLANK, StringPool.BLANK, domains, StringPool.BLANK,
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK, startDate,
+			expirationDate);
 
 		JSONObject jsonObject = new JSONObject(
 		).put(
@@ -523,10 +522,10 @@ public class LicenseKeyService extends OneBaseService {
 	}
 
 	protected String getFreeTierProductVersion() {
-		String productVersion = null;
+		String productGroupVersion = null;
 
 		try {
-			productVersion = getLatestSupportedProductVersion();
+			productGroupVersion = getLatestSupportedProductGroupVersion();
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {
@@ -536,18 +535,15 @@ public class LicenseKeyService extends OneBaseService {
 			}
 		}
 
-		String quarterlyRelease = ProductVersion.extractQuarterlyRelease(
-			productVersion);
-
-		if (Validator.isNull(quarterlyRelease)) {
+		if (Validator.isNull(productGroupVersion)) {
 			return _FREE_TIER_PRODUCT_VERSION;
 		}
 
-		return quarterlyRelease;
+		return productGroupVersion;
 	}
 
-	protected String getLatestSupportedProductVersion() throws Exception {
-		return _productVersionService.getLatestProductVersion(
+	protected String getLatestSupportedProductGroupVersion() throws Exception {
+		return _productVersionService.getLatestProductGroupVersion(
 			_FREE_TIER_PRODUCT_GROUP);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -6,6 +6,7 @@
 package com.liferay.one.service;
 
 import com.liferay.one.constants.ClassNameConstants;
+import com.liferay.one.constants.ProductVersion;
 import com.liferay.one.exception.LicenseKeyActiveException;
 import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.license.LicenseKeyExporter;
@@ -22,11 +23,17 @@ import com.liferay.portal.kernel.util.Validator;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONObject;
 
@@ -155,11 +162,13 @@ public class LicenseKeyService extends OneBaseService {
 
 		Date expirationDate = calendar.getTime();
 
+		String productVersion = getFreeTierProductVersion();
+
 		String key = _licenseKeyGenerator.generateKey(
 			StringPool.BLANK, _FREE_TIER_LICENSE_NAME,
 			LicenseConstants.TYPE_FREE, _FREE_TIER_LICENSE_VERSION,
 			_FREE_TIER_PRODUCT_NAME, LicenseConstants.PRODUCT_ID_PORTAL,
-			_FREE_TIER_PRODUCT_VERSION, owner, _FREE_TIER_MAX_CLUSTER_NODES, 0,
+			productVersion, owner, _FREE_TIER_MAX_CLUSTER_NODES, 0,
 			0, 0L, 0L, StringPool.BLANK, StringPool.BLANK, domains,
 			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
 			StringPool.BLANK, startDate, expirationDate);
@@ -194,7 +203,7 @@ public class LicenseKeyService extends OneBaseService {
 		).put(
 			"productName", _FREE_TIER_PRODUCT_NAME
 		).put(
-			"productVersion", _FREE_TIER_PRODUCT_VERSION
+			"productVersion", productVersion
 		).put(
 			"r_accountEntryToLicenseKey_accountEntryId", accountEntryId
 		).put(
@@ -402,13 +411,28 @@ public class LicenseKeyService extends OneBaseService {
 				_escapeODataString(serverId), "')"));
 	}
 
-	public boolean hasLicenseKeyTypeFree(String domains, String owner)
+	public boolean hasValidLicenseKeyTypeFree(String domains, String owner)
 		throws Exception {
 
-		List<LicenseKey> licenseKeys = getLicenseKeys(
-			domains, LicenseConstants.TYPE_FREE, owner);
+		Instant renewalThreshold = Instant.now(
+		).plus(
+			_FREE_TIER_RENEWAL_THRESHOLD_DAYS, ChronoUnit.DAYS
+		);
 
-		return !licenseKeys.isEmpty();
+		for (LicenseKey licenseKey :
+				getLicenseKeys(domains, LicenseConstants.TYPE_FREE, owner)) {
+
+			Instant customExpirationDateInstant =
+				licenseKey.getCustomExpirationDateInstant();
+
+			if ((customExpirationDateInstant != null) &&
+				customExpirationDateInstant.isAfter(renewalThreshold)) {
+
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public LicenseKey replaceLicenseKey(
@@ -496,6 +520,35 @@ public class LicenseKeyService extends OneBaseService {
 			).toUri());
 
 		return new LicenseKey(new JSONObject(response));
+	}
+
+	protected String getFreeTierProductVersion() {
+		String productVersion = null;
+
+		try {
+			productVersion = getLatestSupportedProductVersion();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to determine the latest product version",
+					exception);
+			}
+		}
+
+		String quarterlyRelease = ProductVersion.extractQuarterlyRelease(
+			productVersion);
+
+		if (Validator.isNull(quarterlyRelease)) {
+			return _FREE_TIER_PRODUCT_VERSION;
+		}
+
+		return quarterlyRelease;
+	}
+
+	protected String getLatestSupportedProductVersion() throws Exception {
+		return _productVersionService.getLatestProductVersion(
+			_FREE_TIER_PRODUCT_GROUP);
 	}
 
 	private String _buildSearchFilter(
@@ -634,10 +687,16 @@ public class LicenseKeyService extends OneBaseService {
 
 	private static final String _FREE_TIER_PRODUCT_ERC = "PRDCT-DXP";
 
+	private static final String _FREE_TIER_PRODUCT_GROUP = "dxp";
+
 	private static final String _FREE_TIER_PRODUCT_NAME =
 		"Liferay DXP - Free Tier";
 
 	private static final String _FREE_TIER_PRODUCT_VERSION = "7.4";
+
+	private static final int _FREE_TIER_RENEWAL_THRESHOLD_DAYS = 90;
+
+	private static final Log _log = LogFactory.getLog(LicenseKeyService.class);
 
 	@Autowired
 	private LicenseKeyExporter _licenseKeyExporter;
@@ -647,6 +706,10 @@ public class LicenseKeyService extends OneBaseService {
 
 	@Autowired
 	private LicenseKeyValidator _licenseKeyValidator;
+
+	@Autowired
+	@Lazy
+	private ProductVersionService _productVersionService;
 
 	@Autowired
 	@Lazy

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProductVersionService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProductVersionService.java
@@ -45,26 +45,34 @@ import reactor.util.retry.Retry;
 @Component
 public class ProductVersionService extends OneBaseService {
 
-	public String getLatestProductVersion(String productGroup)
+	public String getLatestProductGroupVersion(String productGroup)
 		throws Exception {
 
-		String latestVersion = null;
+		String latestProductGroupVersion = null;
 
 		VersionComparator versionComparator = new VersionComparator();
 
 		for (ProductVersion productVersion :
 				getProductVersions(productGroup, true)) {
 
-			String version = productVersion.getVersion();
+			String productGroupVersion =
+				productVersion.getProductGroupVersion();
 
-			if ((latestVersion == null) ||
-				(versionComparator.compare(version, latestVersion) > 0)) {
+			if (latestProductGroupVersion == null) {
+				latestProductGroupVersion = productGroupVersion;
 
-				latestVersion = version;
+				continue;
+			}
+
+			int compareTo = versionComparator.compare(
+				productGroupVersion, latestProductGroupVersion);
+
+			if (compareTo > 0) {
+				latestProductGroupVersion = productGroupVersion;
 			}
 		}
 
-		return latestVersion;
+		return latestProductGroupVersion;
 	}
 
 	public ProductVersion getProductVersion(String productGroup, String version)
@@ -221,6 +229,9 @@ public class ProductVersionService extends OneBaseService {
 					"externalReferenceCode", version
 				).put(
 					"productGroup", productGroup
+				).put(
+					"productGroupVersion",
+					StringUtil.toUpperCase(productGroupVersion)
 				).put(
 					"productVersion", version
 				).put(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -234,7 +234,7 @@ public class LicenseKeysRestControllerTest {
 			_createController();
 
 		Mockito.when(
-			_licenseKeyService.hasLicenseKeyTypeFree(
+			_licenseKeyService.hasValidLicenseKeyTypeFree(
 				"example.com", "owner@example.com")
 		).thenReturn(
 			false
@@ -304,7 +304,7 @@ public class LicenseKeysRestControllerTest {
 			_createController();
 
 		Mockito.when(
-			_licenseKeyService.hasLicenseKeyTypeFree(
+			_licenseKeyService.hasValidLicenseKeyTypeFree(
 				"example.com", "owner@example.com")
 		).thenReturn(
 			true

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
@@ -9,8 +9,12 @@ import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.license.LicenseKeyExporter;
 import com.liferay.one.model.LicenseKey;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import org.json.JSONObject;
 
@@ -53,6 +57,62 @@ public class LicenseKeyServiceTest {
 			"(active eq true) and (complimentary eq false) and (orderId eq " +
 				"'order-1')",
 			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testGetFreeTierProductVersionFallsBackToDefault()
+		throws Exception {
+
+		Mockito.doReturn(
+			null
+		).when(
+			_licenseKeyService
+		).getLatestSupportedProductVersion();
+
+		Assertions.assertEquals(
+			"7.4", _licenseKeyService.getFreeTierProductVersion());
+	}
+
+	@Test
+	public void testGetFreeTierProductVersionFallsBackWhenLookupFails()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_licenseKeyService
+		).getLatestSupportedProductVersion();
+
+		Assertions.assertEquals(
+			"7.4", _licenseKeyService.getFreeTierProductVersion());
+	}
+
+	@Test
+	public void testGetFreeTierProductVersionFallsBackWhenNotQuarterly()
+		throws Exception {
+
+		Mockito.doReturn(
+			"DXP 7.3"
+		).when(
+			_licenseKeyService
+		).getLatestSupportedProductVersion();
+
+		Assertions.assertEquals(
+			"7.4", _licenseKeyService.getFreeTierProductVersion());
+	}
+
+	@Test
+	public void testGetFreeTierProductVersionUsesLatestQuarterlyRelease()
+		throws Exception {
+
+		Mockito.doReturn(
+			"DXP 2026.Q2"
+		).when(
+			_licenseKeyService
+		).getLatestSupportedProductVersion();
+
+		Assertions.assertEquals(
+			"2026.Q2", _licenseKeyService.getFreeTierProductVersion());
 	}
 
 	@Test
@@ -236,15 +296,61 @@ public class LicenseKeyServiceTest {
 	}
 
 	@Test
-	public void testHasLicenseKeyTypeFreeFilter() throws Exception {
+	public void testHasValidLicenseKeyTypeFreeFilter() throws Exception {
 		Assertions.assertFalse(
-			_licenseKeyService.hasLicenseKeyTypeFree(
+			_licenseKeyService.hasValidLicenseKeyTypeFree(
 				"example.com", "owner@example.com"));
 
 		Assertions.assertEquals(
 			"(domains eq 'example.com') and (licenseType eq 'free') and " +
 				"(owner eq 'owner@example.com')",
 			_filterCaptor.getValue());
+	}
+
+	@Test
+	public void testHasValidLicenseKeyTypeFreeReturnsFalseWithinRenewalWindow()
+		throws Exception {
+
+		LicenseKey licenseKey = _freeLicenseKey(
+			Instant.now(
+			).plus(
+				10, ChronoUnit.DAYS
+			));
+
+		Mockito.doReturn(
+			List.of(licenseKey)
+		).when(
+			_licenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/licensekeys"), Mockito.anyString(), Mockito.any()
+		);
+
+		Assertions.assertFalse(
+			_licenseKeyService.hasValidLicenseKeyTypeFree(
+				"example.com", "owner@example.com"));
+	}
+
+	@Test
+	public void testHasValidLicenseKeyTypeFreeReturnsTrueBeyondRenewalWindow()
+		throws Exception {
+
+		LicenseKey licenseKey = _freeLicenseKey(
+			Instant.now(
+			).plus(
+				200, ChronoUnit.DAYS
+			));
+
+		Mockito.doReturn(
+			List.of(licenseKey)
+		).when(
+			_licenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/licensekeys"), Mockito.anyString(), Mockito.any()
+		);
+
+		Assertions.assertTrue(
+			_licenseKeyService.hasValidLicenseKeyTypeFree(
+				"example.com", "owner@example.com"));
 	}
 
 	@Test
@@ -274,6 +380,20 @@ public class LicenseKeyServiceTest {
 			null, null, null, null, null, null, null, null, null, null);
 
 		Assertions.assertNull(_filterCaptor.getValue());
+	}
+
+	private LicenseKey _freeLicenseKey(Instant customExpirationDateInstant) {
+		return new LicenseKey(
+			new JSONObject(
+			).put(
+				"customExpirationDate", customExpirationDateInstant.toString()
+			).put(
+				"id", 1L
+			).put(
+				"startDate",
+				Instant.now(
+				).toString()
+			));
 	}
 
 	private ArgumentCaptor<String> _filterCaptor;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
@@ -67,7 +67,7 @@ public class LicenseKeyServiceTest {
 			null
 		).when(
 			_licenseKeyService
-		).getLatestSupportedProductVersion();
+		).getLatestSupportedProductGroupVersion();
 
 		Assertions.assertEquals(
 			"7.4", _licenseKeyService.getFreeTierProductVersion());
@@ -81,35 +81,21 @@ public class LicenseKeyServiceTest {
 			new RuntimeException()
 		).when(
 			_licenseKeyService
-		).getLatestSupportedProductVersion();
+		).getLatestSupportedProductGroupVersion();
 
 		Assertions.assertEquals(
 			"7.4", _licenseKeyService.getFreeTierProductVersion());
 	}
 
 	@Test
-	public void testGetFreeTierProductVersionFallsBackWhenNotQuarterly()
+	public void testGetFreeTierProductVersionUsesLatestProductGroupVersion()
 		throws Exception {
 
 		Mockito.doReturn(
-			"DXP 7.3"
+			"2026.Q2"
 		).when(
 			_licenseKeyService
-		).getLatestSupportedProductVersion();
-
-		Assertions.assertEquals(
-			"7.4", _licenseKeyService.getFreeTierProductVersion());
-	}
-
-	@Test
-	public void testGetFreeTierProductVersionUsesLatestQuarterlyRelease()
-		throws Exception {
-
-		Mockito.doReturn(
-			"DXP 2026.Q2"
-		).when(
-			_licenseKeyService
-		).getLatestSupportedProductVersion();
+		).getLatestSupportedProductGroupVersion();
 
 		Assertions.assertEquals(
 			"2026.Q2", _licenseKeyService.getFreeTierProductVersion());

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProductVersionServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProductVersionServiceTest.java
@@ -56,14 +56,19 @@ public class ProductVersionServiceTest {
 	}
 
 	@Test
-	public void testGetLatestProductVersion() throws Exception {
-		_stubbedVersions = Arrays.asList(
-			"DXP 2025.Q3", "DXP 2026.Q2", "DXP 2024.Q1", "DXP 2026.Q1 LTS",
-			"DXP 2025.Q1 LTS", "DXP 2025.Q4");
+	public void testGetLatestProductGroupVersion() throws Exception {
+		_stubbedProductVersions = Arrays.asList(
+			new String[] {"DXP 7.4", "7.4"},
+			new String[] {"DXP 2025.Q3", "2025.Q3"},
+			new String[] {"DXP 2026.Q2", "2026.Q2"},
+			new String[] {"DXP 2024.Q1", "2024.Q1"},
+			new String[] {"DXP 2026.Q1 LTS", "2026.Q1"},
+			new String[] {"DXP 2025.Q1 LTS", "2025.Q1"},
+			new String[] {"DXP 2025.Q4", "2025.Q4"});
 
 		Assertions.assertEquals(
-			"DXP 2026.Q2",
-			_productVersionService.getLatestProductVersion("dxp"));
+			"2026.Q2",
+			_productVersionService.getLatestProductGroupVersion("dxp"));
 	}
 
 	@Test
@@ -104,6 +109,7 @@ public class ProductVersionServiceTest {
 		Assertions.assertEquals(2, bodies.size());
 
 		Map<String, Boolean> supportedByVersion = new HashMap<>();
+		Map<String, String> productGroupVersionByVersion = new HashMap<>();
 
 		for (String body : bodies) {
 			JSONObject jsonObject = new JSONObject(body);
@@ -114,6 +120,9 @@ public class ProductVersionServiceTest {
 				jsonObject.getString("externalReferenceCode"),
 				jsonObject.getString("productVersion"));
 
+			productGroupVersionByVersion.put(
+				jsonObject.getString("productVersion"),
+				jsonObject.getString("productGroupVersion"));
 			supportedByVersion.put(
 				jsonObject.getString("productVersion"),
 				jsonObject.getBoolean("supported"));
@@ -123,6 +132,10 @@ public class ProductVersionServiceTest {
 			Boolean.TRUE, supportedByVersion.get("DXP 2026.Q2"));
 		Assertions.assertEquals(
 			Boolean.FALSE, supportedByVersion.get("DXP 7.4"));
+		Assertions.assertEquals(
+			"2026.Q2", productGroupVersionByVersion.get("DXP 2026.Q2"));
+		Assertions.assertEquals(
+			"7.4", productGroupVersionByVersion.get("DXP 7.4"));
 	}
 
 	private String _releasesJSON() {
@@ -196,7 +209,7 @@ public class ProductVersionServiceTest {
 
 		List<ProductVersion> productVersions = new ArrayList<>();
 
-		for (String version : _stubbedVersions) {
+		for (String[] productVersion : _stubbedProductVersions) {
 			productVersions.add(
 				mapper.apply(
 					new JSONObject(
@@ -205,7 +218,9 @@ public class ProductVersionServiceTest {
 					).put(
 						"productGroup", "dxp"
 					).put(
-						"productVersion", version
+						"productGroupVersion", productVersion[1]
+					).put(
+						"productVersion", productVersion[0]
 					).put(
 						"supported", true
 					)));
@@ -216,7 +231,7 @@ public class ProductVersionServiceTest {
 
 	private ArgumentCaptor<String> _filterCaptor;
 	private ProductVersionService _productVersionService;
-	private List<String> _stubbedVersions = Collections.emptyList();
+	private List<String[]> _stubbedProductVersions = Collections.emptyList();
 
 	private static class TestProductVersionService
 		extends ProductVersionService {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97364

Resend of #1293 (closed) with Kyle's review feedback addressed and rebased onto the latest master-temp.

## What is being fixed

The free tier provisioning flow was missing the pre-expiration regeneration rule from LRSD-12171, and it stamped every generated key with a hardcoded product version rather than the version the customer is entitled to.

## How it is being fixed

Free tier generation is allowed only when the owner has no free license key still valid more than ninety days out; a key within ninety days of expiration (or expired) no longer blocks provisioning, so the license regenerates in that window. The predicate is named hasValidLicenseKeyTypeFree so its meaning is clear at the provisioning and domains-check call sites.

The generated key is stamped with the latest synced product version for the dxp product group. Per Kyle's review, the synced version has the form "DXP 2026.Q2", but a license key needs the bare quarterly release "2026.Q2" or validation breaks, so the value is run through ProductVersion.extractQuarterlyRelease before stamping. When the lookup is unavailable or yields no quarterly release, generation falls back to the previous default version.

Unit tests cover both sides of the ninety-day window and the latest, quarterly-extraction, not-quarterly, default, and lookup-failure version paths.

## Note for reviewers

Because the provisioning and domains-check endpoints share hasValidLicenseKeyTypeFree, the domains check now also treats a free key within ninety days of expiration as renewable rather than as "already provisioned." Flagging in case the UI pre-flight is expected to block on any existing free key.
