### PR TITLE
LPD-98655 Replace portal-kernel XML/LocaleUtil in the client extension

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/TrialRestController.java
@@ -19,10 +19,10 @@ import com.liferay.one.service.ConsoleService;
 import com.liferay.one.service.NotificationQueueEntryService;
 import com.liferay.one.service.NotificationTemplateService;
 import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.LocaleUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -5,18 +5,18 @@
 
 package com.liferay.one.license;
 
+import com.liferay.one.util.LocaleUtil;
+import com.liferay.one.xml.Document;
+import com.liferay.one.xml.Element;
+import com.liferay.one.xml.SAXReaderUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.xml.Document;
-import com.liferay.portal.kernel.xml.Element;
-import com.liferay.portal.kernel.xml.SAXReaderUtil;
 
 import java.text.DateFormat;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/LocaleUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/LocaleUtil.java
@@ -14,6 +14,8 @@ import java.util.Locale;
  */
 public class LocaleUtil {
 
+	public static final Locale US = Locale.forLanguageTag("en-US");
+
 	public static Locale fromLanguageId(String languageId) {
 		return Locale.forLanguageTag(StringUtil.replace(languageId, '_', '-'));
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/Document.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/Document.java
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.xml;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class Document {
+
+	public Element addElement(String name) {
+		_rootElement = new Element(name);
+
+		return _rootElement;
+	}
+
+	public String formattedString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+
+		if (_rootElement != null) {
+			_rootElement.write(sb, StringPool.BLANK);
+		}
+
+		return sb.toString();
+	}
+
+	public Element getRootElement() {
+		return _rootElement;
+	}
+
+	public void setRootElement(Element rootElement) {
+		_rootElement = rootElement;
+	}
+
+	private Element _rootElement;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/Element.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/Element.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.xml;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class Element {
+
+	public Element(String name) {
+		_name = name;
+	}
+
+	public void add(Element element) {
+		_elements.add(element);
+	}
+
+	public Element addElement(String name) {
+		Element element = new Element(name);
+
+		_elements.add(element);
+
+		return element;
+	}
+
+	public void addText(String text) {
+		_text = text;
+	}
+
+	public void write(StringBundler sb, String indent) {
+		sb.append(indent);
+		sb.append(StringPool.LESS_THAN);
+		sb.append(_name);
+
+		if (_elements.isEmpty() && (_text == null)) {
+			sb.append("/>\n");
+
+			return;
+		}
+
+		sb.append(StringPool.GREATER_THAN);
+
+		if (_elements.isEmpty()) {
+			sb.append(_escape(_text));
+			sb.append("</");
+			sb.append(_name);
+			sb.append(StringPool.GREATER_THAN);
+			sb.append(StringPool.NEW_LINE);
+
+			return;
+		}
+
+		sb.append(StringPool.NEW_LINE);
+
+		for (Element element : _elements) {
+			element.write(sb, indent + StringPool.TAB);
+		}
+
+		sb.append(indent);
+		sb.append("</");
+		sb.append(_name);
+		sb.append(StringPool.GREATER_THAN);
+		sb.append(StringPool.NEW_LINE);
+	}
+
+	private String _escape(String text) {
+		text = StringUtil.replace(text, '&', "&amp;");
+		text = StringUtil.replace(text, '<', "&lt;");
+		text = StringUtil.replace(text, '>', "&gt;");
+
+		return text;
+	}
+
+	private final List<Element> _elements = new ArrayList<>();
+	private final String _name;
+	private String _text;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/SAXReaderUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/xml/SAXReaderUtil.java
@@ -1,0 +1,111 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.xml;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class SAXReaderUtil {
+
+	public static Document createDocument() {
+		return new Document();
+	}
+
+	public static Document read(String xml) {
+		Document document = new Document();
+
+		int[] position = {0};
+
+		document.setRootElement(_read(xml, position));
+
+		return document;
+	}
+
+	private static boolean _isNameEnd(char c) {
+		if ((c == CharPool.GREATER_THAN) || (c == CharPool.SLASH) ||
+			Character.isWhitespace(c)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private static Element _read(String xml, int[] position) {
+		_skipProlog(xml, position);
+
+		position[0]++;
+
+		int nameStart = position[0];
+
+		while (!_isNameEnd(xml.charAt(position[0]))) {
+			position[0]++;
+		}
+
+		Element element = new Element(xml.substring(nameStart, position[0]));
+
+		int tagEnd = xml.indexOf(CharPool.GREATER_THAN, position[0]);
+
+		if (xml.charAt(tagEnd - 1) == CharPool.SLASH) {
+			position[0] = tagEnd + 1;
+
+			return element;
+		}
+
+		position[0] = tagEnd + 1;
+
+		boolean hasChildElements = false;
+
+		while (true) {
+			int index = xml.indexOf(CharPool.LESS_THAN, position[0]);
+
+			if (xml.charAt(index + 1) == CharPool.SLASH) {
+				if (!hasChildElements) {
+					element.addText(
+						_unescape(xml.substring(position[0], index)));
+				}
+
+				position[0] = xml.indexOf(CharPool.GREATER_THAN, index) + 1;
+
+				return element;
+			}
+
+			position[0] = index;
+
+			element.add(_read(xml, position));
+
+			hasChildElements = true;
+		}
+	}
+
+	private static void _skipProlog(String xml, int[] position) {
+		while (true) {
+			while (Character.isWhitespace(xml.charAt(position[0]))) {
+				position[0]++;
+			}
+
+			if (xml.startsWith("<?", position[0])) {
+				position[0] = xml.indexOf("?>", position[0]) + 2;
+
+				continue;
+			}
+
+			return;
+		}
+	}
+
+	private static String _unescape(String text) {
+		text = StringUtil.replace(text, "&gt;", ">");
+		text = StringUtil.replace(text, "&lt;", "<");
+		text = StringUtil.replace(text, "&amp;", "&");
+
+		return text;
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyExporterTest.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+
+import java.util.Date;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.XML;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyExporterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_licenseKeyExporter = new LicenseKeyExporter();
+
+		ReflectionTestUtils.setField(
+			_licenseKeyExporter, "_licenseKeyGenerator",
+			new LicenseKeyGenerator());
+	}
+
+	@Test
+	public void testAggregateXMLsCombinesLicenses() throws Exception {
+		String aggregateXML = _licenseKeyExporter.aggregateXMLs(
+			new String[] {_toXML("KEY1"), _toXML("KEY2")});
+
+		JSONObject jsonObject = XML.toJSONObject(aggregateXML);
+
+		JSONObject licensesJSONObject = jsonObject.getJSONObject("licenses");
+
+		JSONArray licenseJSONArray = licensesJSONObject.getJSONArray("license");
+
+		Assertions.assertEquals(2, licenseJSONArray.length());
+
+		JSONObject firstLicenseJSONObject = licenseJSONArray.getJSONObject(0);
+
+		Assertions.assertEquals(
+			"KEY1", firstLicenseJSONObject.getString("key"));
+
+		JSONObject hostNamesJSONObject = firstLicenseJSONObject.getJSONObject(
+			"host-names");
+
+		Assertions.assertEquals(
+			"host.example.com", hostNamesJSONObject.getString("host-name"));
+
+		JSONObject secondLicenseJSONObject = licenseJSONArray.getJSONObject(1);
+
+		Assertions.assertEquals(
+			"KEY2", secondLicenseJSONObject.getString("key"));
+	}
+
+	@Test
+	public void testToXMLEscapesSpecialCharacters() throws Exception {
+		String xml = _licenseKeyExporter.toXML(
+			"TESTKEY", "Acme Corp", "Enterprise",
+			LicenseConstants.TYPE_ENTERPRISE, 3, "Liferay DXP", "", "7.4",
+			"Acme Corp", 0, 0, 0, 0L, 0L, "", "R&D <secure> \"team\"", "",
+			"host.example.com", "127.0.0.1", "00:11:22:33:44:55", "srv-1",
+			new Date(1000000000000L), new Date(2000000000000L));
+
+		Assertions.assertTrue(xml.startsWith("<?xml "));
+
+		JSONObject jsonObject = XML.toJSONObject(xml);
+
+		JSONObject licenseJSONObject = jsonObject.getJSONObject("license");
+
+		Assertions.assertEquals(
+			"Acme Corp", licenseJSONObject.getString("owner"));
+		Assertions.assertEquals(
+			"R&D <secure> \"team\"",
+			licenseJSONObject.getString("description"));
+		Assertions.assertEquals("TESTKEY", licenseJSONObject.getString("key"));
+	}
+
+	private String _toXML(String key) throws Exception {
+		return _licenseKeyExporter.toXML(
+			key, "Acme Corp", "Enterprise", LicenseConstants.TYPE_PRODUCTION, 4,
+			"Liferay DXP", "", "7.4", "Acme Corp", 0, 1, 0, 0L, 0L, "",
+			"Production license", "", "host.example.com", "127.0.0.1",
+			"00:11:22:33:44:55", "srv-1", new Date(1000000000000L),
+			new Date(2000000000000L));
+	}
+
+	private LicenseKeyExporter _licenseKeyExporter;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98655

## What is being fixed

LicenseKeyExporter and TrialRestController were copied from the portal OSB provisioning code, where the OSGi runtime wires up com.liferay.portal.kernel.xml.SAXReaderUtil and com.liferay.portal.kernel.util.LocaleUtil. In the standalone Spring Boot client extension there is no such runtime, so referencing either triggers a class-initialization chain that throws NoClassDefFoundError for com.liferay.petra.concurrent.DCLSingleton and the class cannot load. The defect was latent because LicenseKeyExporter.toXML had no caller until LPD-91431 added the license-key download endpoint.

## How it is being fixed

The exporter's SAXReaderUtil, Document, and Element references are replaced with a small standalone XML package (com.liferay.one.xml) that mirrors only the operations the exporter uses. Building and serializing run on an order-preserving element tree with a hand-written pretty-printer; the parser is self-contained and only ever reads the exporter's own output, so it stays clear of the source-formatter XML-security check and needs no new dependency. A US constant is added to the workspace-local com.liferay.one.util.LocaleUtil, and both LicenseKeyExporter and TrialRestController switch to it. A round-trip test covers both toXML and the multi-key aggregateXMLs path.
