### PR TITLE
LPD-95398 Update permission check for ticket attachments in the backend

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketAttachmentsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketAttachmentsRestController.java
@@ -8,6 +8,9 @@ package com.liferay.one;
 import com.google.cloud.storage.StorageException;
 
 import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
 import com.liferay.one.exception.FileServerUnavailableException;
 import com.liferay.one.exception.TicketAttachmentAlreadyApprovedException;
 import com.liferay.one.exception.TicketAttachmentNotFoundException;
@@ -18,17 +21,23 @@ import com.liferay.one.jira.model.JiraSupportIssue;
 import com.liferay.one.jira.service.JiraIssueService;
 import com.liferay.one.model.Project;
 import com.liferay.one.model.TicketAttachment;
+import com.liferay.one.permission.ProjectMembershipPermission;
 import com.liferay.one.service.GoogleCloudStorageService;
 import com.liferay.one.service.NotificationQueueEntryService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.TicketAttachmentService;
+import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.StackTraceUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.security.Principal;
 
 import java.util.List;
 import java.util.regex.Matcher;
@@ -76,6 +85,9 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 		TicketAttachment ticketAttachment =
 			_ticketAttachmentService.getTicketAttachment(
 				"Bearer " + jwt.getTokenValue(), ticketAttachmentId);
+
+		_checkPermission(
+			ActionKeys.UPDATE, jwt, ticketAttachment.getProjectKey());
 
 		_ticketAttachmentService.updateTicketAttachmentState(
 			"Bearer " + jwt.getTokenValue(), WorkflowConstants.STATUS_IN_TRASH,
@@ -149,6 +161,15 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 			"JIRA_ORGANIZATION_ERROR", HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
+	@ExceptionHandler(PrincipalException.class)
+	public ResponseEntity<String> handleException(
+		Principal principal, PrincipalException principalException) {
+
+		_log.error(principalException);
+
+		return new ResponseEntity<>("FORBIDDEN_ACCESS", HttpStatus.FORBIDDEN);
+	}
+
 	@ExceptionHandler(StorageException.class)
 	public ResponseEntity<String> handleException(
 		StorageException storageException) {
@@ -215,8 +236,14 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 		throws Exception {
 
 		TicketAttachment ticketAttachment =
-			_ticketAttachmentService.approveTicketAttachment(
+			_ticketAttachmentService.getTicketAttachment(
 				"Bearer " + jwt.getTokenValue(), ticketAttachmentId);
+
+		_checkPermission(
+			ActionKeys.UPDATE, jwt, ticketAttachment.getProjectKey());
+
+		ticketAttachment = _ticketAttachmentService.approveTicketAttachment(
+			"Bearer " + jwt.getTokenValue(), ticketAttachmentId);
 
 		JSONObject jsonObject = new JSONObject(json);
 
@@ -273,6 +300,8 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 			jiraSupportIssue.getJiraOrganization();
 
 		String projectERC = jiraOrganization.getExternalKey();
+
+		_checkPermission(ActionKeys.UPDATE, jwt, projectERC);
 
 		Project project = _projectService.getProject(projectERC);
 
@@ -505,6 +534,24 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 		).toString();
 	}
 
+	private void _checkPermission(
+			String actionId, Jwt jwt, String projectExternalReferenceCode)
+		throws Exception {
+
+		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
+
+		for (RoleBrief roleBrief : userAccount.getRoleBriefs()) {
+			String roleBriefName = roleBrief.getName();
+
+			if (roleBriefName.equals(RoleConstants.NAME_PROVISIONING_MEMBER)) {
+				return;
+			}
+		}
+
+		_projectMembershipPermission.check(
+			actionId, jwt, projectExternalReferenceCode);
+	}
+
 	private void _deleteTicketAttachments(String jiraIssueKey)
 		throws Exception {
 
@@ -627,6 +674,9 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 
 		TicketAttachment ticketAttachment = unsafeFunction.apply(authorization);
 
+		_checkPermission(
+			ActionKeys.VIEW, jwt, ticketAttachment.getProjectKey());
+
 		return new ResponseEntity<>(
 			_googleCloudStorageService.getDownloadURL(
 				ticketAttachment.getGCSBucketName(),
@@ -664,9 +714,15 @@ public class TicketAttachmentsRestController extends OneBaseRestController {
 	private String _onePortalURL;
 
 	@Autowired
+	private ProjectMembershipPermission _projectMembershipPermission;
+
+	@Autowired
 	private ProjectService _projectService;
 
 	@Autowired
 	private TicketAttachmentService _ticketAttachmentService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketsTicketAttachmentsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TicketsTicketAttachmentsRestController.java
@@ -18,6 +18,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
+import java.security.Principal;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -46,7 +48,7 @@ public class TicketsTicketAttachmentsRestController
 			@PathVariable("ticketId") String ticketId)
 		throws Exception {
 
-		return _getResponseEntity(true, jwt, ticketId);
+		return _getResponseEntity(ActionKeys.VIEW, true, jwt, ticketId);
 	}
 
 	@GetMapping("/upload-access-check")
@@ -55,7 +57,7 @@ public class TicketsTicketAttachmentsRestController
 			@PathVariable("ticketId") String ticketId)
 		throws Exception {
 
-		return _getResponseEntity(false, jwt, ticketId);
+		return _getResponseEntity(ActionKeys.UPDATE, false, jwt, ticketId);
 	}
 
 	@ExceptionHandler(Exception.class)
@@ -78,15 +80,15 @@ public class TicketsTicketAttachmentsRestController
 
 	@ExceptionHandler(PrincipalException.class)
 	public ResponseEntity<String> handleException(
-		PrincipalException principalException) {
+		Principal principal, PrincipalException principalException) {
 
 		_log.error(principalException);
 
 		return new ResponseEntity<>("FORBIDDEN_ACCESS", HttpStatus.FORBIDDEN);
 	}
 
-	private void _checkViewPermission(
-			Jwt jwt, String projectExternalReferenceCode)
+	private void _checkPermission(
+			String actionId, Jwt jwt, String projectExternalReferenceCode)
 		throws Exception {
 
 		UserAccount userAccount = _userAccountService.getMyUserAccount(jwt);
@@ -100,11 +102,12 @@ public class TicketsTicketAttachmentsRestController
 		}
 
 		_projectMembershipPermission.check(
-			ActionKeys.UPDATE, jwt, projectExternalReferenceCode);
+			actionId, jwt, projectExternalReferenceCode);
 	}
 
 	private ResponseEntity<String> _getResponseEntity(
-			boolean allowClosedTicket, Jwt jwt, String ticketId)
+			String actionId, boolean allowClosedTicket, Jwt jwt,
+			String ticketId)
 		throws Exception {
 
 		JiraSupportIssue jiraSupportIssue =
@@ -123,7 +126,7 @@ public class TicketsTicketAttachmentsRestController
 		JiraOrganization jiraOrganization =
 			jiraSupportIssue.getJiraOrganization();
 
-		_checkViewPermission(jwt, jiraOrganization.getExternalKey());
+		_checkPermission(actionId, jwt, jiraOrganization.getExternalKey());
 
 		return new ResponseEntity<>(StringPool.BLANK, HttpStatus.OK);
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95398

## What is being fixed

The support ticket-attachment REST endpoints in liferay-one-etc-spring-boot did not enforce project-level permissions on the backend. The file-serving controller (`/ticket-attachments/**`) performed no permission check at all, so a Project User (or any caller) could download, upload, delete, and complete uploads by calling the endpoints directly, bypassing the frontend's pre-flight access checks. In addition, both controllers declared an `@ExceptionHandler(PrincipalException.class)` whose signature did not match the one inherited from `OneBaseRestController`, making Spring's handler resolution ambiguous and throwing `IllegalStateException` (HTTP 500) instead of returning a 403 whenever permission was denied.

## How it is being fixed

Both controllers now gate every attachment operation through `ProjectMembershipPermission.check(...)`: downloads require `VIEW` (Project Admin, Project Requester, and Project User), while uploads, completes, and deletes require `UPDATE` (Project Admin and Project Requester only), matching the ticket attachments permission matrix. The project is resolved from each attachment's `projectKey` (or the Jira organization external key for new uploads), and the Provisioning Member bypass is preserved. The complete-upload path was reordered to fetch and authorize before approving so a denied request cannot mutate state. The ambiguous exception handlers were changed to match the base-class signature (`Principal, PrincipalException`) so they override it cleanly, resolving the `IllegalStateException` while still returning the `FORBIDDEN_ACCESS` body the frontend relies on.
