### PR TITLE
LPD-89434 Port the license key permission checks to Spring Boot

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -6,20 +6,17 @@
 package com.liferay.one;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
-import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
-import com.liferay.one.service.AccountService;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.SubscriptionEntryService;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
-
-import java.util.Objects;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.json.JSONObject;
 
@@ -143,7 +140,8 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
 				jwt, licenseKeyId);
 
-			_checkAccountViewPermission(licenseKey.getAccountEntryId(), jwt);
+			_licenseKeyPermission.check(
+				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
 		}
 
 		UserAccount userAccount = getMyUserAccount(jwt);
@@ -155,33 +153,11 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		}
 	}
 
-	private void _checkAccountViewPermission(long accountEntryId, Jwt jwt)
-		throws Exception {
-
-		try {
-			_accountService.getAccount(accountEntryId, jwt);
-		}
-		catch (Problem.ProblemException problemException) {
-			Problem problem = problemException.getProblem();
-
-			if ((problem != null) &&
-				(Objects.equals(
-					HttpStatus.FORBIDDEN.name(), problem.getStatus()) ||
-				 Objects.equals(
-					 HttpStatus.NOT_FOUND.name(), problem.getStatus()))) {
-
-				throw new PrincipalException();
-			}
-
-			throw problemException;
-		}
-	}
-
-	@Autowired
-	private AccountService _accountService;
-
 	@Autowired
 	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private LicenseKeyPermission _licenseKeyPermission;
 
 	@Autowired
 	private LicenseKeyService _licenseKeyService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
@@ -37,6 +37,8 @@ public class RoleConstants {
 	public static final String NAME_CLOUD_NATIVE_CONTACT =
 		"Cloud Native Contact";
 
+	public static final String NAME_LIFERAY_SALES = "Liferay Sales";
+
 	public static final String NAME_LIFERAY_STAFF = "Liferay Staff";
 
 	public static final String NAME_PARTNER_MANAGER = "Partner Manager";
@@ -62,6 +64,10 @@ public class RoleConstants {
 	public static final String[] NAMES_CUSTOMER_ACCOUNT_ROLES = {
 		NAME_ACCOUNT_ADMINISTRATOR, NAME_ACCOUNT_MEMBER, NAME_ACCOUNT_REQUESTER,
 		NAME_SUPPORT_ADMINISTRATOR
+	};
+
+	public static final String[] NAMES_MANAGE_LICENSE_KEYS = {
+		NAME_LIFERAY_SALES, NAME_PARTNER_MANAGER, NAME_SUPPORT_ADMINISTRATOR
 	};
 
 	public static final String[] NAMES_PARTNER_ACCOUNT_ROLES = {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/LicenseKeyPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/LicenseKeyPermission.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.UserAccountUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Wellington Barbosa
+ */
+@Component
+public class LicenseKeyPermission {
+
+	public void check(long accountEntryId, String actionId, Jwt jwt)
+		throws Exception {
+
+		if (!_contains(accountEntryId, actionId, jwt)) {
+			throw new PrincipalException();
+		}
+	}
+
+	private boolean _contains(long accountEntryId, String actionId, Jwt jwt)
+		throws Exception {
+
+		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
+
+		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
+			String roleBriefName = roleBrief.getName();
+
+			if (roleBriefName.equals(RoleConstants.NAME_ADMINISTRATOR) ||
+				roleBriefName.equals(
+					RoleConstants.NAME_PROVISIONING_ADMINISTRATOR) ||
+				roleBriefName.equals(RoleConstants.NAME_PROVISIONING_MEMBER)) {
+
+				return true;
+			}
+
+			if (roleBriefName.equals(RoleConstants.NAME_LIFERAY_STAFF) &&
+				actionId.equals(ActionKeys.VIEW)) {
+
+				return true;
+			}
+		}
+
+		if (actionId.equals(ActionKeys.UPDATE)) {
+			return UserAccountUtil.hasAccountRole(
+				userAccount, accountEntryId,
+				RoleConstants.NAMES_MANAGE_LICENSE_KEYS);
+		}
+
+		if (!actionId.equals(ActionKeys.VIEW)) {
+			return false;
+		}
+
+		if (UserAccountUtil.hasAccountMembership(userAccount, accountEntryId)) {
+			return true;
+		}
+
+		Account account = _accountService.fetchAccount(accountEntryId);
+
+		if (account == null) {
+			return false;
+		}
+
+		for (OrganizationBrief organizationBrief :
+				userAccount.getOrganizationBriefs()) {
+
+			if (ArrayUtil.contains(
+					account.getOrganizationIds(), organizationBrief.getId())) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -6,19 +6,19 @@
 package com.liferay.one;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
-import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
-import com.liferay.one.service.AccountService;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.SubscriptionEntryService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -220,9 +220,9 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.verify(
-			_accountService, Mockito.times(2)
-		).getAccount(
-			_ACCOUNT_ID, null
+			_licenseKeyPermission, Mockito.times(2)
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
 		);
 
 		Mockito.verify(
@@ -259,14 +259,12 @@ public class LicenseKeysRestControllerTest {
 			licenseKey
 		);
 
-		Problem problem = new Problem();
-
-		problem.setStatus(HttpStatus.FORBIDDEN.name());
-
-		Mockito.when(
-			_accountService.getAccount(Mockito.anyLong(), Mockito.any())
-		).thenThrow(
-			new Problem.ProblemException(problem)
+		Mockito.doThrow(
+			new PrincipalException()
+		).when(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
 		);
 
 		Assertions.assertThrows(
@@ -304,11 +302,12 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		ReflectionTestUtils.setField(
-			licenseKeysRestController, "_accountService", _accountService);
-
-		ReflectionTestUtils.setField(
 			licenseKeysRestController, "_commerceOrderService",
 			_commerceOrderService);
+
+		ReflectionTestUtils.setField(
+			licenseKeysRestController, "_licenseKeyPermission",
+			_licenseKeyPermission);
 
 		ReflectionTestUtils.setField(
 			licenseKeysRestController, "_licenseKeyService",
@@ -329,10 +328,10 @@ public class LicenseKeysRestControllerTest {
 
 	private static final long _USER_ID = 123L;
 
-	private final AccountService _accountService = Mockito.mock(
-		AccountService.class);
 	private final CommerceOrderService _commerceOrderService = Mockito.mock(
 		CommerceOrderService.class);
+	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(
+		LicenseKeyPermission.class);
 	private final LicenseKeyService _licenseKeyService = Mockito.mock(
 		LicenseKeyService.class);
 	private final SubscriptionEntryService _subscriptionEntryService =

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/permission/LicenseKeyPermissionTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/permission/LicenseKeyPermissionTest.java
@@ -1,0 +1,315 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Wellington Barbosa
+ */
+public class LicenseKeyPermissionTest {
+
+	@Test
+	public void testCheckUpdateGrantsManageLicenseKeysAccountRoles()
+		throws Exception {
+
+		for (String roleName : RoleConstants.NAMES_MANAGE_LICENSE_KEYS) {
+			LicenseKeyPermission licenseKeyPermission = _createPermission(
+				_createUserAccount(
+					new String[0],
+					_createAccountBrief(_ACCOUNT_ID, new String[] {roleName})));
+
+			licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.UPDATE, null);
+		}
+	}
+
+	@Test
+	public void testCheckUpdateGrantsProvisioningAdministrator()
+		throws Exception {
+
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[] {RoleConstants.NAME_PROVISIONING_ADMINISTRATOR}));
+
+		licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.UPDATE, null);
+	}
+
+	@Test
+	public void testCheckUpdateThrowsForAccountMemberWithoutManageRole()
+		throws Exception {
+
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[0],
+				_createAccountBrief(
+					_ACCOUNT_ID,
+					new String[] {RoleConstants.NAME_ACCOUNT_MEMBER})));
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeyPermission.check(
+				_ACCOUNT_ID, ActionKeys.UPDATE, null));
+	}
+
+	@Test
+	public void testCheckUpdateThrowsForLiferayStaff() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[] {RoleConstants.NAME_LIFERAY_STAFF}));
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeyPermission.check(
+				_ACCOUNT_ID, ActionKeys.UPDATE, null));
+	}
+
+	@Test
+	public void testCheckUpdateThrowsForManageRoleOnAnotherAccount()
+		throws Exception {
+
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[0],
+				_createAccountBrief(
+					_ACCOUNT_ID + 1,
+					new String[] {RoleConstants.NAME_SUPPORT_ADMINISTRATOR})));
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeyPermission.check(
+				_ACCOUNT_ID, ActionKeys.UPDATE, null));
+	}
+
+	@Test
+	public void testCheckViewGrantsAccountMember() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[0],
+				_createAccountBrief(_ACCOUNT_ID, new String[0])));
+
+		licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.VIEW, null);
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).fetchAccount(
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testCheckViewGrantsAdministrator() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[] {RoleConstants.NAME_ADMINISTRATOR}));
+
+		licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.VIEW, null);
+	}
+
+	@Test
+	public void testCheckViewGrantsLiferayStaff() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(
+				new String[] {RoleConstants.NAME_LIFERAY_STAFF}));
+
+		licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.VIEW, null);
+	}
+
+	@Test
+	public void testCheckViewGrantsOrganizationMember() throws Exception {
+		UserAccount userAccount = _createUserAccount(new String[0]);
+
+		OrganizationBrief organizationBrief = Mockito.mock(
+			OrganizationBrief.class);
+
+		Mockito.when(
+			organizationBrief.getId()
+		).thenReturn(
+			_ORGANIZATION_ID
+		);
+
+		Mockito.when(
+			userAccount.getOrganizationBriefs()
+		).thenReturn(
+			new OrganizationBrief[] {organizationBrief}
+		);
+
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			userAccount);
+
+		Account account = Mockito.mock(Account.class);
+
+		Mockito.when(
+			account.getOrganizationIds()
+		).thenReturn(
+			new Long[] {_ORGANIZATION_ID}
+		);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ID)
+		).thenReturn(
+			account
+		);
+
+		licenseKeyPermission.check(_ACCOUNT_ID, ActionKeys.VIEW, null);
+	}
+
+	@Test
+	public void testCheckViewThrowsForNonmember() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(new String[0]));
+
+		Account account = Mockito.mock(Account.class);
+
+		Mockito.when(
+			account.getOrganizationIds()
+		).thenReturn(
+			new Long[0]
+		);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ID)
+		).thenReturn(
+			account
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeyPermission.check(
+				_ACCOUNT_ID, ActionKeys.VIEW, null));
+	}
+
+	@Test
+	public void testCheckViewThrowsWhenAccountMissing() throws Exception {
+		LicenseKeyPermission licenseKeyPermission = _createPermission(
+			_createUserAccount(new String[0]));
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeyPermission.check(
+				_ACCOUNT_ID, ActionKeys.VIEW, null));
+	}
+
+	private AccountBrief _createAccountBrief(
+		long accountId, String[] roleNames) {
+
+		AccountBrief accountBrief = Mockito.mock(AccountBrief.class);
+
+		Mockito.when(
+			accountBrief.getId()
+		).thenReturn(
+			accountId
+		);
+
+		RoleBrief[] roleBriefs = new RoleBrief[roleNames.length];
+
+		for (int i = 0; i < roleNames.length; i++) {
+			RoleBrief roleBrief = Mockito.mock(RoleBrief.class);
+
+			Mockito.when(
+				roleBrief.getName()
+			).thenReturn(
+				roleNames[i]
+			);
+
+			roleBriefs[i] = roleBrief;
+		}
+
+		Mockito.when(
+			accountBrief.getRoleBriefs()
+		).thenReturn(
+			roleBriefs
+		);
+
+		return accountBrief;
+	}
+
+	private LicenseKeyPermission _createPermission(UserAccount userAccount)
+		throws Exception {
+
+		LicenseKeyPermission licenseKeyPermission = new LicenseKeyPermission();
+
+		UserAccountService userAccountService = Mockito.mock(
+			UserAccountService.class);
+
+		Mockito.when(
+			userAccountService.getMyUserAccount(Mockito.any())
+		).thenReturn(
+			userAccount
+		);
+
+		ReflectionTestUtils.setField(
+			licenseKeyPermission, "_accountService", _accountService);
+
+		ReflectionTestUtils.setField(
+			licenseKeyPermission, "_userAccountService", userAccountService);
+
+		return licenseKeyPermission;
+	}
+
+	private UserAccount _createUserAccount(
+		String[] roleNames, AccountBrief... accountBriefs) {
+
+		UserAccount userAccount = Mockito.mock(UserAccount.class);
+
+		Mockito.when(
+			userAccount.getAccountBriefs()
+		).thenReturn(
+			accountBriefs
+		);
+
+		Mockito.when(
+			userAccount.getOrganizationBriefs()
+		).thenReturn(
+			new OrganizationBrief[0]
+		);
+
+		RoleBrief[] roleBriefs = new RoleBrief[roleNames.length];
+
+		for (int i = 0; i < roleNames.length; i++) {
+			RoleBrief roleBrief = Mockito.mock(RoleBrief.class);
+
+			Mockito.when(
+				roleBrief.getName()
+			).thenReturn(
+				roleNames[i]
+			);
+
+			roleBriefs[i] = roleBrief;
+		}
+
+		Mockito.when(
+			userAccount.getRoleBriefs()
+		).thenReturn(
+			roleBriefs
+		);
+
+		return userAccount;
+	}
+
+	private static final long _ACCOUNT_ID = 555L;
+
+	private static final long _ORGANIZATION_ID = 77L;
+
+	private final AccountService _accountService = Mockito.mock(
+		AccountService.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89434

## What is being fixed

The legacy OSB provisioning CustomerPortalReleaseImpl gates license key visibility and management by traversing Koroneiki external links to Okta groups, team membership, and contact roles. After the Koroneiki to OOTB migration that model no longer exists, so the new Spring Boot client extension had no equivalent of hasAccountAccessPermission and hasAccountManageLicenseKeysPermission, and the only license key endpoint delegated its account check to the headless API under the caller's token, which denied organization linked users and Liferay staff who are not direct account members.

## How it is being fixed

A new LicenseKeyPermission component ports the legacy precedence onto the new account role model. The view check grants access to direct account members, to users belonging to an organization linked to the account, and to the Administrator, Liferay Staff, Provisioning Administrator, and Provisioning Member regular roles. The manage check grants access to the Liferay Sales, Partner Manager, and Support Administrator account roles and to the provisioning regular roles; the legacy Liferay Customer Success fallback is intentionally dropped because that role was not migrated per the LPD-89038 role configuration decision. The license key subscription endpoint now uses the ported view check, restoring the legacy access precedence, and unit tests cover the full permission matrix.
