### PR TITLE
LPD-99085 Add CMP to Koroneiki, Provisioning, CP

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
@@ -9,6 +9,7 @@ export const PRODUCT_TYPES = {
 	cloudNative: 'Cloud Native',
 	commerce: 'Commerce',
 	commerceCloud: 'Commerce for Cloud',
+	contentMarketingPlatform: 'Content Marketing Platform',
 	dxp: 'DXP',
 	dxpCloud: 'Liferay PaaS',
 	enterpriseSearch: 'Enterprise Search',

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
@@ -118,5 +118,10 @@
 		"externalReferenceCode": "ERC-024",
 		"name": "Liferay DXP Academic Test Account",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "ERC-026",
+		"name": "Content Marketing Platform Test Account",
+		"type": "business"
 	}
 ]

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
@@ -32,7 +32,7 @@
 		},
 		{
 			"accountKey": "ERC-001",
-			"activationProductName": "AI Hub, Cloud Native, Liferay PaaS, Liferay SaaS",
+			"activationProductName": "AI Hub, Cloud Native, Content Marketing Platform, Liferay PaaS, Liferay SaaS",
 			"activationStatus": "Active",
 			"externalReferenceCode": "ERC-001_liferay-cloud",
 			"hasActivation": true,
@@ -317,6 +317,17 @@
 			"menuOrder": 1,
 			"name": "Self-Hosted",
 			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-024",
+			"tabOrder": 2
+		},
+		{
+			"accountKey": "ERC-026",
+			"activationProductName": "Content Marketing Platform",
+			"activationStatus": "Active",
+			"externalReferenceCode": "ERC-026_liferay-cloud",
+			"hasActivation": false,
+			"menuOrder": 1,
+			"name": "Liferay Cloud",
+			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-026",
 			"tabOrder": 2
 		}
 	],

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -577,6 +577,42 @@
 			"subscriptionStatus": "Active"
 		},
 		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_content-marketing-platform",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_content-marketing-platform-production",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform - Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_content-marketing-platform-non-production",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform - Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
 			"accountKey": "ERC-023",
 			"accountSubscriptionGroupERC": "ERC-023_liferay-cloud",
 			"endDate": "2026-12-31T00:00:00Z",
@@ -621,6 +657,42 @@
 			"name": "Academic Non-Production",
 			"quantity": 1,
 			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-026",
+			"accountSubscriptionGroupERC": "ERC-026_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-026_liferay-cloud_content-marketing-platform",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-026",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-026",
+			"accountSubscriptionGroupERC": "ERC-026_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-026_liferay-cloud_content-marketing-platform-production",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform - Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-026",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-026",
+			"accountSubscriptionGroupERC": "ERC-026_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-026_liferay-cloud_content-marketing-platform-non-production",
+			"instanceSize": "1",
+			"name": "Content Marketing Platform - Non-Production",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-026",
 			"startDate": "2023-01-01T00:00:00Z",
 			"subscriptionStatus": "Active"
 		}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
@@ -383,6 +383,22 @@
 			"partner": false,
 			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-024",
 			"region": "United States"
+		},
+		{
+			"accountKey": "ERC-026",
+			"code": "TESTACCOUNT26",
+			"dxpVersion": "7.4",
+			"externalReferenceCode": "ERC-026",
+			"liferayContactEmailAddress": "customer-service@liferay.com",
+			"liferayContactName": "Liferay Support",
+			"maxRequestors": -1,
+			"name": "Content Marketing Platform Test Account",
+			"partner": false,
+			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-026",
+			"region": "United States",
+			"slaCurrent": "Platinum Subscription",
+			"slaCurrentEndDate": "2026-12-31 00:00:00.0",
+			"slaCurrentStartDate": "2023-01-01 00:00:00.0"
 		}
 	],
 	"objectDefinitionName": "KoroneikiAccount"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99085

## What Is Being Fixed

The Customer Portal is missing the new "Content Marketing Platform" (CMP) product. It needs to be available in Koroneiki, Provisioning, and the Customer Portal so it can be provisioned and shown to customers. The CRM team confirmed the SKU names as `Content Marketing Platform`, `Content Marketing Platform - Production`, and `Content Marketing Platform - Non-Production`.

## How It Is Being Fixed

Following the pattern established when AI Hub was introduced (LRSD-12365 / PR liferay-one/liferay-portal#1132), this registers CMP as a brand-new product across the Customer Portal site-initializer: it adds the `contentMarketingPlatform` product type, lists "Content Marketing Platform" in the ERC-001 Liferay Cloud group activation, seeds the three CMP SKUs on the main test account (ERC-001), and adds a dedicated "Content Marketing Platform Test Account" (ERC-026) mirroring the AI Hub test account. CMP is grouped under "Liferay Cloud" per the acceptance criteria, so the SKU names are product-prefixed to avoid colliding with the base Liferay Cloud "Production" subscription. Koroneiki and Provisioning are configured through the Control Panel UI (no code change).

## Why Are There No Tests?

This is site-initializer test-data plus a one-line product-type constant, not testable logic. It mirrors PR #1132 (LRSD-12365), which likewise added products without tests.

## PR Check

**pr-check: PASS** — tested on `a7d525cf5404e84b31aced994932f1170088de6d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "a7d525cf5404e84b31aced994932f1170088de6d"} -->
