### PR TITLE
LPD-90495 Sync Accounts and Projects to JSM via AccountSyncService

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -9,6 +9,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.jira.service.AccountSyncService;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.service.AccountService;
@@ -107,6 +108,20 @@ public class AccountsRestController extends OneBaseRestController {
 		return new ResponseEntity<>(
 			_accountAssetService.getAccountObjectKey(externalReferenceCode),
 			HttpStatus.OK);
+	}
+
+	@PostMapping("/{externalReferenceCode}/sync-to-jsm")
+	public ResponseEntity<Void> postSyncToJSM(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_accountPermission.check(externalReferenceCode, ActionKeys.UPDATE, jwt);
+
+		_accountSyncService.syncAccount(
+			_accountService.getAccount(externalReferenceCode));
+
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 	@PostMapping("/{externalReferenceCode}/user-accounts/{userId}")
@@ -312,6 +327,9 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private AccountService _accountService;
+
+	@Autowired
+	private AccountSyncService _accountSyncService;
 
 	@Autowired
 	private EmailAddressValidatorService _emailAddressValidatorService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CacheConfiguration.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CacheConfiguration.java
@@ -21,8 +21,9 @@ public class CacheConfiguration {
 	@Bean
 	public CacheManager cacheManager() {
 		CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager(
-			"assetObjectFieldOptions", "assetObjectTypeIds",
-			"assetObjectTypeAttributeIds", "productVersions");
+			"assetObjectFieldOptions", "assetObjectTypeAttributeIds",
+			"assetObjectTypeAttributeOptions", "assetObjectTypeIds",
+			"productVersions");
 
 		caffeineCacheManager.setCaffeine(
 			Caffeine.newBuilder(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
@@ -11,6 +11,7 @@ import com.liferay.one.exception.LicenseKeyActiveException;
 import com.liferay.one.exception.LicenseKeyValidationException;
 import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.jira.exception.AccountNotFoundException;
+import com.liferay.one.jira.exception.JiraAssetObjectException;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 
@@ -55,6 +56,16 @@ public abstract class OneBaseRestController extends BaseRestController {
 
 		return _toResponseEntity(
 			HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");
+	}
+
+	@ExceptionHandler(JiraAssetObjectException.class)
+	public ResponseEntity<?> handleException(
+		JiraAssetObjectException jiraAssetObjectException) {
+
+		_log.error("The asset object was not found", jiraAssetObjectException);
+
+		return _toResponseEntity(
+			HttpStatus.NOT_FOUND, jiraAssetObjectException.getMessage());
 	}
 
 	@ExceptionHandler(LicenseKeyActiveException.class)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -6,8 +6,10 @@
 package com.liferay.one;
 
 import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.jira.service.AccountSyncService;
 import com.liferay.one.permission.BusinessEventPermission;
 import com.liferay.one.service.ProjectMembershipService;
+import com.liferay.one.service.ProjectService;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,13 +73,34 @@ public class ProjectRestController extends OneBaseRestController {
 			jwt, projectId, accountRoleExternalReferenceCode, userId);
 	}
 
+	@PostMapping("/{externalReferenceCode}/sync-to-jsm")
+	public ResponseEntity<Void> postSyncToJSM(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_businessEventPermission.check(
+			ActionKeys.UPDATE, jwt, externalReferenceCode);
+
+		_accountSyncService.syncProject(
+			_projectService.getProject(externalReferenceCode));
+
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+
 	@Autowired
 	private AccountAssetService _accountAssetService;
+
+	@Autowired
+	private AccountSyncService _accountSyncService;
 
 	@Autowired
 	private BusinessEventPermission _businessEventPermission;
 
 	@Autowired
 	private ProjectMembershipService _projectMembershipService;
+
+	@Autowired
+	private ProjectService _projectService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/SupportLanguageConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/SupportLanguageConstants.java
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public class SupportLanguageConstants {
+
+	public static final String CHINESE = "Chinese";
+
+	public static final String ENGLISH = "English";
+
+	public static final String JAPANESE = "Japanese";
+
+	public static final String PORTUGUESE = "Portuguese";
+
+	public static final String SPANISH = "Spanish";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/AccountConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/AccountConstants.java
@@ -10,7 +10,54 @@ package com.liferay.one.jira.constants;
  */
 public interface AccountConstants {
 
+	public static final String ATTRIBUTE_NAME_ASSIGNED_TEAMS = "Assigned Teams";
+
+	public static final String ATTRIBUTE_NAME_BUSINESS_EVENTS =
+		"Business Events";
+
+	public static final String ATTRIBUTE_NAME_CODE = "Code";
+
+	public static final String ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS =
+		"Contact Email Address";
+
+	public static final String ATTRIBUTE_NAME_CUSTOMER_CONTACTS =
+		"Customer Contacts";
+
+	public static final String ATTRIBUTE_NAME_DESCRIPTION = "Description";
+
+	public static final String ATTRIBUTE_NAME_ENTITLEMENTS = "Entitlements";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_CREATED_AT =
+		"External Created At";
+
 	public static final String ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_LINKS = "External Links";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT =
+		"External Updated At";
+
+	public static final String ATTRIBUTE_NAME_FAX_NUMBER = "Fax Number";
+
+	public static final String ATTRIBUTE_NAME_LANGUAGE = "Language";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String ATTRIBUTE_NAME_PHONE_NUMBER = "Phone Number";
+
+	public static final String ATTRIBUTE_NAME_POSTAL_ADDRESSES =
+		"Postal Addresses";
+
+	public static final String ATTRIBUTE_NAME_STATUS = "Status";
+
+	public static final String ATTRIBUTE_NAME_SUPPORT_REGION = "Support Region";
+
+	public static final String ATTRIBUTE_NAME_TIER = "Tier";
+
+	public static final String ATTRIBUTE_NAME_WEBSITE = "Website";
+
+	public static final String ATTRIBUTE_NAME_WORKER_CONTACTS =
+		"Worker Contacts";
 
 	public static final String OBJECT_TYPE_NAME = "Account";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/ContactConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/ContactConstants.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface ContactConstants {
+
+	public static final String ATTRIBUTE_NAME_ACCOUNT = "Account";
+
+	public static final String ATTRIBUTE_NAME_CONTACT_ROLES = "Contact Roles";
+
+	public static final String ATTRIBUTE_NAME_EMAIL_ADDRESS = "Email Address";
+
+	public static final String ATTRIBUTE_NAME_EMAIL_ADDRESS_VERIFIED =
+		"Email Address Verified";
+
+	public static final String ATTRIBUTE_NAME_ENTITLEMENTS = "Entitlements";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_CREATED_AT =
+		"External Created At";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_LINKS = "External Links";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT =
+		"External Updated At";
+
+	public static final String ATTRIBUTE_NAME_FIRST_NAME = "First Name";
+
+	public static final String ATTRIBUTE_NAME_LANGUAGE_ID = "Language ID";
+
+	public static final String ATTRIBUTE_NAME_LAST_NAME = "Last Name";
+
+	public static final String ATTRIBUTE_NAME_MIDDLE_NAME = "Middle Name";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String ATTRIBUTE_NAME_PHONES = "Phones";
+
+	public static final String ATTRIBUTE_NAME_TEAMS = "Teams";
+
+	public static final String ATTRIBUTE_NAME_UUID = "UUID";
+
+	public static final String OBJECT_TYPE_NAME = "Contact";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/EntitlementConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/EntitlementConstants.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface EntitlementConstants {
+
+	public static final String ATTRIBUTE_NAME_ENTITLEMENT_DEFINITION_KEY =
+		"Entitlement Definition Key";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String OBJECT_TYPE_NAME = "Entitlement";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/ExternalLinkConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/ExternalLinkConstants.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface ExternalLinkConstants {
+
+	public static final String ATTRIBUTE_NAME_DOMAIN = "Domain";
+
+	public static final String ATTRIBUTE_NAME_ENTITY_ID = "Entity Id";
+
+	public static final String ATTRIBUTE_NAME_ENTITY_NAME = "Entity Name";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String OBJECT_TYPE_NAME = "External Link";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/PostalAddressConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/PostalAddressConstants.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface PostalAddressConstants {
+
+	public static final String ATTRIBUTE_NAME_ADDRESS_COUNTRY =
+		"Address Country";
+
+	public static final String ATTRIBUTE_NAME_ADDRESS_LOCALITY =
+		"Address Locality";
+
+	public static final String ATTRIBUTE_NAME_ADDRESS_REGION = "Address Region";
+
+	public static final String ATTRIBUTE_NAME_ADDRESS_TYPE = "Address Type";
+
+	public static final String ATTRIBUTE_NAME_ID = "ID";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String ATTRIBUTE_NAME_POSTAL_CODE = "Postal Code";
+
+	public static final String ATTRIBUTE_NAME_PRIMARY = "Primary";
+
+	public static final String ATTRIBUTE_NAME_STREET_ADDRESS_LINE_1 =
+		"Street Address Line 1";
+
+	public static final String ATTRIBUTE_NAME_STREET_ADDRESS_LINE_2 =
+		"Street Address Line 2";
+
+	public static final String ATTRIBUTE_NAME_STREET_ADDRESS_LINE_3 =
+		"Street Address Line 3";
+
+	public static final String OBJECT_TYPE_NAME = "Postal Address";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/TeamConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/constants/TeamConstants.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.constants;
+
+/**
+ * @author Drew Brokke
+ */
+public interface TeamConstants {
+
+	public static final String ATTRIBUTE_NAME_ACCOUNT = "Account";
+
+	public static final String ATTRIBUTE_NAME_CONTACTS = "Contacts";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_CREATED_AT =
+		"External Created At";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_LINKS = "External Links";
+
+	public static final String ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT =
+		"External Updated At";
+
+	public static final String ATTRIBUTE_NAME_NAME = "Name";
+
+	public static final String ATTRIBUTE_NAME_TEAM_ROLES = "Team Roles";
+
+	public static final String OBJECT_TYPE_NAME = "Team";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
@@ -17,13 +17,13 @@ import org.springframework.stereotype.Component;
 public class AccountConverter extends BaseJiraAssetObjectConverter {
 
 	@Override
-	protected String getObjectSchemaName() {
-		return _schemaName;
+	public String getObjectTypeName() {
+		return AccountConstants.OBJECT_TYPE_NAME;
 	}
 
 	@Override
-	protected String getObjectTypeName() {
-		return AccountConstants.OBJECT_TYPE_NAME;
+	protected String getObjectSchemaName() {
+		return _schemaName;
 	}
 
 	@Value("${liferay.one.jira.asset.schema.name}")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountConverter.java
@@ -5,7 +5,16 @@
 
 package com.liferay.one.jira.converter;
 
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
 import com.liferay.one.jira.constants.AccountConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -21,10 +30,184 @@ public class AccountConverter extends BaseJiraAssetObjectConverter {
 		return AccountConstants.OBJECT_TYPE_NAME;
 	}
 
+	public JiraAssetObject toAssetObject(Account account) {
+		return toAssetObject(
+			account, account.getExternalReferenceCode(), account.getName());
+	}
+
+	public JiraAssetObject toAssetObject(
+		Account account, String externalKey, String name) {
+
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_KEY, externalKey);
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_NAME, name);
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_DESCRIPTION,
+			account.getDescription());
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT,
+			formatDate(account.getDateCreated()));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT,
+			formatDate(account.getDateModified()));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_STATUS,
+			_status(account.getStatus()));
+
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_CODE,
+			_customFieldData(account, _CUSTOM_FIELD_NAME_ACCOUNT_CODE));
+		jiraAssetObject.setAttributeValue(
+			AccountConstants.ATTRIBUTE_NAME_TIER,
+			_customFieldData(account, _CUSTOM_FIELD_NAME_ACCOUNT_TIER));
+
+		AccountContactInformation accountContactInformation =
+			account.getAccountContactInformation();
+
+		if (accountContactInformation != null) {
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS,
+				_getEmailAddress(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_FAX_NUMBER,
+				_getFaxNumber(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_PHONE_NUMBER,
+				_getPhoneNumber(accountContactInformation));
+			jiraAssetObject.setAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_WEBSITE,
+				_getWebsite(accountContactInformation));
+		}
+
+		return jiraAssetObject;
+	}
+
 	@Override
 	protected String getObjectSchemaName() {
 		return _schemaName;
 	}
+
+	private Object _customFieldData(Account account, String name) {
+		CustomField[] customFields = account.getCustomFields();
+
+		if (customFields == null) {
+			return null;
+		}
+
+		for (CustomField customField : customFields) {
+			if (!name.equals(customField.getName())) {
+				continue;
+			}
+
+			CustomValue customValue = customField.getCustomValue();
+
+			if (customValue == null) {
+				return null;
+			}
+
+			return customValue.getData();
+		}
+
+		return null;
+	}
+
+	private String _getEmailAddress(
+		AccountContactInformation accountContactInformation) {
+
+		EmailAddress[] emailAddresses =
+			accountContactInformation.getEmailAddresses();
+
+		if (ArrayUtil.isEmpty(emailAddresses)) {
+			return null;
+		}
+
+		for (EmailAddress emailAddress : emailAddresses) {
+			if (Boolean.TRUE.equals(emailAddress.getPrimary())) {
+				return emailAddress.getEmailAddress();
+			}
+		}
+
+		EmailAddress emailAddress = emailAddresses[0];
+
+		return emailAddress.getEmailAddress();
+	}
+
+	private String _getFaxNumber(
+		AccountContactInformation accountContactInformation) {
+
+		Phone[] telephones = ArrayUtil.filter(
+			accountContactInformation.getTelephones(),
+			telephone -> "fax".equalsIgnoreCase(telephone.getPhoneType()));
+
+		if (ArrayUtil.isEmpty(telephones)) {
+			return null;
+		}
+
+		Phone telephone = telephones[0];
+
+		return telephone.getPhoneNumber();
+	}
+
+	private String _getPhoneNumber(
+		AccountContactInformation accountContactInformation) {
+
+		Phone[] telephones = ArrayUtil.filter(
+			accountContactInformation.getTelephones(),
+			telephone -> !"fax".equalsIgnoreCase(telephone.getPhoneType()));
+
+		if (ArrayUtil.isEmpty(telephones)) {
+			return null;
+		}
+
+		for (Phone telephone : telephones) {
+			if (Boolean.TRUE.equals(telephone.getPrimary())) {
+				return telephone.getPhoneNumber();
+			}
+		}
+
+		Phone telephone = telephones[0];
+
+		return telephone.getPhoneNumber();
+	}
+
+	private String _getWebsite(
+		AccountContactInformation accountContactInformation) {
+
+		WebUrl[] webUrls = accountContactInformation.getWebUrls();
+
+		if (ArrayUtil.isEmpty(webUrls)) {
+			return null;
+		}
+
+		for (WebUrl webUrl : webUrls) {
+			if (Boolean.TRUE.equals(webUrl.getPrimary())) {
+				return webUrl.getUrl();
+			}
+		}
+
+		WebUrl webUrl = webUrls[0];
+
+		return webUrl.getUrl();
+	}
+
+	private String _status(Integer status) {
+		if (status == null) {
+			return null;
+		}
+
+		if (status == 0) {
+			return "Active";
+		}
+
+		return "Closed";
+	}
+
+	private static final String _CUSTOM_FIELD_NAME_ACCOUNT_CODE = "accountCode";
+
+	private static final String _CUSTOM_FIELD_NAME_ACCOUNT_TIER = "accountTier";
 
 	@Value("${liferay.one.jira.asset.schema.name}")
 	private String _schemaName;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
@@ -9,7 +9,12 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.AssetSchemaService;
 import com.liferay.one.jira.util.AQLUtil;
 
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
 import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
 import java.util.function.Consumer;
 
 import org.json.JSONObject;
@@ -22,6 +27,10 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public abstract class BaseJiraAssetObjectConverter {
 
+	public JiraAssetObject createJiraAssetObject() {
+		return new JiraAssetObject(_getAttributeIds(), _getAttributeOptions());
+	}
+
 	public String getAQLWithBuilder(Consumer<AQLUtil.Builder> consumer) {
 		AQLUtil.Builder builder = AQLUtil.builder(getBaseAQL());
 
@@ -32,18 +41,33 @@ public abstract class BaseJiraAssetObjectConverter {
 		return builder.build();
 	}
 
+	public String getExternalKeyAttributeName() {
+		return _ATTRIBUTE_NAME_EXTERNAL_KEY;
+	}
+
 	public String getObjectTypeId() {
 		return _assetSchemaService.getObjectTypeId(
 			getObjectSchemaName(), getObjectTypeName());
 	}
 
+	public abstract String getObjectTypeName();
+
 	public JiraAssetObject toJiraAssetObject(JSONObject jsonObject) {
-		return new JiraAssetObject(jsonObject, getAttributeIds());
+		return new JiraAssetObject(
+			jsonObject, _getAttributeIds(), _getAttributeOptions());
 	}
 
-	protected Map<String, String> getAttributeIds() {
-		return _assetSchemaService.getAttributeIds(
-			getObjectSchemaName(), getObjectTypeName());
+	protected String formatDate(Date date) {
+		if (date == null) {
+			return null;
+		}
+
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return simpleDateFormat.format(date);
 	}
 
 	protected String getBaseAQL() {
@@ -52,7 +76,17 @@ public abstract class BaseJiraAssetObjectConverter {
 
 	protected abstract String getObjectSchemaName();
 
-	protected abstract String getObjectTypeName();
+	private Map<String, String> _getAttributeIds() {
+		return _assetSchemaService.getAttributeIds(
+			getObjectSchemaName(), getObjectTypeName());
+	}
+
+	private Map<String, Set<String>> _getAttributeOptions() {
+		return _assetSchemaService.getAttributeOptions(
+			getObjectSchemaName(), getObjectTypeName());
+	}
+
+	private static final String _ATTRIBUTE_NAME_EXTERNAL_KEY = "External Key";
 
 	@Autowired
 	private AssetSchemaService _assetSchemaService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ContactConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ContactConverter.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.constants.ContactConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class ContactConverter extends BaseJiraAssetObjectConverter {
+
+	@Override
+	public String getObjectTypeName() {
+		return ContactConstants.OBJECT_TYPE_NAME;
+	}
+
+	public JiraAssetObject toAssetObject(UserAccount userAccount) {
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_KEY,
+			userAccount.getExternalReferenceCode());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_NAME, userAccount.getName());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_FIRST_NAME,
+			userAccount.getGivenName());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_MIDDLE_NAME,
+			userAccount.getAdditionalName());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_LAST_NAME,
+			userAccount.getFamilyName());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS,
+			userAccount.getEmailAddress());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_LANGUAGE_ID,
+			userAccount.getLanguageId());
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT,
+			formatDate(userAccount.getDateCreated()));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT,
+			formatDate(userAccount.getDateModified()));
+
+		return jiraAssetObject;
+	}
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _schemaName;
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/EntitlementConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/EntitlementConverter.java
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.EntitlementConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.model.EntitlementDefinition;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class EntitlementConverter extends BaseJiraAssetObjectConverter {
+
+	@Override
+	public String getExternalKeyAttributeName() {
+		return EntitlementConstants.ATTRIBUTE_NAME_NAME;
+	}
+
+	@Override
+	public String getObjectTypeName() {
+		return EntitlementConstants.OBJECT_TYPE_NAME;
+	}
+
+	public JiraAssetObject toAssetObject(
+		EntitlementDefinition entitlementDefinition) {
+
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		jiraAssetObject.setAttributeValue(
+			EntitlementConstants.ATTRIBUTE_NAME_NAME,
+			entitlementDefinition.getDisplayName());
+		jiraAssetObject.setAttributeValue(
+			EntitlementConstants.ATTRIBUTE_NAME_ENTITLEMENT_DEFINITION_KEY,
+			entitlementDefinition.getExternalReferenceCode());
+
+		return jiraAssetObject;
+	}
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _schemaName;
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ExternalLinkConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ExternalLinkConverter.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.ExternalLinkConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.model.Property;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringUtil;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class ExternalLinkConverter extends BaseJiraAssetObjectConverter {
+
+	@Override
+	public String getObjectTypeName() {
+		return ExternalLinkConstants.OBJECT_TYPE_NAME;
+	}
+
+	public JiraAssetObject toAssetObject(Property property) {
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		List<String> parts = StringUtil.split(
+			property.getName(), CharPool.COLON);
+
+		if (parts.size() != 2) {
+			return null;
+		}
+
+		String domain = parts.get(0);
+		String entityName = parts.get(1);
+
+		jiraAssetObject.setAttributeValue(
+			ExternalLinkConstants.ATTRIBUTE_NAME_NAME, property.getClassName());
+		jiraAssetObject.setAttributeValue(
+			ExternalLinkConstants.ATTRIBUTE_NAME_EXTERNAL_KEY,
+			property.getExternalReferenceCode());
+		jiraAssetObject.setAttributeValue(
+			ExternalLinkConstants.ATTRIBUTE_NAME_DOMAIN, domain);
+		jiraAssetObject.setAttributeValue(
+			ExternalLinkConstants.ATTRIBUTE_NAME_ENTITY_ID,
+			property.getValue());
+		jiraAssetObject.setAttributeValue(
+			ExternalLinkConstants.ATTRIBUTE_NAME_ENTITY_NAME, entityName);
+
+		return jiraAssetObject;
+	}
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _schemaName;
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraBusinessEventConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraBusinessEventConverter.java
@@ -20,11 +20,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class JiraBusinessEventConverter extends BaseJiraAssetObjectConverter {
 
+	@Override
+	public String getObjectTypeName() {
+		return JiraBusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT;
+	}
+
 	public JiraAssetObject toAssetObject(
 		String accountObjectKey, JiraBusinessEvent jiraBusinessEvent) {
 
-		JiraAssetObject jiraAssetObject = new JiraAssetObject(
-			getAttributeIds());
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
 
 		jiraAssetObject.setAttributeValue(
 			JiraBusinessEventConstants.ATTRIBUTE_NAME_ACTUAL_EVENT_DATE,
@@ -79,8 +83,8 @@ public class JiraBusinessEventConverter extends BaseJiraAssetObjectConverter {
 		JSONObject jiraAssetObjectJSONObject,
 		String projectExternalReferenceCode) {
 
-		JiraAssetObject jiraAssetObject = new JiraAssetObject(
-			jiraAssetObjectJSONObject, getAttributeIds());
+		JiraAssetObject jiraAssetObject = toJiraAssetObject(
+			jiraAssetObjectJSONObject);
 
 		return new JiraBusinessEvent(
 			jiraAssetObject.getAttributeValue(
@@ -143,11 +147,6 @@ public class JiraBusinessEventConverter extends BaseJiraAssetObjectConverter {
 	@Override
 	protected String getObjectSchemaName() {
 		return JiraBusinessEventConstants.OBJECT_SCHEMA_BUSINESS_EVENTS;
-	}
-
-	@Override
-	protected String getObjectTypeName() {
-		return JiraBusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT;
 	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraBusinessEventVersionConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraBusinessEventVersionConverter.java
@@ -20,11 +20,16 @@ import org.springframework.stereotype.Component;
 public class JiraBusinessEventVersionConverter
 	extends BaseJiraAssetObjectConverter {
 
+	@Override
+	public String getObjectTypeName() {
+		return JiraBusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT_VERSION;
+	}
+
 	public JiraBusinessEventVersion toJiraBusinessEventVersion(
 		JSONObject jiraAssetObjectJSONObject) {
 
-		JiraAssetObject jiraAssetObject = new JiraAssetObject(
-			jiraAssetObjectJSONObject, getAttributeIds());
+		JiraAssetObject jiraAssetObject = toJiraAssetObject(
+			jiraAssetObjectJSONObject);
 
 		return new JiraBusinessEventVersion(
 			jiraAssetObject.getAttributeDisplayValue(
@@ -40,11 +45,6 @@ public class JiraBusinessEventVersionConverter
 	@Override
 	protected String getObjectSchemaName() {
 		return JiraBusinessEventConstants.OBJECT_SCHEMA_BUSINESS_EVENTS;
-	}
-
-	@Override
-	protected String getObjectTypeName() {
-		return JiraBusinessEventConstants.OBJECT_TYPE_BUSINESS_EVENT_VERSION;
 	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraOrganizationConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/JiraOrganizationConverter.java
@@ -20,11 +20,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class JiraOrganizationConverter extends BaseJiraAssetObjectConverter {
 
+	@Override
+	public String getObjectTypeName() {
+		return AccountConstants.OBJECT_TYPE_NAME;
+	}
+
 	public JiraOrganization toJiraOrganization(
 		JSONObject assetObjectJSONObject) {
 
-		JiraAssetObject jiraAssetObject = new JiraAssetObject(
-			assetObjectJSONObject, getAttributeIds());
+		JiraAssetObject jiraAssetObject = toJiraAssetObject(
+			assetObjectJSONObject);
 
 		return new JiraOrganization(
 			jiraAssetObject.getAttributeValue(
@@ -35,11 +40,6 @@ public class JiraOrganizationConverter extends BaseJiraAssetObjectConverter {
 	@Override
 	protected String getObjectSchemaName() {
 		return _schemaName;
-	}
-
-	@Override
-	protected String getObjectTypeName() {
-		return AccountConstants.OBJECT_TYPE_NAME;
 	}
 
 	@Value("${liferay.one.jira.asset.schema.name}")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/PostalAddressConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/PostalAddressConverter.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
+import com.liferay.one.jira.constants.PostalAddressConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class PostalAddressConverter extends BaseJiraAssetObjectConverter {
+
+	@Override
+	public String getExternalKeyAttributeName() {
+		return PostalAddressConstants.ATTRIBUTE_NAME_ID;
+	}
+
+	@Override
+	public String getObjectTypeName() {
+		return PostalAddressConstants.OBJECT_TYPE_NAME;
+	}
+
+	public JiraAssetObject toAssetObject(PostalAddress postalAddress) {
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		Long id = postalAddress.getId();
+
+		if (id != null) {
+			jiraAssetObject.setAttributeValue(
+				PostalAddressConstants.ATTRIBUTE_NAME_ID, String.valueOf(id));
+		}
+
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_NAME,
+			_getName(postalAddress));
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_ADDRESS_COUNTRY,
+			postalAddress.getAddressCountry());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_ADDRESS_LOCALITY,
+			postalAddress.getAddressLocality());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_ADDRESS_REGION,
+			postalAddress.getAddressRegion());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_ADDRESS_TYPE,
+			postalAddress.getAddressType());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_POSTAL_CODE,
+			postalAddress.getPostalCode());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_PRIMARY,
+			postalAddress.getPrimary());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_STREET_ADDRESS_LINE_1,
+			postalAddress.getStreetAddressLine1());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_STREET_ADDRESS_LINE_2,
+			postalAddress.getStreetAddressLine2());
+		jiraAssetObject.setAttributeValue(
+			PostalAddressConstants.ATTRIBUTE_NAME_STREET_ADDRESS_LINE_3,
+			postalAddress.getStreetAddressLine3());
+
+		return jiraAssetObject;
+	}
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _schemaName;
+	}
+
+	private String _getName(PostalAddress postalAddress) {
+		List<String> parts = new ArrayList<>();
+
+		for (String part :
+				new String[] {
+					postalAddress.getStreetAddressLine1(),
+					postalAddress.getStreetAddressLine2(),
+					postalAddress.getStreetAddressLine3(),
+					postalAddress.getAddressLocality(),
+					postalAddress.getAddressRegion(),
+					postalAddress.getAddressCountry(),
+					postalAddress.getPostalCode()
+				}) {
+
+			if (Validator.isNotNull(part)) {
+				parts.add(part);
+			}
+		}
+
+		return StringUtil.merge(parts, ", ");
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/TeamConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/TeamConverter.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.one.jira.constants.TeamConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class TeamConverter extends BaseJiraAssetObjectConverter {
+
+	@Override
+	public String getObjectTypeName() {
+		return TeamConstants.OBJECT_TYPE_NAME;
+	}
+
+	public JiraAssetObject toAssetObject(Organization organization) {
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+
+		jiraAssetObject.setAttributeValue(
+			TeamConstants.ATTRIBUTE_NAME_EXTERNAL_KEY,
+			organization.getExternalReferenceCode());
+		jiraAssetObject.setAttributeValue(
+			TeamConstants.ATTRIBUTE_NAME_NAME, organization.getName());
+		jiraAssetObject.setAttributeValue(
+			TeamConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT,
+			formatDate(organization.getDateCreated()));
+		jiraAssetObject.setAttributeValue(
+			TeamConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT,
+			formatDate(organization.getDateModified()));
+
+		return jiraAssetObject;
+	}
+
+	@Override
+	protected String getObjectSchemaName() {
+		return _schemaName;
+	}
+
+	@Value("${liferay.one.jira.asset.schema.name}")
+	private String _schemaName;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/exception/JiraAssetObjectException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/exception/JiraAssetObjectException.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.exception;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetObjectException extends RuntimeException {
+
+	public JiraAssetObjectException(String message) {
+		super(message);
+	}
+
+	public JiraAssetObjectException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetObject.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetObject.java
@@ -5,10 +5,15 @@
 
 package com.liferay.one.jira.model;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -22,15 +27,21 @@ import org.json.JSONObject;
 public class JiraAssetObject {
 
 	public JiraAssetObject(
-		JSONObject jsonObject, Map<String, String> attributeNameToIdsMap) {
+		JSONObject jsonObject, Map<String, String> attributeNameToIdsMap,
+		Map<String, Set<String>> attributeNameToOptionsMap) {
 
 		_jsonObject = jsonObject;
 
 		_attributeIds = attributeNameToIdsMap;
+		_attributeOptions = attributeNameToOptionsMap;
 	}
 
-	public JiraAssetObject(Map<String, String> attributeNameToIdsMap) {
-		this(new JSONObject(), attributeNameToIdsMap);
+	public JiraAssetObject(
+		Map<String, String> attributeNameToIdsMap,
+		Map<String, Set<String>> attributeNameToOptionsMap) {
+
+		this(
+			new JSONObject(), attributeNameToIdsMap, attributeNameToOptionsMap);
 	}
 
 	/**
@@ -89,28 +100,53 @@ public class JiraAssetObject {
 			return;
 		}
 
-		_values.put(attributeId, value);
+		if (value instanceof Collection<?> collection) {
+			List<Object> validValues = new ArrayList<>();
+
+			for (Object object : collection) {
+				if (_isValidOption(attributeName, object)) {
+					validValues.add(object);
+				}
+			}
+
+			_values.put(attributeId, validValues);
+		}
+		else if (_isValidOption(attributeName, value)) {
+			_values.put(attributeId, value);
+		}
 	}
 
 	/**
 	 * Serializes this object into the JSM's {@code attributes} JSON shape.
-	 * This method is used by the {@link JiraAssetService}.
+	 * This method is used by the {@link com.liferay.one.jira.service.JiraAssetService}.
 	 */
 	public JSONArray toAttributesJSONArray() {
 		JSONArray attributesJSONArray = new JSONArray();
 
 		for (Map.Entry<String, Object> entry : _values.entrySet()) {
+			JSONArray objectAttributeValuesJSONArray = new JSONArray();
+
+			Object value = entry.getValue();
+
+			if (value instanceof Collection<?> collection) {
+				for (Object object : collection) {
+					if (Validator.isNull(object)) {
+						continue;
+					}
+
+					objectAttributeValuesJSONArray.put(
+						_toAttrbuteValueJSONObject(object));
+				}
+			}
+			else if (Validator.isNotNull(value)) {
+				objectAttributeValuesJSONArray.put(
+					_toAttrbuteValueJSONObject(value));
+			}
+
 			attributesJSONArray.put(
 				new JSONObject(
 				).put(
-					"objectAttributeValues",
-					new JSONArray(
-					).put(
-						new JSONObject(
-						).put(
-							"value", entry.getValue()
-						)
-					)
+					"objectAttributeValues", objectAttributeValuesJSONArray
 				).put(
 					"objectTypeAttributeId", entry.getKey()
 				));
@@ -187,9 +223,38 @@ public class JiraAssetObject {
 		return value;
 	}
 
+	private boolean _isValidOption(String attributeName, Object value) {
+		Set<String> options = _attributeOptions.get(attributeName);
+
+		if ((options == null) || Validator.isNull(value) ||
+			options.contains(String.valueOf(value))) {
+
+			return true;
+		}
+
+		if (_log.isWarnEnabled()) {
+			_log.warn(
+				StringBundler.concat(
+					"Value \"", value, "\" for attribute \"", attributeName,
+					"\" does not match any of the schema's options ", options,
+					"; the option list has likely drifted"));
+		}
+
+		return false;
+	}
+
+	private JSONObject _toAttrbuteValueJSONObject(Object attributeValue) {
+		JSONObject jsonObject = new JSONObject();
+
+		jsonObject.put("value", attributeValue);
+
+		return jsonObject;
+	}
+
 	private static final Log _log = LogFactory.getLog(JiraAssetObject.class);
 
 	private final Map<String, String> _attributeIds;
+	private final Map<String, Set<String>> _attributeOptions;
 	private final JSONObject _jsonObject;
 	private final Map<String, Object> _values = new LinkedHashMap<>();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountAssetService.java
@@ -16,23 +16,35 @@ import org.springframework.stereotype.Component;
 
 /**
  * @author Amos Fong
+ * @author Drew Brokke
  */
 @Component
 public class AccountAssetService {
 
-	public String getAccountObjectKey(String externalKey) throws Exception {
-		List<JiraAssetObject> jiraAssetObjects =
-			_jiraAssetService.searchObjects(
-				_accountConverter.getAQLWithBuilder(
-					aqlBuilder -> aqlBuilder.andEquals(
-						externalKey, "External Key")),
-				_accountConverter::toJiraAssetObject);
+	public JiraAssetObject fetchAccountJiraAssetObjectByExternalKey(
+		String externalKey) {
 
-		if (jiraAssetObjects.isEmpty()) {
-			throw new AccountNotFoundException();
+		List<JiraAssetObject> objects = _jiraAssetService.searchObjects(
+			_accountConverter.getAQLWithBuilder(
+				aqlBuilder -> aqlBuilder.andEquals(
+					externalKey,
+					_accountConverter.getExternalKeyAttributeName())),
+			_accountConverter::toJiraAssetObject);
+
+		if (objects.isEmpty()) {
+			return null;
 		}
 
-		JiraAssetObject jiraAssetObject = jiraAssetObjects.get(0);
+		return objects.get(0);
+	}
+
+	public String getAccountObjectKey(String externalKey) throws Exception {
+		JiraAssetObject jiraAssetObject =
+			fetchAccountJiraAssetObjectByExternalKey(externalKey);
+
+		if (jiraAssetObject == null) {
+			throw new AccountNotFoundException();
+		}
 
 		return jiraAssetObject.getObjectKey();
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
@@ -1,0 +1,491 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.constants.AccountConstants;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.EntitlementConverter;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.jira.converter.PostalAddressConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.model.JiraBusinessEvent;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.model.Entitlement;
+import com.liferay.one.model.EntitlementDefinition;
+import com.liferay.one.model.Project;
+import com.liferay.one.model.Property;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.EntitlementDefinitionService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.OrganizationService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class AccountSyncService {
+
+	public void syncAccount(Account account) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing account " + account.getExternalReferenceCode() +
+					" to JSM");
+		}
+
+		Map<String, Object> attributeValues = _getAccountAttributeValues(
+			account);
+
+		_syncAccountAsset(
+			account, attributeValues, account.getExternalReferenceCode(),
+			account.getName());
+
+		for (Project project : _projectService.getProjects(account.getId())) {
+			try {
+				_syncAccountAsset(
+					account, attributeValues,
+					project.getExternalReferenceCode(), project.getName());
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to sync project " +
+						project.getExternalReferenceCode(),
+					exception);
+			}
+		}
+	}
+
+	public void syncProject(Project project) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing project " + project.getExternalReferenceCode() +
+					" to JSM");
+		}
+
+		Account account = _accountService.getAccount(
+			project.getAccountExternalReferenceCode());
+
+		_syncAccountAsset(
+			account, _getAccountAttributeValues(account),
+			project.getExternalReferenceCode(), project.getName());
+	}
+
+	private void _addJiraBusinessEventLine(
+		List<String> lines, String fieldName, String value) {
+
+		if (Validator.isNull(value)) {
+			return;
+		}
+
+		lines.add(fieldName + ": " + value);
+	}
+
+	private <T> T _findFirst(List<T> list, Predicate<T> predicate) {
+		if (ListUtil.isEmpty(list)) {
+			return null;
+		}
+
+		for (T t : list) {
+			if (predicate.test(t)) {
+				return t;
+			}
+		}
+
+		return null;
+	}
+
+	private <T> T _findFirst(T[] arr, Predicate<T> predicate) {
+		if (arr == null) {
+			return null;
+		}
+
+		return _findFirst(Arrays.asList(arr), predicate);
+	}
+
+	private Map<String, Object> _getAccountAttributeValues(Account account)
+		throws Exception {
+
+		AccountUserAccountBucket accountUserAccountBucket =
+			_getAccountUserAccountBucket(account);
+
+		AccountSupportInfo accountSupportInfo =
+			_commerceOrderService.getAccountSupportInfo(
+				account.getId(), account.getDefaultBillingAddressId());
+
+		return LinkedHashMapBuilder.<String, Object>put(
+			AccountConstants.ATTRIBUTE_NAME_ASSIGNED_TEAMS,
+			_assetReferenceObjectService.fetchReferenceObjectIds(
+				_teamConverter,
+				_organizationService.getAccountOrganizations(account.getId()),
+				Organization::getExternalReferenceCode)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_BUSINESS_EVENTS,
+			_toBusinessEventsFieldValue(account)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
+			_assetReferenceObjectService.fetchReferenceObjectIds(
+				_contactConverter,
+				accountUserAccountBucket.getCustomerUserAccounts(),
+				UserAccount::getExternalReferenceCode)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
+			_assetReferenceObjectService.getOrCreateReferenceObjectIds(
+				_entitlementConverter, _getEntitlementDefinitions(account),
+				EntitlementDefinition::getDisplayName,
+				_entitlementConverter::toAssetObject)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_LINKS,
+			_assetReferenceObjectService.getOrCreateReferenceObjectIds(
+				_externalLinkConverter, _getExternalLinkProperties(account),
+				Property::getExternalReferenceCode,
+				_externalLinkConverter::toAssetObject)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_LANGUAGE,
+			GetterUtil.getString(accountSupportInfo.getSupportLanguage())
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_POSTAL_ADDRESSES,
+			() -> {
+				AccountContactInformation accountContactInformation =
+					account.getAccountContactInformation();
+
+				if (accountContactInformation == null) {
+					return null;
+				}
+
+				return _assetReferenceObjectService.
+					getOrCreateReferenceObjectIds(
+						_postalAddressConverter,
+						ListUtil.fromArray(
+							accountContactInformation.getPostalAddresses()),
+						postalAddress -> String.valueOf(postalAddress.getId()),
+						_postalAddressConverter::toAssetObject);
+			}
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_SUPPORT_REGION,
+			GetterUtil.getString(accountSupportInfo.getSupportRegion())
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
+			_assetReferenceObjectService.fetchReferenceObjectIds(
+				_contactConverter,
+				accountUserAccountBucket.getWorkerUserAccounts(),
+				UserAccount::getExternalReferenceCode)
+		).build();
+	}
+
+	private AccountUserAccountBucket _getAccountUserAccountBucket(
+			Account account)
+		throws Exception {
+
+		AccountUserAccountBucket accountUserAccountBucket =
+			new AccountUserAccountBucket();
+
+		for (UserAccount accountUserAccount :
+				_userAccountService.getAccountUserAccounts(account.getId())) {
+
+			AccountBrief accountBrief = _findFirst(
+				Arrays.asList(accountUserAccount.getAccountBriefs()),
+				accountBrief1 -> Objects.equals(
+					account.getExternalReferenceCode(),
+					accountBrief1.getExternalReferenceCode()));
+
+			if (accountBrief == null) {
+				_log.error(
+					"accountBrief is null for user account = " +
+						accountUserAccount);
+
+				continue;
+			}
+
+			RoleBrief roleBrief = _findFirst(
+				accountBrief.getRoleBriefs(),
+				roleBrief1 -> _employeeRoleNames.contains(
+					roleBrief1.getName()));
+
+			if (roleBrief != null) {
+				accountUserAccountBucket.addWorkerUserAccount(
+					accountUserAccount);
+			}
+			else {
+				accountUserAccountBucket.addCustomerUserAccount(
+					accountUserAccount);
+			}
+		}
+
+		return accountUserAccountBucket;
+	}
+
+	private List<EntitlementDefinition> _getEntitlementDefinitions(
+			Account account)
+		throws Exception {
+
+		List<Entitlement> entitlements =
+			_entitlementService.getActiveEntitlements(account.getId());
+
+		Set<Long> entitlementDefinitionIds = new LinkedHashSet<>();
+
+		for (Entitlement entitlement : entitlements) {
+			long entitlementDefinitionId =
+				entitlement.getEntitlementDefinitionId();
+
+			if (entitlementDefinitionId > 0) {
+				entitlementDefinitionIds.add(entitlementDefinitionId);
+			}
+		}
+
+		if (entitlementDefinitionIds.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<String> statements = TransformUtil.transform(
+			entitlementDefinitionIds,
+			entitlementDefinitionId ->
+				"(id eq '" + entitlementDefinitionId + "')");
+
+		return _entitlementDefinitionService.getEntitlementDefinitions(
+			StringUtil.merge(statements, " or "));
+	}
+
+	private List<Property> _getExternalLinkProperties(Account account)
+		throws Exception {
+
+		List<Property> externalLinkProperties = new ArrayList<>();
+
+		List<Property> properties = _propertyService.getAccountProperties(
+			account.getId());
+
+		for (Property property : properties) {
+			String[] split = StringUtil.split(
+				property.getName(), CharPool.COLON);
+
+			if (split.length == 2) {
+				externalLinkProperties.add(property);
+			}
+		}
+
+		return externalLinkProperties;
+	}
+
+	private void _syncAccountAsset(
+			Account account, Map<String, Object> attributeValues,
+			String externalKey, String name)
+		throws Exception {
+
+		JiraAssetObject assetObject = _accountConverter.toAssetObject(
+			account, externalKey, name);
+
+		for (Map.Entry<String, Object> entry : attributeValues.entrySet()) {
+			assetObject.setAttributeValue(entry.getKey(), entry.getValue());
+		}
+
+		_assetObjectUpsertService.upsert(_accountConverter, assetObject);
+	}
+
+	private String _toBusinessEventFieldValuePart(
+		JiraBusinessEvent jiraBusinessEvent) {
+
+		List<String> lines = new ArrayList<>();
+
+		_addJiraBusinessEventLine(lines, "name", jiraBusinessEvent.getName());
+		_addJiraBusinessEventLine(
+			lines, "targetGoLiveDateTime",
+			jiraBusinessEvent.getPlannedEventDate());
+		_addJiraBusinessEventLine(
+			lines, "description", jiraBusinessEvent.getDescription());
+		_addJiraBusinessEventLine(
+			lines, "type", jiraBusinessEvent.getEventTypeName());
+		_addJiraBusinessEventLine(
+			lines, "currentVersion",
+			jiraBusinessEvent.getCurrentLiferayVersionName());
+		_addJiraBusinessEventLine(
+			lines, "newVersion", jiraBusinessEvent.getNewLiferayVersionName());
+
+		return StringUtil.merge(lines, ",\n");
+	}
+
+	private String _toBusinessEventsFieldValue(Account account)
+		throws Exception {
+
+		List<String> parts = new ArrayList<>();
+
+		List<JiraBusinessEvent> jiraBusinessEvents =
+			_jiraBusinessEventService.getJiraBusinessEvents(
+				account.getExternalReferenceCode());
+
+		for (JiraBusinessEvent businessEvent : jiraBusinessEvents) {
+			String part = _toBusinessEventFieldValuePart(businessEvent);
+
+			if (Validator.isNotNull(part)) {
+				parts.add(part);
+			}
+		}
+
+		return StringUtil.merge(parts, "\n\n");
+	}
+
+	private static final Log _log = LogFactory.getLog(AccountSyncService.class);
+
+	@Autowired
+	private AccountConverter _accountConverter;
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Autowired
+	private AssetObjectUpsertService _assetObjectUpsertService;
+
+	@Autowired
+	private AssetReferenceObjectService _assetReferenceObjectService;
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private ContactConverter _contactConverter;
+
+	private final List<String> _employeeRoleNames = EmployeeRoles.getNames();
+
+	@Autowired
+	private EntitlementConverter _entitlementConverter;
+
+	@Autowired
+	private EntitlementDefinitionService _entitlementDefinitionService;
+
+	@Autowired
+	private EntitlementService _entitlementService;
+
+	@Autowired
+	private ExternalLinkConverter _externalLinkConverter;
+
+	@Autowired
+	private JiraBusinessEventService _jiraBusinessEventService;
+
+	@Autowired
+	private OrganizationService _organizationService;
+
+	@Autowired
+	private PostalAddressConverter _postalAddressConverter;
+
+	@Autowired
+	private ProjectService _projectService;
+
+	@Autowired
+	private PropertyService _propertyService;
+
+	@Autowired
+	private TeamConverter _teamConverter;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+	private static class AccountUserAccountBucket {
+
+		public void addCustomerUserAccount(UserAccount userAccount) {
+			_customerUserAccounts.add(userAccount);
+		}
+
+		public void addWorkerUserAccount(UserAccount userAccount) {
+			_workerUserAccounts.add(userAccount);
+		}
+
+		public List<UserAccount> getCustomerUserAccounts() {
+			return _customerUserAccounts;
+		}
+
+		public List<UserAccount> getWorkerUserAccounts() {
+			return _workerUserAccounts;
+		}
+
+		private final List<UserAccount> _customerUserAccounts =
+			new ArrayList<>();
+		private final List<UserAccount> _workerUserAccounts = new ArrayList<>();
+
+	}
+
+	private enum EmployeeRoles {
+
+		CUSTOMER_EXPERIENCE_MANAGER(
+			"C_CUSTOMER_EXPERIENCE_MANAGER", "Customer Experience Manager",
+			"account"),
+		LIFERAY_SALES("C_LIFERAY_SALES", "Liferay Sales", "account"),
+		PRIMARY_CONTACT("C_PRIMARY_CONTACT", "Primary Contact", "account"),
+		SECONDARY_CONTACT(
+			"C_SECONDARY_CONTACT", "Secondary Contact", "account"),
+		SOLUTION_ARCHITECT(
+			"C_SOLUTION_ARCHITECT", "Solution Architect", "account");
+
+		public static List<String> getNames() {
+			List<String> names = new ArrayList<>();
+
+			for (EmployeeRoles employeeRole : values()) {
+				names.add(employeeRole.getName());
+			}
+
+			return names;
+		}
+
+		@SuppressWarnings("unused")
+		public String getExternalReferenceCode() {
+			return _externalReferenceCode;
+		}
+
+		public String getName() {
+			return _name;
+		}
+
+		@SuppressWarnings("unused")
+		public String getRoleType() {
+			return _roleType;
+		}
+
+		private EmployeeRoles(
+			String externalReferenceCode, String name, String roleType) {
+
+			_externalReferenceCode = externalReferenceCode;
+			_name = name;
+			_roleType = roleType;
+		}
+
+		private final String _externalReferenceCode;
+		private final String _name;
+		private final String _roleType;
+
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetObjectUpsertService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetObjectUpsertService.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class AssetObjectUpsertService {
+
+	public void upsert(
+		BaseJiraAssetObjectConverter converter,
+		JiraAssetObject jiraAssetObject) {
+
+		String externalKeyAttributeName =
+			converter.getExternalKeyAttributeName();
+
+		String externalKey = jiraAssetObject.getAttributeValue(
+			externalKeyAttributeName);
+
+		if (Validator.isNull(externalKey)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Unable to upsert a ", converter.getObjectTypeName(),
+						" asset object with no \"", externalKeyAttributeName,
+						"\" value"));
+			}
+
+			return;
+		}
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetService.searchObjects(
+				converter.getAQLWithBuilder(
+					aqlBuilder -> aqlBuilder.andEquals(
+						externalKey, externalKeyAttributeName)),
+				converter::toJiraAssetObject);
+
+		if (jiraAssetObjects.isEmpty()) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Creating ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey));
+			}
+
+			_jiraAssetService.createObject(
+				converter.getObjectTypeId(), jiraAssetObject);
+		}
+		else {
+			JiraAssetObject existingJiraAssetObject = jiraAssetObjects.get(0);
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Updating ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey));
+			}
+
+			_jiraAssetService.updateObject(
+				existingJiraAssetObject.getObjectId(), jiraAssetObject);
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		AssetObjectUpsertService.class);
+
+	@Autowired
+	private JiraAssetService _jiraAssetService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
@@ -188,8 +188,9 @@ public class AssetReferenceObjectService {
 		if (jiraAssetObject == null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					"Unable to create asset object for external key " +
-						externalKey);
+					StringBundler.concat(
+						"Unable to create ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey));
 			}
 
 			return null;
@@ -197,8 +198,9 @@ public class AssetReferenceObjectService {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
-				"Creating asset object for unresolved external key " +
-					externalKey);
+				StringBundler.concat(
+					"Creating ", converter.getObjectTypeName(),
+					" asset object for unresolved external key ", externalKey));
 		}
 
 		try {
@@ -240,11 +242,25 @@ public class AssetReferenceObjectService {
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					StringBundler.concat(
-						"Resolved external key ", externalKey,
-						" to existing asset object ", objectId));
+						"Resolved external key ", externalKey, " to existing ",
+						converter.getObjectTypeName(), " asset object ",
+						objectId));
 			}
 
-			externalKeyToObjectIdMap.put(externalKey, objectId);
+			String previousObjectId = externalKeyToObjectIdMap.put(
+				externalKey, objectId);
+
+			if ((previousObjectId != null) &&
+				!Objects.equals(previousObjectId, objectId) &&
+				_log.isWarnEnabled()) {
+
+				_log.warn(
+					StringBundler.concat(
+						"Multiple asset objects share external key ",
+						externalKey, ": ", previousObjectId, " and ", objectId,
+						"; the reference will resolve to ", objectId,
+						" non-deterministically"));
+			}
 		}
 	}
 
@@ -290,7 +306,11 @@ public class AssetReferenceObjectService {
 
 			if (objectId == null) {
 				if (_log.isWarnEnabled()) {
-					_log.warn("Failed to resolve external key " + externalKey);
+					_log.warn(
+						StringBundler.concat(
+							"Unable to resolve external key ", externalKey,
+							" to a ", converter.getObjectTypeName(),
+							" asset object"));
 				}
 
 				continue;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
@@ -1,0 +1,313 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
+import com.liferay.one.jira.exception.JiraAssetObjectException;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class AssetReferenceObjectService {
+
+	/**
+	 * Resolves a single external key to its existing asset object ID.
+	 *
+	 * @param  converter the converter describing the asset object type and its
+	 *         external key attribute
+	 * @param  externalKey the external key of the reference asset object
+	 *
+	 * @return the ID of the existing asset object, or <code>null</code> if the
+	 *         external key is <code>null</code> or no matching asset object
+	 *         exists
+	 */
+	public String fetchReferenceObjectId(
+		BaseJiraAssetObjectConverter converter, String externalKey) {
+
+		if (Validator.isNull(externalKey)) {
+			return null;
+		}
+
+		Map<String, String> externalKeyToObjectIdMap = new HashMap<>();
+
+		_putObjectIds(
+			converter, Collections.singletonList(externalKey),
+			externalKeyToObjectIdMap);
+
+		return externalKeyToObjectIdMap.get(externalKey);
+	}
+
+	/**
+	 * Resolves a collection of entities to the IDs of their existing asset
+	 * objects. Entities whose external key is <code>null</code> or does not
+	 * resolve to an existing asset object are skipped.
+	 *
+	 * @param  converter the converter describing the asset object type and its
+	 *         external key attribute
+	 * @param  entities the entities to resolve to asset objects
+	 * @param  externalKeyFunction the function that extracts an external key
+	 *         from an entity
+	 *
+	 * @return the IDs of the resolved asset objects, or <code>null</code> if
+	 *         <code>entities</code> is <code>null</code>
+	 */
+	public <T> List<String> fetchReferenceObjectIds(
+		BaseJiraAssetObjectConverter converter, Collection<T> entities,
+		Function<T, String> externalKeyFunction) {
+
+		if (entities == null) {
+			return null;
+		}
+
+		Set<String> externalKeys = new LinkedHashSet<>();
+
+		for (T entity : entities) {
+			if (entity == null) {
+				continue;
+			}
+
+			String externalKey = externalKeyFunction.apply(entity);
+
+			if (Validator.isNotNull(externalKey)) {
+				externalKeys.add(externalKey);
+			}
+		}
+
+		return _resolveToObjectIds(converter, externalKeys, null);
+	}
+
+	/**
+	 * Resolves a collection of entities to the IDs of their asset objects,
+	 * creating an asset object for any external key that does not already
+	 * resolve to one.
+	 *
+	 * @param  converter the converter describing the asset object type and its
+	 *         external key attribute
+	 * @param  entities the entities to resolve to asset objects
+	 * @param  externalKeyFunction the function that extracts an external key
+	 *         from an entity
+	 * @param  createAssetObjectFunction the function that builds the asset
+	 *         object to create for an entity whose external key is unresolved;
+	 *         must not be <code>null</code>
+	 *
+	 * @return the IDs of the resolved and newly created asset objects, or
+	 *         <code>null</code> if <code>entities</code> is <code>null</code>
+	 */
+	public <T> List<String> getOrCreateReferenceObjectIds(
+		BaseJiraAssetObjectConverter converter, Collection<T> entities,
+		Function<T, String> externalKeyFunction,
+		Function<T, JiraAssetObject> createAssetObjectFunction) {
+
+		Objects.requireNonNull(createAssetObjectFunction);
+
+		if (entities == null) {
+			return null;
+		}
+
+		Map<String, T> entitiesMap = new LinkedHashMap<>();
+
+		for (T entity : entities) {
+			if (entity == null) {
+				continue;
+			}
+
+			String externalKey = externalKeyFunction.apply(entity);
+
+			if (Validator.isNotNull(externalKey)) {
+				entitiesMap.putIfAbsent(externalKey, entity);
+			}
+		}
+
+		return _resolveToObjectIds(
+			converter, entitiesMap.keySet(),
+			externalKey -> createAssetObjectFunction.apply(
+				entitiesMap.get(externalKey)));
+	}
+
+	/**
+	 * Resolves a single external key to its existing asset object ID, throwing
+	 * an exception when no matching asset object exists.
+	 *
+	 * @param  converter the converter describing the asset object type and its
+	 *         external key attribute
+	 * @param  externalKey the external key of the reference asset object
+	 *
+	 * @return the ID of the existing asset object
+	 * @throws JiraAssetObjectException if no asset object exists for the given
+	 *         external key
+	 */
+	public String getReferenceObjectId(
+		BaseJiraAssetObjectConverter converter, String externalKey) {
+
+		String objectId = fetchReferenceObjectId(converter, externalKey);
+
+		if (objectId == null) {
+			throw new JiraAssetObjectException(
+				StringBundler.concat(
+					"No \"", converter.getObjectTypeName(),
+					"\" asset object exists for external key ", externalKey));
+		}
+
+		return objectId;
+	}
+
+	private String _createObject(
+		BaseJiraAssetObjectConverter converter, String externalKey,
+		Function<String, JiraAssetObject> createAssetObjectFunction) {
+
+		JiraAssetObject jiraAssetObject = createAssetObjectFunction.apply(
+			externalKey);
+
+		if (jiraAssetObject == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to create asset object for external key " +
+						externalKey);
+			}
+
+			return null;
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Creating asset object for unresolved external key " +
+					externalKey);
+		}
+
+		try {
+			JSONObject jsonObject = _jiraAssetService.createObject(
+				converter.getObjectTypeId(), jiraAssetObject);
+
+			return jsonObject.optString("id", null);
+		}
+		catch (Exception exception) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to create ", converter.getObjectTypeName(),
+					" asset object for external key ", externalKey),
+				exception);
+
+			return null;
+		}
+	}
+
+	private void _putObjectIds(
+		BaseJiraAssetObjectConverter converter, List<String> externalKeys,
+		Map<String, String> externalKeyToObjectIdMap) {
+
+		String externalKeyAttributeName =
+			converter.getExternalKeyAttributeName();
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetService.searchObjects(
+				converter.getAQLWithBuilder(
+					aqlBuilder -> aqlBuilder.andIn(
+						externalKeys, externalKeyAttributeName)),
+				converter::toJiraAssetObject);
+
+		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			String externalKey = jiraAssetObject.getAttributeValue(
+				externalKeyAttributeName);
+			String objectId = jiraAssetObject.getObjectId();
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Resolved external key ", externalKey,
+						" to existing asset object ", objectId));
+			}
+
+			externalKeyToObjectIdMap.put(externalKey, objectId);
+		}
+	}
+
+	private List<String> _resolveToObjectIds(
+		BaseJiraAssetObjectConverter converter, Collection<String> externalKeys,
+		Function<String, JiraAssetObject> createAssetObjectFunction) {
+
+		List<String> resolvedObjectIds = new ArrayList<>();
+
+		Set<String> uniqueExternalKeys = new LinkedHashSet<>();
+
+		for (String externalKey : externalKeys) {
+			if (Validator.isNotNull(externalKey)) {
+				uniqueExternalKeys.add(externalKey);
+			}
+		}
+
+		if (uniqueExternalKeys.isEmpty()) {
+			return resolvedObjectIds;
+		}
+
+		Map<String, String> externalKeyToObjectIdMap = new HashMap<>();
+
+		List<String> uniqueExternalKeysList = new ArrayList<>(
+			uniqueExternalKeys);
+
+		for (int i = 0; i < uniqueExternalKeysList.size(); i += _CHUNK_SIZE) {
+			_putObjectIds(
+				converter,
+				uniqueExternalKeysList.subList(
+					i,
+					Math.min(i + _CHUNK_SIZE, uniqueExternalKeysList.size())),
+				externalKeyToObjectIdMap);
+		}
+
+		for (String externalKey : uniqueExternalKeysList) {
+			String objectId = externalKeyToObjectIdMap.get(externalKey);
+
+			if ((objectId == null) && (createAssetObjectFunction != null)) {
+				objectId = _createObject(
+					converter, externalKey, createAssetObjectFunction);
+			}
+
+			if (objectId == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Failed to resolve external key " + externalKey);
+				}
+
+				continue;
+			}
+
+			resolvedObjectIds.add(objectId);
+		}
+
+		return resolvedObjectIds;
+	}
+
+	private static final int _CHUNK_SIZE = 50;
+
+	private static final Log _log = LogFactory.getLog(
+		AssetReferenceObjectService.class);
+
+	@Autowired
+	private JiraAssetService _jiraAssetService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaLoader.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaLoader.java
@@ -9,7 +9,9 @@ import com.liferay.one.jira.exception.JiraAssetSchemaException;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -19,7 +21,8 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 /**
- * Caches and resolves JSM Assets schema metadata to attribute name-to-id maps.
+ * Caches and resolves JSM Assets schema metadata to attribute name-to-id and
+ * name-to-options maps.
  *
  * @author Drew Brokke
  */
@@ -30,6 +33,36 @@ public class AssetSchemaLoader {
 	public Map<String, String> getAttributeIds(String objectTypeId) {
 		return _toNameIdMap(
 			_jiraAssetService.getObjectTypeAttributes(objectTypeId));
+	}
+
+	@Cacheable("assetObjectTypeAttributeOptions")
+	public Map<String, Set<String>> getAttributeOptions(String objectTypeId) {
+		Map<String, Set<String>> attributeOptions = new LinkedHashMap<>();
+
+		JSONArray attributesJSONArray =
+			_jiraAssetService.getObjectTypeAttributes(objectTypeId);
+
+		for (int i = 0; i < attributesJSONArray.length(); i++) {
+			JSONObject attributeJSONObject = attributesJSONArray.getJSONObject(
+				i);
+
+			String name = attributeJSONObject.optString("name");
+			String options = attributeJSONObject.optString("options");
+
+			if (Validator.isNull(name) || Validator.isNull(options)) {
+				continue;
+			}
+
+			Set<String> optionsSet = new LinkedHashSet<>();
+
+			for (String option : options.split(",")) {
+				optionsSet.add(option.trim());
+			}
+
+			attributeOptions.put(name, optionsSet);
+		}
+
+		return attributeOptions;
 	}
 
 	@Cacheable("assetObjectTypeIds")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetSchemaService.java
@@ -9,6 +9,7 @@ import com.liferay.one.jira.exception.JiraAssetSchemaException;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,13 @@ public class AssetSchemaService {
 		String schemaName, String objectTypeName) {
 
 		return _assetSchemaLoader.getAttributeIds(
+			getObjectTypeId(schemaName, objectTypeName));
+	}
+
+	public Map<String, Set<String>> getAttributeOptions(
+		String schemaName, String objectTypeName) {
+
+		return _assetSchemaLoader.getAttributeOptions(
 			getObjectTypeId(schemaName, objectTypeName));
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -18,13 +18,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -36,16 +41,29 @@ public class JiraAssetService extends BaseJiraService {
 	public JSONObject createObject(
 		String objectTypeId, JiraAssetObject jiraAssetObject) {
 
-		String response = post(
-			new JSONObject(
-			).put(
-				"attributes", jiraAssetObject.toAttributesJSONArray()
-			).put(
-				"objectTypeId", objectTypeId
-			).toString(),
-			_headers(), _objectURI("create"));
+		String requestBody = new JSONObject(
+		).put(
+			"attributes", jiraAssetObject.toAttributesJSONArray()
+		).put(
+			"objectTypeId", objectTypeId
+		).toString();
 
-		return _toJSONObject(response);
+		try {
+			String response = post(
+				requestBody, _headers(), _objectURI("create"));
+
+			return _toJSONObject(response);
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to create asset object with object type ",
+					objectTypeId, ": ",
+					webClientResponseException.getResponseBodyAsString(),
+					"; request body: ", requestBody));
+
+			throw webClientResponseException;
+		}
 	}
 
 	public JSONObject deleteObject(String objectId) {
@@ -87,7 +105,7 @@ public class JiraAssetService extends BaseJiraService {
 	}
 
 	public JSONArray getObjectTypeAttributes(String objectTypeId) {
-		return new JSONArray(
+		return _toJSONArray(
 			get(
 				getAuthorization(),
 				_v1URI(
@@ -96,7 +114,7 @@ public class JiraAssetService extends BaseJiraService {
 	}
 
 	public JSONArray getObjectTypes(String schemaId) {
-		return new JSONArray(
+		return _toJSONArray(
 			get(
 				getAuthorization(),
 				_v1URI(
@@ -147,14 +165,26 @@ public class JiraAssetService extends BaseJiraService {
 	public JSONObject updateObject(
 		String objectId, JiraAssetObject jiraAssetObject) {
 
-		String response = put(
-			new JSONObject(
-			).put(
-				"attributes", jiraAssetObject.toAttributesJSONArray()
-			).toString(),
-			_headers(), _objectURI(objectId));
+		String requestBody = new JSONObject(
+		).put(
+			"attributes", jiraAssetObject.toAttributesJSONArray()
+		).toString();
 
-		return _toJSONObject(response);
+		try {
+			String response = put(
+				requestBody, _headers(), _objectURI(objectId));
+
+			return _toJSONObject(response);
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to update asset object ", objectId, ": ",
+					webClientResponseException.getResponseBodyAsString(),
+					"; request body: ", requestBody));
+
+			throw webClientResponseException;
+		}
 	}
 
 	private JSONObject _getObjectSchemasPageJSONObject(int startAt) {
@@ -203,12 +233,39 @@ public class JiraAssetService extends BaseJiraService {
 		return _toJSONObject(response);
 	}
 
+	private JSONArray _toJSONArray(String response) {
+		if (Validator.isNull(response)) {
+			return new JSONArray();
+		}
+
+		try {
+			return new JSONArray(response);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to parse JSON array response", jsonException);
+			}
+
+			return new JSONArray();
+		}
+	}
+
 	private JSONObject _toJSONObject(String response) {
 		if (Validator.isNull(response)) {
 			return new JSONObject();
 		}
 
-		return new JSONObject(response);
+		try {
+			return new JSONObject(response);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to parse JSON object response", jsonException);
+			}
+
+			return new JSONObject();
+		}
 	}
 
 	private URI _v1URI(String path) {
@@ -224,6 +281,8 @@ public class JiraAssetService extends BaseJiraService {
 		"https://api.atlassian.com";
 
 	private static final int _MAX_RESULTS = 100;
+
+	private static final Log _log = LogFactory.getLog(JiraAssetService.class);
 
 	@Value("${liferay.one.jira.workspace.id}")
 	private String _jiraWorkspaceId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraBusinessEventService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraBusinessEventService.java
@@ -139,7 +139,8 @@ public class JiraBusinessEventService {
 		allEntries = true,
 		value = {
 			"assetObjectFieldOptions", "assetObjectTypeAttributeIds",
-			"assetObjectTypeIds", "productVersions"
+			"assetObjectTypeAttributeOptions", "assetObjectTypeIds",
+			"productVersions"
 		}
 	)
 	@Scheduled(cron = "0 0 0 * * *")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
@@ -5,9 +5,12 @@
 
 package com.liferay.one.jira.util;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Collection;
 
 /**
  * @author Drew Brokke
@@ -40,6 +43,24 @@ public class AQLUtil {
 			_sb.append(_field(fieldNames));
 			_sb.append(" = ");
 			_sb.append(objectId);
+
+			return this;
+		}
+
+		public Builder andIn(Collection<String> values, String... fieldNames) {
+			if (values.isEmpty()) {
+				throw new IllegalArgumentException(
+					"An IN clause requires at least one value");
+			}
+
+			_sb.append(" AND ");
+			_sb.append(_field(fieldNames));
+			_sb.append(" IN (");
+			_sb.append(
+				StringUtil.merge(
+					TransformUtil.transform(values, AQLUtil::_quote),
+					StringPool.COMMA_AND_SPACE));
+			_sb.append(")");
 
 			return this;
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/AccountSupportInfo.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/AccountSupportInfo.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.model;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountSupportInfo {
+
+	public AccountSupportInfo(String supportLanguage, String supportRegion) {
+		_supportLanguage = supportLanguage;
+		_supportRegion = supportRegion;
+	}
+
+	public String getSupportLanguage() {
+		return _supportLanguage;
+	}
+
+	public String getSupportRegion() {
+		return _supportRegion;
+	}
+
+	private final String _supportLanguage;
+	private final String _supportRegion;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Property.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Property.java
@@ -5,6 +5,8 @@
 
 package com.liferay.one.model;
 
+import com.liferay.portal.kernel.util.Validator;
+
 import org.json.JSONObject;
 
 /**
@@ -15,6 +17,20 @@ public class Property {
 	public Property(JSONObject jsonObject) {
 		_accountEntryId = jsonObject.optLong(
 			"r_accountEntryToProperty_accountEntryId");
+		_className = jsonObject.optString("className");
+		_classNameId = jsonObject.optLong("classNameId");
+		_classPK = jsonObject.optLong("classPK");
+		_externalReferenceCode = jsonObject.optString("externalReferenceCode");
+
+		String metadataJSON = jsonObject.optString("metadataJson");
+
+		if (Validator.isNotNull(metadataJSON)) {
+			_metadataJSONObject = new JSONObject(metadataJSON);
+		}
+		else {
+			_metadataJSONObject = new JSONObject();
+		}
+
 		_name = jsonObject.optString("name");
 		_propertyId = jsonObject.getLong("id");
 		_value = jsonObject.optString("value");
@@ -22,6 +38,26 @@ public class Property {
 
 	public long getAccountEntryId() {
 		return _accountEntryId;
+	}
+
+	public String getClassName() {
+		return _className;
+	}
+
+	public long getClassNameId() {
+		return _classNameId;
+	}
+
+	public long getClassPK() {
+		return _classPK;
+	}
+
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public JSONObject getMetadataJSONObject() {
+		return _metadataJSONObject;
 	}
 
 	public String getName() {
@@ -37,6 +73,11 @@ public class Property {
 	}
 
 	private final long _accountEntryId;
+	private final String _className;
+	private final long _classNameId;
+	private final long _classPK;
+	private final String _externalReferenceCode;
+	private final JSONObject _metadataJSONObject;
 	private final String _name;
 	private final long _propertyId;
 	private final String _value;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -211,6 +211,18 @@ public class AccountService extends OneBaseService {
 		return accountResource.getAccount(accountEntryId);
 	}
 
+	public Account getAccount(String externalReferenceCode) throws Exception {
+		AccountResource accountResource = AccountResource.builder(
+		).endpoint(
+			lxcDXPMainDomain, lxcDXPServerProtocol
+		).header(
+			HttpHeaders.AUTHORIZATION, getAuthorization()
+		).build();
+
+		return accountResource.getAccountByExternalReferenceCode(
+			externalReferenceCode);
+	}
+
 	public Account getAccount(String externalReferenceCode, Jwt jwt)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -18,10 +18,11 @@ import com.liferay.headless.commerce.admin.order.client.pagination.Pagination;
 import com.liferay.headless.commerce.admin.order.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
 import com.liferay.one.constants.CommerceOrderConstants;
-import com.liferay.one.constants.SupportRegionConstants;
+import com.liferay.one.model.AccountSupportInfo;
 import com.liferay.one.salesforce.model.SalesforceOpportunity;
 import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
 import com.liferay.one.salesforce.model.SalesforceProject;
+import com.liferay.one.util.SupportLanguageUtil;
 import com.liferay.one.util.SupportRegionUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -176,6 +177,19 @@ public class CommerceOrderService extends OneBaseService {
 		return orders;
 	}
 
+	public AccountSupportInfo getAccountSupportInfo(
+			long accountId, Long defaultBillingAddressId)
+		throws Exception {
+
+		String opportunitySoldBy = _getOpportunitySoldBy(accountId);
+		String addressCountry = _getAddressCountry(defaultBillingAddressId);
+
+		return new AccountSupportInfo(
+			SupportLanguageUtil.getLanguage(opportunitySoldBy, addressCountry),
+			SupportRegionUtil.getSupportRegion(
+				opportunitySoldBy, addressCountry));
+	}
+
 	public Order getCommerceOrder(long commerceOrderId) throws Exception {
 		OrderResource orderResource = _buildOrderResource();
 
@@ -203,44 +217,6 @@ public class CommerceOrderService extends OneBaseService {
 		}
 
 		return orders;
-	}
-
-	public String getSupportRegion(long accountId, Long defaultBillingAddressId)
-		throws Exception {
-
-		String addressCountry = null;
-
-		if (Validator.isNotNull(defaultBillingAddressId)) {
-			PostalAddress postalAddress =
-				_postalAddressService.getPostalAddress(defaultBillingAddressId);
-
-			addressCountry = postalAddress.getAddressCountry();
-		}
-
-		OrderResource orderResource = _buildOrderResource();
-
-		Page<Order> ordersPage = orderResource.getOrdersPage(
-			null, "accountId/any(x:x eq " + accountId + ")", null, null);
-
-		for (Order order : ordersPage.getItems()) {
-			Map<String, String> customFields =
-				(Map<String, String>)order.getCustomFields();
-
-			if (customFields == null) {
-				continue;
-			}
-
-			String opportunitySoldBy = customFields.get("opportunitySoldBy");
-
-			if (Validator.isNull(opportunitySoldBy)) {
-				continue;
-			}
-
-			return SupportRegionUtil.getSupportRegion(
-				opportunitySoldBy, addressCountry);
-		}
-
-		return SupportRegionConstants.GLOBAL;
 	}
 
 	public void patchOrderCustomFields(
@@ -399,6 +375,19 @@ public class CommerceOrderService extends OneBaseService {
 		return _channelId;
 	}
 
+	private String _getAddressCountry(Long defaultBillingAddressId)
+		throws Exception {
+
+		if (Validator.isNull(defaultBillingAddressId)) {
+			return null;
+		}
+
+		PostalAddress postalAddress = _postalAddressService.getPostalAddress(
+			defaultBillingAddressId);
+
+		return postalAddress.getAddressCountry();
+	}
+
 	private Map<String, Object> _getCustomFields(
 		Long contractId, SalesforceOpportunity salesforceOpportunity,
 		SalesforceProject salesforceProject) {
@@ -519,6 +508,30 @@ public class CommerceOrderService extends OneBaseService {
 			).toString());
 
 		return customFields;
+	}
+
+	private String _getOpportunitySoldBy(long accountId) throws Exception {
+		OrderResource orderResource = _buildOrderResource();
+
+		Page<Order> ordersPage = orderResource.getOrdersPage(
+			null, "accountId/any(x:x eq " + accountId + ")", null, null);
+
+		for (Order order : ordersPage.getItems()) {
+			Map<String, String> customFields =
+				(Map<String, String>)order.getCustomFields();
+
+			if (customFields == null) {
+				continue;
+			}
+
+			String opportunitySoldBy = customFields.get("opportunitySoldBy");
+
+			if (Validator.isNotNull(opportunitySoldBy)) {
+				return opportunitySoldBy;
+			}
+		}
+
+		return null;
 	}
 
 	private BigDecimal _getTotal(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementDefinitionService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementDefinitionService.java
@@ -20,12 +20,20 @@ import org.springframework.stereotype.Component;
 public class EntitlementDefinitionService extends OneBaseService {
 
 	public List<EntitlementDefinition> getEntitlementDefinitions(
+			String filterString)
+		throws Exception {
+
+		return getAllItems(
+			"/o/c/entitlementdefinitions", filterString,
+			EntitlementDefinition::new);
+	}
+
+	public List<EntitlementDefinition> getEntitlementDefinitions(
 			String filterString, Map<String, String> productOptions)
 		throws Exception {
 
-		List<EntitlementDefinition> entitlementDefinitions = getAllItems(
-			"/o/c/entitlementdefinitions", filterString,
-			EntitlementDefinition::new);
+		List<EntitlementDefinition> entitlementDefinitions =
+			getEntitlementDefinitions(filterString);
 
 		Iterator<EntitlementDefinition> iterator =
 			entitlementDefinitions.iterator();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -184,6 +184,19 @@ public class EntitlementService extends OneBaseService {
 		}
 	}
 
+	public List<Entitlement> getActiveEntitlements(long accountEntryId)
+		throws Exception {
+
+		Instant instant = Instant.now();
+
+		return getEntitlements(
+			StringBundler.concat(
+				"(endDate eq null or endDate ge ", instant,
+				") and (r_accountEntryToEntitlement_accountEntryId eq '",
+				accountEntryId, "') and (startDate eq null or startDate le ",
+				instant, ")"));
+	}
+
 	public List<Entitlement> getEntitlements(String filterString)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
@@ -5,7 +5,13 @@
 
 package com.liferay.one.service;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.pagination.Page;
+import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.OrganizationResource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -27,6 +33,34 @@ public class OrganizationService extends OneBaseService {
 			String.valueOf(organizationId), emailAddress);
 	}
 
+	public List<Organization> getAccountOrganizations(long accountId)
+		throws Exception {
+
+		OrganizationResource organizationResource =
+			_buildOrganizationResource();
+
+		List<Organization> organizations = new ArrayList<>();
+
+		int page = 1;
+
+		while (true) {
+			Page<Organization> organizationsPage =
+				organizationResource.getAccountOrganizationsPage(
+					accountId, null, null, Pagination.of(page, _PAGE_SIZE),
+					null);
+
+			organizations.addAll(organizationsPage.getItems());
+
+			if (page >= organizationsPage.getLastPage()) {
+				break;
+			}
+
+			page++;
+		}
+
+		return organizations;
+	}
+
 	public void removeOrganizationUserAccountByEmailAddress(
 			String emailAddress, long organizationId)
 		throws Exception {
@@ -46,5 +80,7 @@ public class OrganizationService extends OneBaseService {
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
 	}
+
+	private static final int _PAGE_SIZE = 500;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectService.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
 
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -49,6 +51,13 @@ public class ProjectService extends OneBaseService {
 			).toUri());
 
 		return new Project(new JSONObject(response));
+	}
+
+	public List<Project> getProjects(long accountId) throws Exception {
+		return getAllItems(
+			"/o/c/projects",
+			"r_accountEntryToProject_accountEntryId eq '" + accountId + "'",
+			Project::new);
 	}
 
 	public void upsertProject(SalesforceProject salesforceProject)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PropertyService.java
@@ -43,6 +43,25 @@ public class PropertyService extends OneBaseService {
 		return new Property(new JSONObject(response));
 	}
 
+	public List<Property> getAccountProperties(long accountId)
+		throws Exception {
+
+		return getProperties(
+			StringBundler.concat(
+				"(r_accountEntryToProperty_accountEntryId eq '", accountId,
+				"')"));
+	}
+
+	public List<Property> getAccountPropertiesByName(
+			long accountId, String name)
+		throws Exception {
+
+		return getProperties(
+			StringBundler.concat(
+				"(r_accountEntryToProperty_accountEntryId eq '", accountId,
+				"') and (name eq '", name, "')"));
+	}
+
 	public List<Property> getProperties(String filterString) throws Exception {
 		return getAllItems("/o/c/properties", filterString, Property::new);
 	}
@@ -50,12 +69,7 @@ public class PropertyService extends OneBaseService {
 	public String getPropertyValue(long accountId, String name)
 		throws Exception {
 
-		List<Property> properties = getAllItems(
-			"/o/c/properties",
-			StringBundler.concat(
-				"(r_accountEntryToProperty_accountEntryId eq '", accountId,
-				"') and (name eq '", name, "')"),
-			Property::new);
+		List<Property> properties = getAccountPropertiesByName(accountId, name);
 
 		if (properties.isEmpty()) {
 			return null;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningEmailService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningEmailService.java
@@ -12,6 +12,7 @@ import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.constants.OpportunityConstants;
 import com.liferay.one.constants.RoleConstants;
 import com.liferay.one.constants.SupportRegionConstants;
+import com.liferay.one.model.AccountSupportInfo;
 import com.liferay.one.model.Project;
 import com.liferay.one.model.ProjectMembership;
 import com.liferay.one.util.LocaleUtil;
@@ -243,9 +244,12 @@ public class ProvisioningEmailService extends OneBaseService {
 		String provisioningEmailAddress = null;
 
 		for (Account account : accounts) {
+			AccountSupportInfo accountSupportInfo =
+				_commerceOrderService.getAccountSupportInfo(
+					account.getId(), account.getDefaultBillingAddressId());
+
 			String curProvisioningEmailAddress = _getRegionEmailAddress(
-				_commerceOrderService.getSupportRegion(
-					account.getId(), account.getDefaultBillingAddressId()));
+				accountSupportInfo.getSupportRegion());
 
 			if ((provisioningEmailAddress != null) &&
 				!provisioningEmailAddress.equals(curProvisioningEmailAddress)) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/SupportLanguageUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/SupportLanguageUtil.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.util;
+
+import com.liferay.one.constants.SupportLanguageConstants;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
+
+/**
+ * @author Drew Brokke
+ */
+public class SupportLanguageUtil {
+
+	public static String getLanguage(String soldBy, String countryName) {
+		if (Validator.isNull(soldBy)) {
+			return SupportLanguageConstants.ENGLISH;
+		}
+
+		if (soldBy.equals("Liferay Africa") ||
+			soldBy.equals("Liferay Australia") ||
+			soldBy.equals("Liferay Canada") ||
+			soldBy.equals("Liferay France") ||
+			soldBy.equals("Liferay Germany") ||
+			soldBy.equals("Liferay Hungary") ||
+			soldBy.equals("Liferay India") ||
+			soldBy.equals("Liferay International") ||
+			soldBy.equals("Liferay Italy") ||
+			soldBy.equals("Liferay Middle East") ||
+			soldBy.equals("Liferay Netherlands") ||
+			soldBy.equals("Liferay Nordic") ||
+			soldBy.equals("Liferay Singapore") || soldBy.equals("Liferay UK") ||
+			soldBy.equals("Liferay US")) {
+
+			return SupportLanguageConstants.ENGLISH;
+		}
+		else if (soldBy.equals("Liferay Brazil")) {
+			if (Objects.equals(countryName, "Brazil")) {
+				return SupportLanguageConstants.PORTUGUESE;
+			}
+
+			return SupportLanguageConstants.SPANISH;
+		}
+		else if (soldBy.equals("Liferay China")) {
+			if (Objects.equals(countryName, "China")) {
+				return SupportLanguageConstants.CHINESE;
+			}
+
+			return SupportLanguageConstants.ENGLISH;
+		}
+		else if (soldBy.equals("Liferay Japan")) {
+			return SupportLanguageConstants.JAPANESE;
+		}
+		else if (soldBy.equals("Liferay Spain")) {
+			if (Objects.equals(countryName, "Cyprus") ||
+				Objects.equals(countryName, "Greece") ||
+				Objects.equals(countryName, "Italy") ||
+				Objects.equals(countryName, "Portugal")) {
+
+				return SupportLanguageConstants.ENGLISH;
+			}
+
+			return SupportLanguageConstants.SPANISH;
+		}
+
+		return SupportLanguageConstants.ENGLISH;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90495

## What is being fixed

Accounts and their Projects are not yet pushed to JSM as Account assets. The connector had no way to send a full Account snapshot — assigned teams, customer and worker contacts, entitlements, external links, postal addresses, business events, and support language/region — to the One Liferay asset schema. Asset write failures were also opaque: JSM rejections surfaced as a bare "400 Bad Request" with no indication of which attribute was rejected, and a single failed reference object aborted the entire sync.

## How it is being fixed

A new AccountSyncService assembles the Account asset attribute values and upserts one Account asset per account plus one per project, exposed through new sync endpoints on the Account and Project REST controllers. AssetReferenceObjectService resolves reference attributes by external key with an optional create fallback, JiraAssetObject supports multiple values per attribute, and select type attributes validate values against the available options. When JSM rejects a write, JiraAssetService now logs the response body and request payload, and a failed get-or-create of a reference object (for example an External Link) logs the cause and omits the value instead of aborting the sync. Account role associations are intentionally excluded and will follow separately (LPD-98406).
