### PR TITLE
LPD-90495 Harden account sync error handling and determinism

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ExternalLinkConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/ExternalLinkConverter.java
@@ -27,18 +27,22 @@ public class ExternalLinkConverter extends BaseJiraAssetObjectConverter {
 		return ExternalLinkConstants.OBJECT_TYPE_NAME;
 	}
 
+	public boolean isExternalLinkProperty(Property property) {
+		if (_toExternalLinkInfo(property) != null) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public JiraAssetObject toAssetObject(Property property) {
-		JiraAssetObject jiraAssetObject = createJiraAssetObject();
+		ExternalLinkInfo externalLinkInfo = _toExternalLinkInfo(property);
 
-		List<String> parts = StringUtil.split(
-			property.getName(), CharPool.COLON);
-
-		if (parts.size() != 2) {
+		if (externalLinkInfo == null) {
 			return null;
 		}
 
-		String domain = parts.get(0);
-		String entityName = parts.get(1);
+		JiraAssetObject jiraAssetObject = createJiraAssetObject();
 
 		jiraAssetObject.setAttributeValue(
 			ExternalLinkConstants.ATTRIBUTE_NAME_NAME, property.getClassName());
@@ -46,12 +50,14 @@ public class ExternalLinkConverter extends BaseJiraAssetObjectConverter {
 			ExternalLinkConstants.ATTRIBUTE_NAME_EXTERNAL_KEY,
 			property.getExternalReferenceCode());
 		jiraAssetObject.setAttributeValue(
-			ExternalLinkConstants.ATTRIBUTE_NAME_DOMAIN, domain);
+			ExternalLinkConstants.ATTRIBUTE_NAME_DOMAIN,
+			externalLinkInfo.getDomain());
 		jiraAssetObject.setAttributeValue(
 			ExternalLinkConstants.ATTRIBUTE_NAME_ENTITY_ID,
 			property.getValue());
 		jiraAssetObject.setAttributeValue(
-			ExternalLinkConstants.ATTRIBUTE_NAME_ENTITY_NAME, entityName);
+			ExternalLinkConstants.ATTRIBUTE_NAME_ENTITY_NAME,
+			externalLinkInfo.getEntityName());
 
 		return jiraAssetObject;
 	}
@@ -61,7 +67,38 @@ public class ExternalLinkConverter extends BaseJiraAssetObjectConverter {
 		return _schemaName;
 	}
 
+	private ExternalLinkInfo _toExternalLinkInfo(Property property) {
+		List<String> parts = StringUtil.split(
+			property.getName(), CharPool.COLON);
+
+		if (parts.size() != 2) {
+			return null;
+		}
+
+		return new ExternalLinkInfo(parts.get(0), parts.get(1));
+	}
+
 	@Value("${liferay.one.jira.asset.schema.name}")
 	private String _schemaName;
+
+	private static class ExternalLinkInfo {
+
+		public ExternalLinkInfo(String domain, String entityName) {
+			_domain = domain;
+			_entityName = entityName;
+		}
+
+		public String getDomain() {
+			return _domain;
+		}
+
+		public String getEntityName() {
+			return _entityName;
+		}
+
+		private final String _domain;
+		private final String _entityName;
+
+	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
@@ -34,7 +34,6 @@ import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.function.transform.TransformUtil;
-import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -291,10 +290,7 @@ public class AccountSyncService {
 			account.getId());
 
 		for (Property property : properties) {
-			String[] split = StringUtil.split(
-				property.getName(), CharPool.COLON);
-
-			if (split.length == 2) {
+			if (_externalLinkConverter.isExternalLinkProperty(property)) {
 				externalLinkProperties.add(property);
 			}
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountSyncService.java
@@ -18,6 +18,7 @@ import com.liferay.one.jira.converter.EntitlementConverter;
 import com.liferay.one.jira.converter.ExternalLinkConverter;
 import com.liferay.one.jira.converter.PostalAddressConverter;
 import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.exception.AccountNotFoundException;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.model.JiraBusinessEvent;
 import com.liferay.one.model.AccountSupportInfo;
@@ -98,8 +99,17 @@ public class AccountSyncService {
 					" to JSM");
 		}
 
+		String accountExternalReferenceCode =
+			project.getAccountExternalReferenceCode();
+
+		if (Validator.isNull(accountExternalReferenceCode)) {
+			throw new AccountNotFoundException(
+				"Project " + project.getExternalReferenceCode() +
+					" has no account external reference code");
+		}
+
 		Account account = _accountService.getAccount(
-			project.getAccountExternalReferenceCode());
+			accountExternalReferenceCode);
 
 		_syncAccountAsset(
 			account, _getAccountAttributeValues(account),

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AssetReferenceObjectService.java
@@ -247,7 +247,7 @@ public class AssetReferenceObjectService {
 						objectId));
 			}
 
-			String previousObjectId = externalKeyToObjectIdMap.put(
+			String previousObjectId = externalKeyToObjectIdMap.putIfAbsent(
 				externalKey, objectId);
 
 			if ((previousObjectId != null) &&
@@ -258,8 +258,8 @@ public class AssetReferenceObjectService {
 					StringBundler.concat(
 						"Multiple asset objects share external key ",
 						externalKey, ": ", previousObjectId, " and ", objectId,
-						"; the reference will resolve to ", objectId,
-						" non-deterministically"));
+						"; the reference will resolve to the first match ",
+						previousObjectId));
 			}
 		}
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -5,6 +5,7 @@
 
 package com.liferay.one.jira.service;
 
+import com.liferay.one.jira.exception.JiraAssetSchemaException;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -105,21 +106,24 @@ public class JiraAssetService extends BaseJiraService {
 	}
 
 	public JSONArray getObjectTypeAttributes(String objectTypeId) {
-		return _toJSONArray(
+		return _toSchemaJSONArray(
 			get(
 				getAuthorization(),
 				_v1URI(
 					StringBundler.concat(
-						"objecttype/", objectTypeId, "/attributes"))));
+						"objecttype/", objectTypeId, "/attributes"))),
+			"Unable to parse attributes response for object type " +
+				objectTypeId);
 	}
 
 	public JSONArray getObjectTypes(String schemaId) {
-		return _toJSONArray(
+		return _toSchemaJSONArray(
 			get(
 				getAuthorization(),
 				_v1URI(
 					StringBundler.concat(
-						"objectschema/", schemaId, "/objecttypes"))));
+						"objectschema/", schemaId, "/objecttypes"))),
+			"Unable to parse object types response for schema " + schemaId);
 	}
 
 	public JSONArray searchObjects(String aql) {
@@ -233,23 +237,6 @@ public class JiraAssetService extends BaseJiraService {
 		return _toJSONObject(response);
 	}
 
-	private JSONArray _toJSONArray(String response) {
-		if (Validator.isNull(response)) {
-			return new JSONArray();
-		}
-
-		try {
-			return new JSONArray(response);
-		}
-		catch (JSONException jsonException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to parse JSON array response", jsonException);
-			}
-
-			return new JSONArray();
-		}
-	}
-
 	private JSONObject _toJSONObject(String response) {
 		if (Validator.isNull(response)) {
 			return new JSONObject();
@@ -265,6 +252,19 @@ public class JiraAssetService extends BaseJiraService {
 			}
 
 			return new JSONObject();
+		}
+	}
+
+	private JSONArray _toSchemaJSONArray(String response, String message) {
+		if (Validator.isNull(response)) {
+			throw new JiraAssetSchemaException(message + ": empty response");
+		}
+
+		try {
+			return new JSONArray(response);
+		}
+		catch (JSONException jsonException) {
+			throw new JiraAssetSchemaException(message, jsonException);
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -15,6 +15,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import java.util.List;
 import java.util.Map;
@@ -199,7 +200,10 @@ public class EntitlementService extends OneBaseService {
 	public List<Entitlement> getActiveEntitlements(long accountEntryId)
 		throws Exception {
 
-		Instant instant = Instant.now();
+		Instant instant = Instant.now(
+		).truncatedTo(
+			ChronoUnit.MILLIS
+		);
 
 		return getEntitlements(
 			StringBundler.concat(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98953

## What is being fixed

Review findings from the account sync work (LPD-90495) collected on LPD-98953: swallowed JSM schema parse errors could poison the @Cacheable schema maps and silently blank every subsequent sync, a project with no account ERC produced an opaque HTTP 500, duplicate external keys resolved to a different asset object on each run, and the raw Instant.now() literal in the entitlement OData filter could be rejected when the JVM emits sub-millisecond precision.

## How it is being fixed

Schema lookups now parse strictly and throw JiraAssetSchemaException on an empty or malformed response, so nothing is cached on failure and the error surfaces. Project sync validates the account external reference code up front and throws AccountNotFoundException, which maps to a meaningful 404. Duplicate external keys now deterministically resolve to the first match, with a warning naming both objects. The active entitlement filter timestamp is truncated to millisecond precision.

Ticket items addressed: 1, 4, 5, 6, and 8 (external link parsing consolidation, already merged into this branch). Deferred to sub-tasks under LPD-90495: 7 (async sync dispatch) and 9 (redundant schema fetches on cold cache).
