### PR TITLE
LPD-95398 Update code-style rule to sort method parameters

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/rules/code-style.md
+++ b/workspaces/liferay-one-workspace/.agents/rules/code-style.md
@@ -10,6 +10,7 @@ Lists, arrays, and JSON entries must always be in sorted order. This applies to:
 - `[#assign ... /]` variable blocks in FreeMarker templates (logical dependency order, then alphabetical)
 - Java `import` statements (already handled by source formatter)
 - Entries in configuration files
+- Method and constructor parameter lists — alphabetical by parameter name. When you reorder a signature, update every call site to match. Example: `_getResponseEntity(boolean allowClosedTicket, String actionId, ...)` → `_getResponseEntity(String actionId, boolean allowClosedTicket, ...)`.
 
 When Brian sees items out of order, he comments `"sort"` and bounces the PR back.
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95398

## What is being fixed

The workspace `code-style.md` "Sort Everything" rule enumerated the places that must be kept in sorted order (JSON arrays, FreeMarker assign blocks, imports, config entries) but did not mention method and constructor parameter lists. The codebase already follows alphabetical parameter ordering, so the rule was incomplete guidance for contributors and reviewers.

## How it is being fixed

Adds method and constructor parameter lists to the "Sort Everything" rule, specifying alphabetical order by parameter name and reminding contributors to update every call site when a signature is reordered, with a concrete before/after example.
