### PR TITLE
LPD-92999 Show the Help & Support tab only for applications

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/resolveProductTabConfig.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/resolveProductTabConfig.ts
@@ -53,10 +53,11 @@ export function resolveProductTabConfig({
 	const learnUrl = getSpecificationValue(product, 'project-learn-url');
 
 	const hasSupportInfo =
-		Boolean(learnUrl) ||
-		SUPPORT_SPECIFICATION_KEYS.some((specificationKey) =>
-			getSpecificationValue(product, specificationKey)
-		);
+		kind === 'application' &&
+		(Boolean(learnUrl) ||
+			SUPPORT_SPECIFICATION_KEYS.some((specificationKey) =>
+				getSpecificationValue(product, specificationKey)
+			));
 
 	const tabPresent: Record<ProjectTabKey, boolean> = {
 		'activation': activationProfile !== 'none',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92999

## What is being fixed

QA (Tiffany King) marked LPD-92999 as FAILED: the **Help & Support** tab is meant to appear only for marketplace applications, but it was also rendering on Liferay products such as PaaS (e.g. `/products/PRDCT-PAAS?tab=help-and-support`).

The tab gate in `resolveProductTabConfig` only checked whether the item carried any support specification or a learn URL. Since Liferay products also carry those specifications — and the recent `LPD-88277` change added project tab specs to SaaS, PaaS, and CMP products — the tab leaked onto product pages it was never built for.

## How it is being fixed

The `kind` (`'application'` vs `'product'`) already flows into `resolveProductTabConfig` from the route (`ProjectItemDetails kind="product"` vs `kind="application"`). The fix requires `kind === 'application'` in the `hasSupportInfo` gate, so products never render the Help & Support tab while applications keep the existing empty-specifications behavior (the tab still hides for an application that has no support details). A deep link to `?tab=help-and-support` on a product falls back to the first tab gracefully.

## PR Check

**pr-check: PASS** — tested on `b23a04e69ffe4266559e4ecddd2762340fe90b29`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "b23a04e69ffe4266559e4ecddd2762340fe90b29"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
