### PR TITLE
LPD-98484 Add DSR to Koroneiki, Provisioning, CP

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
@@ -9,6 +9,7 @@ export const PRODUCT_TYPES = {
 	cloudNative: 'Cloud Native',
 	commerce: 'Commerce',
 	commerceCloud: 'Commerce for Cloud',
+	digitalSalesRoom: 'Digital Sales Room',
 	dxp: 'DXP',
 	dxpCloud: 'Liferay PaaS',
 	enterpriseSearch: 'Enterprise Search',

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
@@ -118,5 +118,10 @@
 		"externalReferenceCode": "ERC-024",
 		"name": "Liferay DXP Academic Test Account",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "ERC-025",
+		"name": "Digital Sales Room Test Account",
+		"type": "business"
 	}
 ]

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
@@ -32,7 +32,7 @@
 		},
 		{
 			"accountKey": "ERC-001",
-			"activationProductName": "AI Hub, Cloud Native, Liferay PaaS, Liferay SaaS",
+			"activationProductName": "AI Hub, Cloud Native, Digital Sales Room, Liferay PaaS, Liferay SaaS",
 			"activationStatus": "Active",
 			"externalReferenceCode": "ERC-001_liferay-cloud",
 			"hasActivation": true,
@@ -317,6 +317,17 @@
 			"menuOrder": 1,
 			"name": "Self-Hosted",
 			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-024",
+			"tabOrder": 2
+		},
+		{
+			"accountKey": "ERC-025",
+			"activationProductName": "Digital Sales Room",
+			"activationStatus": "Active",
+			"externalReferenceCode": "ERC-025_liferay-cloud",
+			"hasActivation": false,
+			"menuOrder": 1,
+			"name": "Liferay Cloud",
+			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-025",
 			"tabOrder": 2
 		}
 	],

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -565,6 +565,42 @@
 			"subscriptionStatus": "Active"
 		},
 		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_digital-sales-room",
+			"instanceSize": "1",
+			"name": "Digital Sales Room",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_digital-sales-room-production",
+			"instanceSize": "1",
+			"name": "Digital Sales Room - Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_digital-sales-room-non-production",
+			"instanceSize": "1",
+			"name": "Digital Sales Room - Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
 			"accountKey": "ERC-023",
 			"accountSubscriptionGroupERC": "ERC-023_liferay-cloud",
 			"endDate": "2026-12-31T00:00:00Z",
@@ -609,6 +645,42 @@
 			"name": "Academic Non-Production",
 			"quantity": 1,
 			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-025",
+			"accountSubscriptionGroupERC": "ERC-025_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-025_liferay-cloud_digital-sales-room",
+			"instanceSize": "1",
+			"name": "Digital Sales Room",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-025",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-025",
+			"accountSubscriptionGroupERC": "ERC-025_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-025_liferay-cloud_digital-sales-room-production",
+			"instanceSize": "1",
+			"name": "Digital Sales Room - Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-025",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-025",
+			"accountSubscriptionGroupERC": "ERC-025_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-025_liferay-cloud_digital-sales-room-non-production",
+			"instanceSize": "1",
+			"name": "Digital Sales Room - Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-025",
 			"startDate": "2023-01-01T00:00:00Z",
 			"subscriptionStatus": "Active"
 		}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
@@ -383,6 +383,22 @@
 			"partner": false,
 			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-024",
 			"region": "United States"
+		},
+		{
+			"accountKey": "ERC-025",
+			"code": "TESTACCOUNT25",
+			"dxpVersion": "7.4",
+			"externalReferenceCode": "ERC-025",
+			"liferayContactEmailAddress": "customer-service@liferay.com",
+			"liferayContactName": "Liferay Support",
+			"maxRequestors": -1,
+			"name": "Digital Sales Room Test Account",
+			"partner": false,
+			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-025",
+			"region": "United States",
+			"slaCurrent": "Platinum Subscription",
+			"slaCurrentEndDate": "2026-12-31 00:00:00.0",
+			"slaCurrentStartDate": "2023-01-01 00:00:00.0"
 		}
 	],
 	"objectDefinitionName": "KoroneikiAccount"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98484

## What Is Being Fixed

The Customer Portal is missing the new "Digital Sales Room" (DSR) product. It needs to be available in Koroneiki, Provisioning, and the Customer Portal so it can be provisioned and shown to customers. The CRM team confirmed the SKU names as `Digital Sales Room`, `Digital Sales Room - Production`, and `Digital Sales Room - Non-Production`.

## How It Is Being Fixed

Following the pattern established when AI Hub was introduced (LRSD-12365 / PR liferay-one/liferay-portal#1132), this registers DSR as a brand-new product across the Customer Portal site-initializer: it adds the `digitalSalesRoom` product type, lists "Digital Sales Room" in the ERC-001 Liferay Cloud group activation, seeds the three DSR SKUs on the main test account (ERC-001), and adds a dedicated "Digital Sales Room Test Account" (ERC-024) mirroring the AI Hub test account (ERC-023). DSR is grouped under "Liferay Cloud" per the acceptance criteria, exactly like AI Hub, so the SKU names are product-prefixed to avoid colliding with the base Liferay Cloud "Production" subscription. Koroneiki and Provisioning are configured through the Control Panel UI (no code change).

## Why Are There No Tests?

This is site-initializer test-data plus a one-line product-type constant, not testable logic. It mirrors PR #1132 (LRSD-12365), which likewise added products without tests.

## PR Check

**pr-check: PASS** — tested on `cfc3abfcfbf22d5f9cd84628271777098526400a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "cfc3abfcfbf22d5f9cd84628271777098526400a"} -->
