### PR TITLE
LPD-98483 Add AI Hub Studio to Koroneiki, Provisioning, CP

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -520,6 +520,18 @@
 			"accountKey": "ERC-001",
 			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
 			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_ai-hub-studio",
+			"instanceSize": "1",
+			"name": "AI Hub - Studio",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
 			"externalReferenceCode": "ERC-001_liferay-cloud_lr-tokens-5000",
 			"instanceSize": "1",
 			"name": "LR Tokens (5,000)",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98483

## What Is Being Fixed

The AI Hub product catalog is missing the new "AI Hub - Studio" primary product. It needs to be available in Koroneiki, Provisioning, and the Customer Portal so it can be provisioned and shown to customers. The CRM team confirmed the exact naming as `AI Hub - Studio`.

## How It Is Being Fixed

Following the pattern established in LRSD-12365 (PR liferay-one/liferay-portal#1132), this adds an "AI Hub - Studio" account subscription entry to the Customer Portal site-initializer test data, under the ERC-001 test account and grouped under "Liferay Cloud". The product type "AI Hub" already exists, so no product-type or subscription-group changes are needed. Koroneiki and Provisioning are configured through the Control Panel UI (no code change), mirroring how the earlier AI Hub products were added in LRSD-12365.

## Why Are There No Tests?

This is a site-initializer test-data addition (JSON), not testable logic. It mirrors PR #1132 (LRSD-12365), which likewise added AI Hub product entries without tests.

## PR Check

**pr-check: PASS** — tested on `8fa929b5851796b4ea35a46e2fed46047d379f79`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "8fa929b5851796b4ea35a46e2fed46047d379f79"} -->
