### PR TITLE
LPD-99238 Create CMP orders from Koroneiki product purchase events

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/KoroneikiRestController.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/KoroneikiRestController.java
@@ -171,6 +171,13 @@ public class KoroneikiRestController extends BaseRestController {
 				"license-usage-type", orderItem.getOptions());
 
 			if (name == null) {
+				Sku sku = _marketplaceService.getSku(orderItem.getSkuId());
+
+				name = MarketplaceUtil.getSkuOptionValue(
+					"license-usage-type", sku.getSkuOptions());
+			}
+
+			if (name == null) {
 				name = orderItem.getSkuExternalReferenceCode();
 			}
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceMessageReceiver.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceMessageReceiver.java
@@ -20,11 +20,14 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.PostalAddressResource;
+import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Sku;
+import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.SkuOption;
 import com.liferay.headless.commerce.admin.catalog.client.resource.v1_0.SkuResource;
 import com.liferay.headless.commerce.admin.channel.client.dto.v1_0.Channel;
 import com.liferay.headless.commerce.admin.channel.client.resource.v1_0.ChannelResource;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderItemResource;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderResource;
 import com.liferay.marketplace.constants.MarketplaceConstants;
 import com.liferay.marketplace.service.KoroneikiService;
@@ -45,6 +48,7 @@ import java.util.Objects;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.http.HttpStatus;
@@ -120,6 +124,47 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 		}
 	}
 
+	private void _addMissingOrderItem(
+			Order order, ProductPurchase productPurchase)
+		throws Exception {
+
+		OrderItemResource orderItemResource =
+			_marketplaceService.getOrderItemResource();
+
+		for (OrderItem orderItem :
+				orderItemResource.getOrderIdOrderItemsPage(
+					order.getId(),
+					com.liferay.headless.commerce.admin.order.client.pagination.
+						Pagination.of(1, 100)
+				).getItems()) {
+
+			if (Objects.equals(
+					orderItem.getSkuExternalReferenceCode(),
+					productPurchase.getProductKey())) {
+
+				return;
+			}
+		}
+
+		orderItemResource.postOrderIdOrderItem(
+			order.getId(),
+			_createOrderItem(
+				productPurchase, _getSku(productPurchase.getProductKey())));
+	}
+
+	private OrderItem _createOrderItem(
+		ProductPurchase productPurchase, Sku catalogSku) {
+
+		return new OrderItem() {
+			{
+				setOptions(() -> _getOptions(catalogSku));
+				setQuantity(
+					() -> new BigDecimal(productPurchase.getQuantity()));
+				setSkuExternalReferenceCode(productPurchase::getProductKey);
+			}
+		};
+	}
+
 	private Account _getAccount(String externalReferenceCode) throws Exception {
 		AccountResource accountResource =
 			_marketplaceService.getAccountResource();
@@ -183,6 +228,32 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 		};
 	}
 
+	private String _getOptions(Sku sku) {
+		JSONArray jsonArray = new JSONArray();
+
+		SkuOption[] skuOptions = sku.getSkuOptions();
+
+		if (skuOptions == null) {
+			return jsonArray.toString();
+		}
+
+		for (SkuOption skuOption : skuOptions) {
+			jsonArray.put(
+				new JSONObject(
+				).put(
+					"key", skuOption.getKey()
+				).put(
+					"value",
+					new JSONArray(
+					).put(
+						skuOption.getValue()
+					)
+				));
+		}
+
+		return jsonArray.toString();
+	}
+
 	private Order _getOrder(String externalReferenceCode) throws Exception {
 		OrderResource orderResource = _marketplaceService.getOrderResource();
 
@@ -201,6 +272,10 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 	private String _getOrderTypeExternalReferenceCode(String productName) {
 		if (productName.contains("AI Hub")) {
 			return "AI_HUB";
+		}
+
+		if (productName.contains("Content Marketing Platform")) {
+			return "CMP";
 		}
 
 		if (productName.contains("LR Tokens")) {
@@ -240,6 +315,24 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 				return postalAddress;
 			},
 			PostalAddress.class);
+	}
+
+	private Sku _getSku(String skuExternalReferenceCode) throws Exception {
+		SkuResource skuResource = _marketplaceService.getSkuResource();
+
+		com.liferay.headless.commerce.admin.catalog.client.http.HttpInvoker.
+			HttpResponse httpResponse =
+				skuResource.getSkuByExternalReferenceCodeHttpResponse(
+					skuExternalReferenceCode);
+
+		if (!_isOKStatusCode(httpResponse.getStatusCode())) {
+			throw new Exception(
+				StringBundler.concat(
+					"Unable to process product purchase, SKU ",
+					skuExternalReferenceCode, " not found"));
+		}
+
+		return Sku.toDTO(httpResponse.getContent());
 	}
 
 	private UserAccount _getUserAccount(String emailAddress) throws Exception {
@@ -354,31 +447,14 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 		Order order = _getOrder(opportunityId);
 
 		if (order == null) {
-			SkuResource skuResource = _marketplaceService.getSkuResource();
-
-			com.liferay.headless.commerce.admin.catalog.client.http.HttpInvoker.
-				HttpResponse httpResponse =
-					skuResource.getSkuByExternalReferenceCodeHttpResponse(
-						productPurchase.getProductKey());
-
-			if (!_isOKStatusCode(httpResponse.getStatusCode())) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						"Unable to process product purchase, SKU not found");
-				}
-
-				return;
-			}
-
 			if (_getAccount(koroneikiAccount.getParentAccountKey()) == null) {
-				if (_log.isInfoEnabled()) {
-					_log.info(
-						"Unable to process product purchase, Account not " +
-							"found");
-				}
-
-				return;
+				throw new Exception(
+					StringBundler.concat(
+						"Unable to process product purchase, account ",
+						koroneikiAccount.getParentAccountKey(), " not found"));
 			}
+
+			Sku sku = _getSku(productPurchase.getProductKey());
 
 			OrderResource orderResource =
 				_marketplaceService.getOrderResource();
@@ -395,15 +471,7 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 						setExternalReferenceCode(() -> opportunityId);
 						setOrderItems(
 							() -> new OrderItem[] {
-								new OrderItem() {
-									{
-										setQuantity(
-											() -> new BigDecimal(
-												productPurchase.getQuantity()));
-										setSkuExternalReferenceCode(
-											productPurchase::getProductKey);
-									}
-								}
+								_createOrderItem(productPurchase, sku)
 							});
 						setOrderTypeExternalReferenceCode(
 							() -> _getOrderTypeExternalReferenceCode(
@@ -414,6 +482,9 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 									ORDER_PAYMENT_STATUS_NOT_REQUIRED);
 					}
 				});
+		}
+		else {
+			_addMissingOrderItem(order, productPurchase);
 		}
 
 		_provisioningHubService.provision(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
@@ -50,7 +50,7 @@ import org.springframework.stereotype.Service;
 public class MarketplaceTopicSubscriber {
 
 	@PostConstruct
-	public void postConstruct() {
+	public void postConstruct() throws Exception {
 		GoogleCredentials googleCredentials;
 
 		try {

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/KoroneikiService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/KoroneikiService.java
@@ -179,6 +179,37 @@ public class KoroneikiService {
 			productPurchase);
 	}
 
+	public void linkProductPurchaseToOrder(
+			long orderId, String productPurchaseKey)
+		throws Exception {
+
+		ProductPurchaseResource productPurchaseResource =
+			getProductPurchaseResource();
+
+		ProductPurchase productPurchase =
+			productPurchaseResource.getProductPurchase(productPurchaseKey);
+
+		String entityId = String.valueOf(orderId);
+
+		ExternalLink[] externalLinks = productPurchase.getExternalLinks();
+
+		if (externalLinks != null) {
+			for (ExternalLink externalLink : externalLinks) {
+				if (Objects.equals(externalLink.getEntityId(), entityId)) {
+					return;
+				}
+			}
+		}
+
+		productPurchase.setExternalLinks(
+			MarketplaceUtil.appendExternalLink(
+				externalLinks, "marketplace", entityId, "opportunity"));
+
+		productPurchaseResource.putProductPurchase(
+			_MARKETPLACE_AGENT_NAME, _MARKETPLACE_AGENT_NAME,
+			productPurchaseKey, productPurchase);
+	}
+
 	public ProductPurchase postAccountAccountKeyProductPurchase(
 			String accountKey, Jwt jwt, String licenseType,
 			String licenseUsageType, OrderItem orderItem)
@@ -352,6 +383,8 @@ public class KoroneikiService {
 		return accountResource.postAccount(
 			jwt.getClaim("username"), jwt.getClaim("sub"), koroneikiAccount);
 	}
+
+	private static final String _MARKETPLACE_AGENT_NAME = "marketplace";
 
 	private static final Log _log = LogFactory.getLog(KoroneikiService.class);
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -45,6 +45,12 @@ public class ProvisioningHubService extends BaseService {
 			ProductPurchase productPurchase)
 		throws Exception {
 
+		if (Objects.equals(order.getOrderTypeExternalReferenceCode(), "CMP")) {
+			_provisionCMP(order, productPurchase);
+
+			return;
+		}
+
 		Product product = productPurchase.getProduct();
 
 		String productName = product.getName();
@@ -193,6 +199,16 @@ public class ProvisioningHubService extends BaseService {
 						"project")
 				).toString()
 			).build(),
+			order.getId(), order.getPaymentStatus());
+	}
+
+	private void _provisionCMP(Order order, ProductPurchase productPurchase)
+		throws Exception {
+
+		_koroneikiService.linkProductPurchaseToOrder(
+			order.getId(), productPurchase.getKey());
+
+		_marketplaceService.completeOrder(
 			order.getId(), order.getPaymentStatus());
 	}
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/util/MarketplaceUtil.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/util/MarketplaceUtil.java
@@ -14,6 +14,7 @@ import com.liferay.osb.koroneiki.phloem.rest.client.dto.v1_0.ExternalLink;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -334,6 +335,10 @@ public class MarketplaceUtil {
 	}
 
 	public static String getSkuOptionValue(String key, SkuOption[] skuOptions) {
+		if (skuOptions == null) {
+			return null;
+		}
+
 		for (SkuOption skuOption : skuOptions) {
 			String skuOptionKey = skuOption.getKey();
 
@@ -348,6 +353,10 @@ public class MarketplaceUtil {
 	}
 
 	public static String getSkuOptionValue(String key, String options) {
+		if (Validator.isNull(options)) {
+			return null;
+		}
+
 		JSONArray optionsJSONArray = new JSONArray(options);
 
 		for (int i = 0; i < optionsJSONArray.length(); i++) {

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/commerce-order-types.json
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/commerce-order-types.json
@@ -165,5 +165,17 @@
 			"en_US": "CMP Beta"
 		},
 		"neverExpire": true
+	},
+	{
+		"active": true,
+		"description": {
+			"en_US": "Designates that the order is Liferay CMP."
+		},
+		"displayOrder": 14,
+		"externalReferenceCode": "CMP",
+		"name": {
+			"en_US": "CMP"
+		},
+		"neverExpire": true
 	}
 ]


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99238

## What Is Being Fixed

CMP is sold through the traditional sales channel at GA, so no self-service checkout creates the Marketplace order, and the customer dashboard license wizard had no data to work with: the Subscription step resolves the order's subscriptions by matching a Koroneiki product purchase linked to the numeric order ID, which nothing created for CMP. Orders created outside checkout also carry no options on their order items, so the subscriptions endpoint rendered the Koroneiki product key (`KOR-…`) as the subscription name and threw when the options were null. The pub/sub topic subscriber also did not compile because `SubscriptionAdminClient.create` throws a checked `IOException` that was neither caught nor declared.

## How It Is Being Fixed

A new `CMP` commerce order type designates GA orders, keeping `CMP_BETA` untouched for the beta checkout flow. When Salesforce closes a deal, Koroneiki emits a product purchase event and the pub/sub receiver now maps Content Marketing Platform products to the `CMP` order type, carries the catalog SKU options onto the created order item, and appends missing order items when several SKUs share one opportunity. `ProvisioningHubService` links the product purchase back to the numeric order ID — the same link the paid-app flow records — and completes the order so the dashboard license wizard can resolve the subscriptions. The receiver now fails instead of acknowledging when the account or SKU is not yet available, so the message is redelivered under the subscription's retry policy instead of being silently dropped. The subscriptions endpoint falls back to the catalog SKU options when the order item carries none.

## Why Are There No Tests?

The marketplace Spring Boot client extension has no unit test infrastructure (no src/test tree or test dependencies in the workspace), and the change orchestrates external systems — GCP Pub/Sub, Koroneiki, Salesforce — that only exist in the provisioning environments. Verification is manual against the dev environment.

## PR Check

**pr-check: PASS** — tested on `63442ea8c2944b76da7df9e58ea5e371a42a5504`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "63442ea8c2944b76da7df9e58ea5e371a42a5504"} -->
