### PR TITLE
LPD-98645 Add a common license key upload endpoint

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommonLicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/CommonLicenseKeysRestController.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.one.service.CommonLicenseKeyService;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@RequestMapping("/common-license-keys")
+@RestController
+public class CommonLicenseKeysRestController extends OneBaseRestController {
+
+	@PostMapping
+	public void postCommonLicenseKeys(
+			@RequestParam("productGroup") String productGroup,
+			@RequestParam("files") MultipartFile[] multipartFiles)
+		throws Exception {
+
+		for (MultipartFile multipartFile : multipartFiles) {
+			String fileName = multipartFile.getOriginalFilename();
+
+			if (_commonLicenseKeyService.hasCommonLicenseKey(fileName)) {
+				throw new ResponseStatusException(
+					HttpStatus.CONFLICT,
+					"A common license key already exists for the file " +
+						fileName);
+			}
+
+			try {
+				_commonLicenseKeyService.addCommonLicenseKey(
+					new String(
+						multipartFile.getBytes(), StandardCharsets.UTF_8),
+					fileName, multipartFile.getSize(), productGroup);
+			}
+			catch (IllegalArgumentException illegalArgumentException) {
+				throw new ResponseStatusException(
+					HttpStatus.BAD_REQUEST,
+					"Unable to parse the license file " + fileName,
+					illegalArgumentException);
+			}
+		}
+	}
+
+	@Autowired
+	private CommonLicenseKeyService _commonLicenseKeyService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductEnvironment.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductEnvironment.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class ProductEnvironment {
+
+	public static final String BACKUP = "backup";
+
+	public static final String NONPRODUCTION = "non-production";
+
+	public static final String PRODUCTION = "production";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/UploadProductEnvironmentConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/UploadProductEnvironmentConstants.java
@@ -8,7 +8,7 @@ package com.liferay.one.constants;
 /**
  * @author Allen Ziegenfus
  */
-public class ProductEnvironment {
+public class UploadProductEnvironmentConstants {
 
 	public static final String BACKUP = "backup";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/UploadProductGroupConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/UploadProductGroupConstants.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class UploadProductGroupConstants {
+
+	public static final String COMMERCE = "COMMERCE";
+
+	public static final String ENTERPRISE_SEARCH = "ENTERPRISE_SEARCH";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyData.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyData.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import java.time.Instant;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class CommonLicenseKeyData {
+
+	public CommonLicenseKeyData(
+		String productEnvironment, Instant startDateInstant,
+		Instant endDateInstant) {
+
+		_productEnvironment = productEnvironment;
+		_startDateInstant = startDateInstant;
+		_endDateInstant = endDateInstant;
+	}
+
+	public Instant getEndDateInstant() {
+		return _endDateInstant;
+	}
+
+	public String getProductEnvironment() {
+		return _productEnvironment;
+	}
+
+	public Instant getStartDateInstant() {
+		return _startDateInstant;
+	}
+
+	private final Instant _endDateInstant;
+	private final String _productEnvironment;
+	private final Instant _startDateInstant;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyData.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyData.java
@@ -13,12 +13,12 @@ import java.time.Instant;
 public class CommonLicenseKeyData {
 
 	public CommonLicenseKeyData(
-		String productEnvironment, Instant startDateInstant,
-		Instant endDateInstant) {
+		Instant endDateInstant, String productEnvironment,
+		Instant startDateInstant) {
 
+		_endDateInstant = endDateInstant;
 		_productEnvironment = productEnvironment;
 		_startDateInstant = startDateInstant;
-		_endDateInstant = endDateInstant;
 	}
 
 	public Instant getEndDateInstant() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyParser.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyParser.java
@@ -5,16 +5,20 @@
 
 package com.liferay.one.license;
 
-import com.liferay.one.constants.ProductEnvironment;
+import com.liferay.one.constants.UploadProductEnvironmentConstants;
 import com.liferay.one.util.LocaleUtil;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 import java.time.Instant;
 
 import java.util.Date;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.XML;
 
@@ -26,53 +30,73 @@ import org.springframework.stereotype.Component;
 @Component
 public class CommonLicenseKeyParser {
 
-	public CommonLicenseKeyData parseCommerce(String fileContent)
-		throws Exception {
+	public CommonLicenseKeyData parseCommerce(String fileContent) {
+		try {
+			JSONObject jsonObject = XML.toJSONObject(fileContent);
 
-		JSONObject jsonObject = XML.toJSONObject(fileContent);
+			Iterator<String> keysIterator = jsonObject.keys();
 
-		JSONObject rootJSONObject = jsonObject.getJSONObject(
-			jsonObject.keys(
-			).next());
+			JSONObject rootJSONObject = jsonObject.getJSONObject(
+				keysIterator.next());
 
-		DateFormat dateFormat = new SimpleDateFormat(
-			"EEEE, MMMM d, yyyy hh:mm:ss a z", LocaleUtil.US);
+			DateFormat dateFormat = new SimpleDateFormat(
+				_COMMERCE_LICENSE_DATE_FORMAT, LocaleUtil.US);
 
-		Date endDate = dateFormat.parse(
-			rootJSONObject.getString("expiration-date"));
-		Date startDate = dateFormat.parse(
-			rootJSONObject.getString("start-date"));
+			Date endDate = dateFormat.parse(
+				rootJSONObject.getString("expiration-date"));
+			Date startDate = dateFormat.parse(
+				rootJSONObject.getString("start-date"));
 
-		return new CommonLicenseKeyData(
-			_toProductEnvironment(rootJSONObject.getString("description")),
-			startDate.toInstant(), endDate.toInstant());
+			return new CommonLicenseKeyData(
+				endDate.toInstant(),
+				_toProductEnvironment(rootJSONObject.getString("description")),
+				startDate.toInstant());
+		}
+		catch (JSONException | NoSuchElementException | ParseException
+					exception) {
+
+			throw new IllegalArgumentException(
+				"Unable to parse the Commerce license file", exception);
+		}
 	}
 
 	public CommonLicenseKeyData parseEnterpriseSearch(String fileContent) {
-		JSONObject jsonObject = new JSONObject(fileContent);
+		try {
+			JSONObject jsonObject = new JSONObject(fileContent);
 
-		JSONObject licenseJSONObject = jsonObject.getJSONObject("license");
+			JSONObject licenseJSONObject = jsonObject.getJSONObject("license");
 
-		return new CommonLicenseKeyData(
-			_toProductEnvironment(licenseJSONObject.getString("issued_to")),
-			Instant.ofEpochMilli(
-				licenseJSONObject.getLong("start_date_in_millis")),
-			Instant.ofEpochMilli(
-				licenseJSONObject.getLong("expiry_date_in_millis")));
+			return new CommonLicenseKeyData(
+				Instant.ofEpochMilli(
+					licenseJSONObject.getLong("expiry_date_in_millis")),
+				_toProductEnvironment(licenseJSONObject.getString("issued_to")),
+				Instant.ofEpochMilli(
+					licenseJSONObject.getLong("start_date_in_millis")));
+		}
+		catch (JSONException jsonException) {
+			throw new IllegalArgumentException(
+				"Unable to parse the Enterprise Search license file",
+				jsonException);
+		}
 	}
 
 	private String _toProductEnvironment(String text) {
 		String lowerCaseText = text.toLowerCase(LocaleUtil.US);
 
-		if (lowerCaseText.contains(ProductEnvironment.BACKUP)) {
-			return ProductEnvironment.BACKUP;
+		if (lowerCaseText.contains(UploadProductEnvironmentConstants.BACKUP)) {
+			return UploadProductEnvironmentConstants.BACKUP;
 		}
 
-		if (lowerCaseText.contains(ProductEnvironment.NONPRODUCTION)) {
-			return ProductEnvironment.NONPRODUCTION;
+		if (lowerCaseText.contains(
+				UploadProductEnvironmentConstants.NONPRODUCTION)) {
+
+			return UploadProductEnvironmentConstants.NONPRODUCTION;
 		}
 
-		return ProductEnvironment.PRODUCTION;
+		return UploadProductEnvironmentConstants.PRODUCTION;
 	}
+
+	private static final String _COMMERCE_LICENSE_DATE_FORMAT =
+		"EEEE, MMMM d, yyyy hh:mm:ss a z";
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyParser.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/CommonLicenseKeyParser.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.one.constants.ProductEnvironment;
+import com.liferay.one.util.LocaleUtil;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.time.Instant;
+
+import java.util.Date;
+
+import org.json.JSONObject;
+import org.json.XML;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class CommonLicenseKeyParser {
+
+	public CommonLicenseKeyData parseCommerce(String fileContent)
+		throws Exception {
+
+		JSONObject jsonObject = XML.toJSONObject(fileContent);
+
+		JSONObject rootJSONObject = jsonObject.getJSONObject(
+			jsonObject.keys(
+			).next());
+
+		DateFormat dateFormat = new SimpleDateFormat(
+			"EEEE, MMMM d, yyyy hh:mm:ss a z", LocaleUtil.US);
+
+		Date endDate = dateFormat.parse(
+			rootJSONObject.getString("expiration-date"));
+		Date startDate = dateFormat.parse(
+			rootJSONObject.getString("start-date"));
+
+		return new CommonLicenseKeyData(
+			_toProductEnvironment(rootJSONObject.getString("description")),
+			startDate.toInstant(), endDate.toInstant());
+	}
+
+	public CommonLicenseKeyData parseEnterpriseSearch(String fileContent) {
+		JSONObject jsonObject = new JSONObject(fileContent);
+
+		JSONObject licenseJSONObject = jsonObject.getJSONObject("license");
+
+		return new CommonLicenseKeyData(
+			_toProductEnvironment(licenseJSONObject.getString("issued_to")),
+			Instant.ofEpochMilli(
+				licenseJSONObject.getLong("start_date_in_millis")),
+			Instant.ofEpochMilli(
+				licenseJSONObject.getLong("expiry_date_in_millis")));
+	}
+
+	private String _toProductEnvironment(String text) {
+		String lowerCaseText = text.toLowerCase(LocaleUtil.US);
+
+		if (lowerCaseText.contains(ProductEnvironment.BACKUP)) {
+			return ProductEnvironment.BACKUP;
+		}
+
+		if (lowerCaseText.contains(ProductEnvironment.NONPRODUCTION)) {
+			return ProductEnvironment.NONPRODUCTION;
+		}
+
+		return ProductEnvironment.PRODUCTION;
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.constants.UploadProductEnvironmentConstants;
+import com.liferay.one.constants.UploadProductGroupConstants;
+import com.liferay.one.license.CommonLicenseKeyData;
+import com.liferay.one.license.CommonLicenseKeyParser;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class CommonLicenseKeyService extends OneBaseService {
+
+	public void addCommonLicenseKey(
+			String fileContent, String fileName, long fileSize,
+			String productGroup)
+		throws Exception {
+
+		CommonLicenseKeyData commonLicenseKeyData = null;
+		String productFamily = null;
+
+		if (StringUtil.equals(
+				productGroup, UploadProductGroupConstants.ENTERPRISE_SEARCH)) {
+
+			commonLicenseKeyData =
+				_commonLicenseKeyParser.parseEnterpriseSearch(fileContent);
+			productFamily = _PRODUCT_FAMILY_ENTERPRISE_SEARCH;
+		}
+		else {
+			commonLicenseKeyData = _commonLicenseKeyParser.parseCommerce(
+				fileContent);
+			productFamily = _PRODUCT_FAMILY_COMMERCE;
+		}
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"endDate",
+			commonLicenseKeyData.getEndDateInstant(
+			).toString()
+		).put(
+			"environmentType",
+			new JSONObject(
+			).put(
+				"key",
+				_toEnvironmentTypeKey(
+					commonLicenseKeyData.getProductEnvironment())
+			)
+		).put(
+			"fileContent", fileContent
+		).put(
+			"fileName", fileName
+		).put(
+			"fileSize", fileSize
+		).put(
+			"productFamily",
+			new JSONObject(
+			).put(
+				"key", productFamily
+			)
+		).put(
+			"startDate",
+			commonLicenseKeyData.getStartDateInstant(
+			).toString()
+		);
+
+		postCommonLicenseKey(jsonObject);
+	}
+
+	public boolean hasCommonLicenseKey(String fileName) throws Exception {
+		List<JSONObject> commonLicenseKeys = _getCommonLicenseKeys(fileName);
+
+		return !commonLicenseKeys.isEmpty();
+	}
+
+	protected void postCommonLicenseKey(JSONObject jsonObject)
+		throws Exception {
+
+		post(
+			getAuthorization(), jsonObject.toString(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/commonlicensekeys"
+			).build(
+			).toUri());
+	}
+
+	private List<JSONObject> _getCommonLicenseKeys(String fileName)
+		throws Exception {
+
+		return getAllItems(
+			"/o/c/commonlicensekeys",
+			"fileName eq '" + StringUtil.replace(fileName, '\'', "''") + "'",
+			jsonObject -> jsonObject);
+	}
+
+	private String _toEnvironmentTypeKey(String productEnvironment) {
+		if (StringUtil.equals(
+				productEnvironment,
+				UploadProductEnvironmentConstants.NONPRODUCTION)) {
+
+			return "nonProduction";
+		}
+
+		return productEnvironment;
+	}
+
+	private static final String _PRODUCT_FAMILY_COMMERCE = "commerce";
+
+	private static final String _PRODUCT_FAMILY_ENTERPRISE_SEARCH =
+		"enterpriseSearch";
+
+	@Autowired
+	private CommonLicenseKeyParser _commonLicenseKeyParser;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/CommonLicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/CommonLicenseKeysRestControllerTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one;
+
+import com.liferay.one.service.CommonLicenseKeyService;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class CommonLicenseKeysRestControllerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_commonLicenseKeyService = Mockito.mock(CommonLicenseKeyService.class);
+
+		_commonLicenseKeysRestController =
+			new CommonLicenseKeysRestController();
+
+		ReflectionTestUtils.setField(
+			_commonLicenseKeysRestController, "_commonLicenseKeyService",
+			_commonLicenseKeyService);
+	}
+
+	@Test
+	public void testPostCommonLicenseKeys() throws Exception {
+		MultipartFile multipartFile = new MockMultipartFile(
+			"files", "commerce.xml", "text/xml",
+			"<license/>".getBytes(StandardCharsets.UTF_8));
+
+		_commonLicenseKeysRestController.postCommonLicenseKeys(
+			"COMMERCE", new MultipartFile[] {multipartFile});
+
+		Mockito.verify(
+			_commonLicenseKeyService
+		).addCommonLicenseKey(
+			"<license/>", "commerce.xml", 10L, "COMMERCE"
+		);
+	}
+
+	@Test
+	public void testPostCommonLicenseKeysRejectsDuplicate() throws Exception {
+		Mockito.when(
+			_commonLicenseKeyService.hasCommonLicenseKey("commerce.xml")
+		).thenReturn(
+			true
+		);
+
+		MultipartFile multipartFile = new MockMultipartFile(
+			"files", "commerce.xml", "text/xml",
+			"<license/>".getBytes(StandardCharsets.UTF_8));
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> _commonLicenseKeysRestController.postCommonLicenseKeys(
+					"COMMERCE", new MultipartFile[] {multipartFile}));
+
+		Assertions.assertEquals(
+			HttpStatus.CONFLICT, responseStatusException.getStatusCode());
+
+		Mockito.verify(
+			_commonLicenseKeyService, Mockito.never()
+		).addCommonLicenseKey(
+			Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(),
+			Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testPostCommonLicenseKeysRejectsUnparsableFile()
+		throws Exception {
+
+		Mockito.doThrow(
+			new IllegalArgumentException()
+		).when(
+			_commonLicenseKeyService
+		).addCommonLicenseKey(
+			Mockito.anyString(), Mockito.anyString(), Mockito.anyLong(),
+			Mockito.anyString()
+		);
+
+		MultipartFile multipartFile = new MockMultipartFile(
+			"files", "commerce.xml", "text/xml",
+			"garbage".getBytes(StandardCharsets.UTF_8));
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> _commonLicenseKeysRestController.postCommonLicenseKeys(
+					"COMMERCE", new MultipartFile[] {multipartFile}));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
+	}
+
+	private CommonLicenseKeyService _commonLicenseKeyService;
+	private CommonLicenseKeysRestController _commonLicenseKeysRestController;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/CommonLicenseKeyParserTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/CommonLicenseKeyParserTest.java
@@ -5,7 +5,7 @@
 
 package com.liferay.one.license;
 
-import com.liferay.one.constants.ProductEnvironment;
+import com.liferay.one.constants.UploadProductEnvironmentConstants;
 
 import java.time.Instant;
 
@@ -26,7 +26,7 @@ public class CommonLicenseKeyParserTest {
 					"Wednesday, January 1, 2025 12:00:00 AM UTC"));
 
 		Assertions.assertEquals(
-			ProductEnvironment.BACKUP,
+			UploadProductEnvironmentConstants.BACKUP,
 			commonLicenseKeyData.getProductEnvironment());
 	}
 
@@ -40,7 +40,7 @@ public class CommonLicenseKeyParserTest {
 					"Wednesday, January 1, 2025 12:00:00 AM UTC"));
 
 		Assertions.assertEquals(
-			ProductEnvironment.PRODUCTION,
+			UploadProductEnvironmentConstants.PRODUCTION,
 			commonLicenseKeyData.getProductEnvironment());
 		Assertions.assertEquals(
 			Instant.parse("2024-01-01T00:00:00Z"),
@@ -51,6 +51,15 @@ public class CommonLicenseKeyParserTest {
 	}
 
 	@Test
+	public void testParseCommerceThrowsForUnparsableFile() {
+		Assertions.assertThrows(
+			IllegalArgumentException.class,
+			() -> _commonLicenseKeyParser.parseCommerce(
+				_commerceXML(
+					"Production instance", "not a date", "not a date")));
+	}
+
+	@Test
 	public void testParseEnterpriseSearchNonproduction() {
 		CommonLicenseKeyData commonLicenseKeyData =
 			_commonLicenseKeyParser.parseEnterpriseSearch(
@@ -58,7 +67,7 @@ public class CommonLicenseKeyParserTest {
 					"Acme Non-Production", 1704067200000L, 1735689600000L));
 
 		Assertions.assertEquals(
-			ProductEnvironment.NONPRODUCTION,
+			UploadProductEnvironmentConstants.NONPRODUCTION,
 			commonLicenseKeyData.getProductEnvironment());
 		Assertions.assertEquals(
 			Instant.ofEpochMilli(1704067200000L),
@@ -75,7 +84,7 @@ public class CommonLicenseKeyParserTest {
 				_enterpriseSearchJSON("Acme", 1L, 2L));
 
 		Assertions.assertEquals(
-			ProductEnvironment.PRODUCTION,
+			UploadProductEnvironmentConstants.PRODUCTION,
 			commonLicenseKeyData.getProductEnvironment());
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/CommonLicenseKeyParserTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/CommonLicenseKeyParserTest.java
@@ -1,0 +1,104 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.one.constants.ProductEnvironment;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class CommonLicenseKeyParserTest {
+
+	@Test
+	public void testParseCommerceBackup() throws Exception {
+		CommonLicenseKeyData commonLicenseKeyData =
+			_commonLicenseKeyParser.parseCommerce(
+				_commerceXML(
+					"Backup server", "Monday, January 1, 2024 12:00:00 AM UTC",
+					"Wednesday, January 1, 2025 12:00:00 AM UTC"));
+
+		Assertions.assertEquals(
+			ProductEnvironment.BACKUP,
+			commonLicenseKeyData.getProductEnvironment());
+	}
+
+	@Test
+	public void testParseCommerceProduction() throws Exception {
+		CommonLicenseKeyData commonLicenseKeyData =
+			_commonLicenseKeyParser.parseCommerce(
+				_commerceXML(
+					"Production instance",
+					"Monday, January 1, 2024 12:00:00 AM UTC",
+					"Wednesday, January 1, 2025 12:00:00 AM UTC"));
+
+		Assertions.assertEquals(
+			ProductEnvironment.PRODUCTION,
+			commonLicenseKeyData.getProductEnvironment());
+		Assertions.assertEquals(
+			Instant.parse("2024-01-01T00:00:00Z"),
+			commonLicenseKeyData.getStartDateInstant());
+		Assertions.assertEquals(
+			Instant.parse("2025-01-01T00:00:00Z"),
+			commonLicenseKeyData.getEndDateInstant());
+	}
+
+	@Test
+	public void testParseEnterpriseSearchNonproduction() {
+		CommonLicenseKeyData commonLicenseKeyData =
+			_commonLicenseKeyParser.parseEnterpriseSearch(
+				_enterpriseSearchJSON(
+					"Acme Non-Production", 1704067200000L, 1735689600000L));
+
+		Assertions.assertEquals(
+			ProductEnvironment.NONPRODUCTION,
+			commonLicenseKeyData.getProductEnvironment());
+		Assertions.assertEquals(
+			Instant.ofEpochMilli(1704067200000L),
+			commonLicenseKeyData.getStartDateInstant());
+		Assertions.assertEquals(
+			Instant.ofEpochMilli(1735689600000L),
+			commonLicenseKeyData.getEndDateInstant());
+	}
+
+	@Test
+	public void testParseEnterpriseSearchProduction() {
+		CommonLicenseKeyData commonLicenseKeyData =
+			_commonLicenseKeyParser.parseEnterpriseSearch(
+				_enterpriseSearchJSON("Acme", 1L, 2L));
+
+		Assertions.assertEquals(
+			ProductEnvironment.PRODUCTION,
+			commonLicenseKeyData.getProductEnvironment());
+	}
+
+	private String _commerceXML(
+		String description, String startDate, String expirationDate) {
+
+		return String.format(
+			"<license><product-name>Liferay Commerce</product-name>" +
+				"<description>%s</description><start-date>%s</start-date>" +
+					"<expiration-date>%s</expiration-date></license>",
+			description, startDate, expirationDate);
+	}
+
+	private String _enterpriseSearchJSON(
+		String issuedTo, long startMillis, long expiryMillis) {
+
+		return String.format(
+			"{\"license\":{\"issued_to\":\"%s\"," +
+				"\"start_date_in_millis\":%d,\"expiry_date_in_millis\":%d}}",
+			issuedTo, startMillis, expiryMillis);
+	}
+
+	private final CommonLicenseKeyParser _commonLicenseKeyParser =
+		new CommonLicenseKeyParser();
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
@@ -1,0 +1,167 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.license.CommonLicenseKeyData;
+import com.liferay.one.license.CommonLicenseKeyParser;
+
+import java.time.Instant;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class CommonLicenseKeyServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_commonLicenseKeyService = Mockito.spy(new CommonLicenseKeyService());
+
+		_commonLicenseKeyParser = Mockito.mock(CommonLicenseKeyParser.class);
+
+		ReflectionTestUtils.setField(
+			_commonLicenseKeyService, "_commonLicenseKeyParser",
+			_commonLicenseKeyParser);
+
+		Mockito.doReturn(
+			Collections.<JSONObject>emptyList()
+		).when(
+			_commonLicenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/commonlicensekeys"), Mockito.anyString(),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAddCommonLicenseKeyCommerce() throws Exception {
+		Mockito.doReturn(
+			new CommonLicenseKeyData(
+				Instant.parse("2027-01-01T00:00:00Z"), "production",
+				Instant.parse("2026-01-01T00:00:00Z"))
+		).when(
+			_commonLicenseKeyParser
+		).parseCommerce(
+			"<license/>"
+		);
+
+		JSONObject jsonObject = _capturePostBody(
+			"<license/>", "commerce.xml", 500L, "COMMERCE");
+
+		Assertions.assertEquals(
+			"commerce.xml", jsonObject.getString("fileName"));
+		Assertions.assertEquals(500L, jsonObject.getLong("fileSize"));
+		Assertions.assertEquals(
+			"<license/>", jsonObject.getString("fileContent"));
+		Assertions.assertEquals(
+			"commerce",
+			jsonObject.getJSONObject(
+				"productFamily"
+			).getString(
+				"key"
+			));
+		Assertions.assertEquals(
+			"production",
+			jsonObject.getJSONObject(
+				"environmentType"
+			).getString(
+				"key"
+			));
+		Assertions.assertEquals(
+			"2026-01-01T00:00:00Z", jsonObject.getString("startDate"));
+		Assertions.assertEquals(
+			"2027-01-01T00:00:00Z", jsonObject.getString("endDate"));
+	}
+
+	@Test
+	public void testAddCommonLicenseKeyMapsNonproductionEnvironment()
+		throws Exception {
+
+		Mockito.doReturn(
+			new CommonLicenseKeyData(
+				Instant.parse("2027-01-01T00:00:00Z"), "non-production",
+				Instant.parse("2026-01-01T00:00:00Z"))
+		).when(
+			_commonLicenseKeyParser
+		).parseEnterpriseSearch(
+			"{}"
+		);
+
+		JSONObject jsonObject = _capturePostBody(
+			"{}", "es.json", 100L, "ENTERPRISE_SEARCH");
+
+		Assertions.assertEquals(
+			"enterpriseSearch",
+			jsonObject.getJSONObject(
+				"productFamily"
+			).getString(
+				"key"
+			));
+		Assertions.assertEquals(
+			"nonProduction",
+			jsonObject.getJSONObject(
+				"environmentType"
+			).getString(
+				"key"
+			));
+	}
+
+	@Test
+	public void testHasCommonLicenseKey() throws Exception {
+		Assertions.assertFalse(
+			_commonLicenseKeyService.hasCommonLicenseKey("new.xml"));
+
+		Mockito.doReturn(
+			List.of(new JSONObject())
+		).when(
+			_commonLicenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/commonlicensekeys"), Mockito.anyString(),
+			Mockito.any()
+		);
+
+		Assertions.assertTrue(
+			_commonLicenseKeyService.hasCommonLicenseKey("dup.xml"));
+	}
+
+	private JSONObject _capturePostBody(
+			String fileContent, String fileName, long fileSize,
+			String productGroup)
+		throws Exception {
+
+		ArgumentCaptor<JSONObject> argumentCaptor = ArgumentCaptor.forClass(
+			JSONObject.class);
+
+		Mockito.doNothing(
+		).when(
+			_commonLicenseKeyService
+		).postCommonLicenseKey(
+			argumentCaptor.capture()
+		);
+
+		_commonLicenseKeyService.addCommonLicenseKey(
+			fileContent, fileName, fileSize, productGroup);
+
+		return argumentCaptor.getValue();
+	}
+
+	private CommonLicenseKeyParser _commonLicenseKeyParser;
+	private CommonLicenseKeyService _commonLicenseKeyService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98645

## What is being fixed

Liferay One had no way to upload Commerce or Enterprise Search license files as common license keys. The C_COMMON_LICENSE_KEY object existed but nothing populated it from an uploaded license file.

## How it is being fixed

Adds a POST /common-license-keys endpoint that accepts one or more uploaded license files plus a product group. A parser reads the two license formats — Commerce license XML and Enterprise Search license JSON — extracting the environment (production, non-production, or backup) and the start and end dates. The service maps the product group to a product family, derives the environment type picklist key, rejects a duplicate upload for a file name that already exists, and persists the result to the C_COMMON_LICENSE_KEY object. Parsing deliberately avoids the portal kernel XML utilities so it works inside the standalone Spring Boot client extension.