### PR TITLE
LPD-89424 Skip entitlement generation for products without entitlement definitions

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -141,6 +141,18 @@ public class EntitlementService extends OneBaseService {
 					orderItem.getProductId(), "') and (active eq true)"),
 				OrderItemUtil.getProductOptions(orderItem));
 
+		if (entitlementDefinitions.isEmpty()) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Skipping order item ", commerceOrderItemId,
+						": no active entitlement definitions matched product ",
+						orderItem.getProductId()));
+			}
+
+			return;
+		}
+
 		Order order = _commerceOrderService.fetchCommerceOrder(
 			orderItem.getOrderId());
 


### PR DESCRIPTION
Order items whose product has no active entitlement definitions (e.g. Marketplace apps) now skip entitlement generation with an early return and an INFO log, instead of fetching the parent order and silently iterating an empty definitions list. No behavior change for products with definitions — the definition association remains the single switch for whether a product grants entitlements.