### PR TITLE
LPD-98653 Add LDP and add-ons to Koroneiki, Provisioning, CP

### DIFF
--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-custom-element/src/features/project/utils/constants/productTypes.ts
@@ -13,6 +13,7 @@ export const PRODUCT_TYPES = {
 	dxpCloud: 'Liferay PaaS',
 	enterpriseSearch: 'Enterprise Search',
 	liferayCloud: 'Liferay Cloud',
+	liferayDataPlatform: 'Liferay Data Platform',
 	liferayExperienceCloud: 'Liferay SaaS',
 	other: 'Other',
 	partnership: 'Partnership',

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/accounts.json
@@ -118,5 +118,10 @@
 		"externalReferenceCode": "ERC-024",
 		"name": "Liferay DXP Academic Test Account",
 		"type": "business"
+	},
+	{
+		"externalReferenceCode": "ERC-027",
+		"name": "Liferay Data Platform Test Account",
+		"type": "business"
 	}
 ]

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription-group.object-entries.json
@@ -32,7 +32,7 @@
 		},
 		{
 			"accountKey": "ERC-001",
-			"activationProductName": "AI Hub, Cloud Native, Liferay PaaS, Liferay SaaS",
+			"activationProductName": "AI Hub, Cloud Native, Liferay Data Platform, Liferay PaaS, Liferay SaaS",
 			"activationStatus": "Active",
 			"externalReferenceCode": "ERC-001_liferay-cloud",
 			"hasActivation": true,
@@ -317,6 +317,17 @@
 			"menuOrder": 1,
 			"name": "Self-Hosted",
 			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-024",
+			"tabOrder": 2
+		},
+		{
+			"accountKey": "ERC-027",
+			"activationProductName": "Liferay Data Platform",
+			"activationStatus": "Active",
+			"externalReferenceCode": "ERC-027_liferay-cloud",
+			"hasActivation": false,
+			"menuOrder": 1,
+			"name": "Liferay Cloud",
+			"r_accountEntryToAccountSubscriptionGroup_accountEntryERC": "ERC-027",
 			"tabOrder": 2
 		}
 	],

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/account-subscription.object-entries.json
@@ -577,6 +577,54 @@
 			"subscriptionStatus": "Active"
 		},
 		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_liferay-data-platform",
+			"instanceSize": "1",
+			"name": "Liferay Data Platform",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_additional-events",
+			"instanceSize": "1",
+			"name": "Additional Events",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_overage-events",
+			"instanceSize": "1",
+			"name": "Overage Events",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-001",
+			"accountSubscriptionGroupERC": "ERC-001_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-001_liferay-cloud_ldp-connector",
+			"instanceSize": "1",
+			"name": "LDP Connector",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-001",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
 			"accountKey": "ERC-023",
 			"accountSubscriptionGroupERC": "ERC-023_liferay-cloud",
 			"endDate": "2026-12-31T00:00:00Z",
@@ -621,6 +669,54 @@
 			"name": "Academic Non-Production",
 			"quantity": 1,
 			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-024",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-027",
+			"accountSubscriptionGroupERC": "ERC-027_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-027_liferay-cloud_liferay-data-platform",
+			"instanceSize": "1",
+			"name": "Liferay Data Platform",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-027",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-027",
+			"accountSubscriptionGroupERC": "ERC-027_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-027_liferay-cloud_additional-events",
+			"instanceSize": "1",
+			"name": "Additional Events",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-027",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-027",
+			"accountSubscriptionGroupERC": "ERC-027_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-027_liferay-cloud_overage-events",
+			"instanceSize": "1",
+			"name": "Overage Events",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-027",
+			"startDate": "2023-01-01T00:00:00Z",
+			"subscriptionStatus": "Active"
+		},
+		{
+			"accountKey": "ERC-027",
+			"accountSubscriptionGroupERC": "ERC-027_liferay-cloud",
+			"endDate": "2026-12-31T00:00:00Z",
+			"externalReferenceCode": "ERC-027_liferay-cloud_ldp-connector",
+			"instanceSize": "1",
+			"name": "LDP Connector",
+			"quantity": 1,
+			"r_accountEntryToAccountSubscription_accountEntryERC": "ERC-027",
 			"startDate": "2023-01-01T00:00:00Z",
 			"subscriptionStatus": "Active"
 		}

--- a/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
+++ b/workspaces/liferay-customer-workspace/client-extensions/liferay-customer-site-initializer/site-initializer/object-entries/koroneiki-account.object-entries.json
@@ -383,6 +383,22 @@
 			"partner": false,
 			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-024",
 			"region": "United States"
+		},
+		{
+			"accountKey": "ERC-027",
+			"code": "TESTACCOUNT27",
+			"dxpVersion": "7.4",
+			"externalReferenceCode": "ERC-027",
+			"liferayContactEmailAddress": "customer-service@liferay.com",
+			"liferayContactName": "Liferay Support",
+			"maxRequestors": -1,
+			"name": "Liferay Data Platform Test Account",
+			"partner": false,
+			"r_accountEntryToKoroneikiAccount_accountEntryERC": "ERC-027",
+			"region": "United States",
+			"slaCurrent": "Platinum Subscription",
+			"slaCurrentEndDate": "2026-12-31 00:00:00.0",
+			"slaCurrentStartDate": "2023-01-01 00:00:00.0"
 		}
 	],
 	"objectDefinitionName": "KoroneikiAccount"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98653

## What Is Being Fixed

The Customer Portal is missing the new "Liferay Data Platform" (LDP) product and its add-ons. LDP needs to be available in Koroneiki, Provisioning, and the Customer Portal so it can be provisioned and shown to customers. The CRM team confirmed the SKUs as `Liferay Data Platform` (primary) plus the add-ons `Additional Events`, `Overage Events`, and `LDP Connector`.

## How It Is Being Fixed

Following the pattern established when AI Hub was introduced (LRSD-12365 / PR liferay-one/liferay-portal#1132), this registers LDP as a brand-new product across the Customer Portal site-initializer: it adds the `liferayDataPlatform` product type, lists "Liferay Data Platform" in the ERC-001 Liferay Cloud group activation, seeds the four LDP SKUs on the main test account (ERC-001), and adds a dedicated "Liferay Data Platform Test Account" (ERC-027).

The three add-ons follow the same treatment AI Hub's "LR Tokens" add-ons received: they are plain account subscriptions and do not get their own product type or activation entry — only the primary product does. The add-on classification lives on the Koroneiki product definition. LDP is grouped under "Liferay Cloud" per the acceptance criteria, and Koroneiki and Provisioning are configured through the Control Panel UI (no code change).

## Why Are There No Tests?

This is site-initializer test-data plus a one-line product-type constant, not testable logic. It mirrors PR #1132 (LRSD-12365), which likewise added products without tests.

## PR Check

**pr-check: PASS** — tested on `900a180627d84e30e800771ab9780b003fcc27b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "900a180627d84e30e800771ab9780b003fcc27b9"} -->
