### PR TITLE
LPD-99238 Let CMP customers create and manage license keys

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/enums/Order.ts
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/enums/Order.ts
@@ -32,7 +32,8 @@ export enum OrderTypes {
 	AI_HUB_TOKEN = 'AI_HUB_TOKEN',
 	CLIENT_EXTENSION = 'CLIENT_EXTENSION',
 	CLOUD_APP = 'CLOUD_APP',
-	CMP = 'CMP_BETA',
+	CMP = 'CMP',
+	CMP_BETA = 'CMP_BETA',
 	COMPOSITE_APP = 'COMPOSITE_APP',
 	DSR = 'DSR',
 	DXP = 'DXP',
@@ -71,15 +72,23 @@ export const APP_ORDER_TYPES: readonly OrderTypes[] = [
 	OrderTypes.OTHER,
 ];
 
+export const CMP_ORDER_TYPES: readonly OrderTypes[] = [
+	OrderTypes.CMP,
+	OrderTypes.CMP_BETA,
+];
+
 export const LIFERAY_PRODUCT_ORDER_TYPES: readonly OrderTypes[] = [
 	OrderTypes.ADDONS,
 	OrderTypes.AI_HUB,
 	OrderTypes.CMP,
+	OrderTypes.CMP_BETA,
 	OrderTypes.DXP,
 ];
 
 export const orderTypeDocumentationURL: Partial<Record<OrderTypes, string>> = {
 	[OrderTypes.CMP]: 'https://learn.liferay.com/content-marketing-platform',
+	[OrderTypes.CMP_BETA]:
+		'https://learn.liferay.com/content-marketing-platform',
 	[OrderTypes.DSR]: 'https://learn.liferay.com/w/digital-sales-room/index',
 	[OrderTypes.DXP]:
 		'https://learn.liferay.com/w/dxp/self-hosted-installation-and-upgrades/setting-up-liferay/activating-liferay-dxp',
@@ -92,6 +101,7 @@ export const orderTypeLabel = {
 	[OrderTypes.CLIENT_EXTENSION]: 'Client Extension',
 	[OrderTypes.CLOUD_APP]: 'Cloud',
 	[OrderTypes.CMP]: 'Content Marketing Platform',
+	[OrderTypes.CMP_BETA]: 'Content Marketing Platform',
 	[OrderTypes.COMPOSITE_APP]: 'Composite App',
 	[OrderTypes.DSR]: 'Digital Sales Room',
 	[OrderTypes.DXP_APP]: 'DXP',
@@ -133,6 +143,7 @@ export function getOrderStatusLabel(order: PlacedOrder) {
 		[
 			OrderTypes.ADDONS,
 			OrderTypes.CMP,
+			OrderTypes.CMP_BETA,
 			OrderTypes.DXP,
 			OrderTypes.DSR,
 		].includes(order.orderTypeExternalReferenceCode as OrderTypes)

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/i18n/en_US.ts
@@ -528,6 +528,8 @@ export default {
 	'no-orders-yet': 'No Orders Yet',
 	'no-projects-available-for-x': 'No projects available for {0}',
 	'no-results-found': 'No Results Found',
+	'no-subscriptions-are-available-for-this-order':
+		'No subscriptions are available for this order. Contact your Liferay representative for assistance.',
 	'no-trials-yet': 'No Trials Yet',
 	'no-x': 'No {0}',
 	'not-installed': 'Not Installed',

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/CreateLicense/SelectSubscription.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/CreateLicense/SelectSubscription.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayAlert from '@clayui/alert';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import classNames from 'classnames';
 import {useParams} from 'react-router-dom';
@@ -38,6 +39,14 @@ const SelectSubscription = ({
 			<p>Generate licenses with a selected subscription term.</p>
 
 			{(isLoading || isValidating) && <ClayLoadingIndicator />}
+
+			{!isLoading && !isValidating && !subscriptions.length && (
+				<ClayAlert displayType="info">
+					{i18n.translate(
+						'no-subscriptions-are-available-for-this-order'
+					)}
+				</ClayAlert>
+			)}
 
 			<RadioCardList
 				contentList={subscriptions.map((licenseKey, index) => {

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/CreateLicense/index.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/CreateLicense/index.tsx
@@ -12,6 +12,10 @@ import FooterButtons from '../../../../../../../components/FooterButtons';
 import {useMarketplaceContext} from '../../../../../../../context/MarketplaceContext';
 import {Analytics} from '../../../../../../../core/Analytics';
 import {MarketplaceDeliveryProduct} from '../../../../../../../entity/MarketplaceDeliveryProduct';
+import {
+	LIFERAY_PRODUCT_ORDER_TYPES,
+	OrderTypes,
+} from '../../../../../../../enums/Order';
 import useGetProductByOrderId from '../../../../../../../hooks/useGetProductByOrderId';
 import {Liferay} from '../../../../../../../liferay/liferay';
 import zodSchema from '../../../../../../../schema/zod';
@@ -83,6 +87,10 @@ const CreateLicense = () => {
 
 	const navigate = useNavigate();
 	const product = data?.product;
+
+	const isLiferayProductOrder = LIFERAY_PRODUCT_ORDER_TYPES.includes(
+		data?.placedOrder?.orderTypeExternalReferenceCode as OrderTypes
+	);
 
 	const productCreatorAccountName = product?.catalogName || '';
 
@@ -173,7 +181,11 @@ const CreateLicense = () => {
 					type: form.subscription?.name,
 				});
 
-				navigate(`/order/${orderId}/licenses`);
+				navigate(
+					isLiferayProductOrder
+						? `/products/${orderId}`
+						: `/order/${orderId}/licenses`
+				);
 
 				await provisioningOAuth2.downloadAppLicenseKey(licenseKey.id);
 
@@ -191,14 +203,17 @@ const CreateLicense = () => {
 
 			setLoading(false);
 		},
-		[navigate, orderId, product]
+		[isLiferayProductOrder, navigate, orderId, product]
 	);
 
 	const buttonsInfo = useMemo(
 		() => ({
 			cancelButton: {
 				displayType: 'unstyled',
-				onClick: () => navigate('..'),
+				onClick: () =>
+					navigate(
+						isLiferayProductOrder ? `/products/${orderId}` : '..'
+					),
 				show: true,
 			},
 			customizedButton: {
@@ -231,8 +246,10 @@ const CreateLicense = () => {
 			disableContinueButton,
 			getValues,
 			handleNextButton,
+			isLiferayProductOrder,
 			loading,
 			navigate,
+			orderId,
 			step,
 			subscription,
 		]

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/Licenses.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/Apps/App/Licenses/Licenses.tsx
@@ -70,6 +70,7 @@ const Licenses = ({actions, readOnly = false}: LicensesProps) => {
 	const keyType = [
 		OrderTypes.CLIENT_EXTENSION,
 		OrderTypes.CMP,
+		OrderTypes.CMP_BETA,
 		OrderTypes.COMPOSITE_APP,
 		OrderTypes.DSR,
 		OrderTypes.DXP_APP,

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/ActivationKeysDetails.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/ActivationKeysDetails.tsx
@@ -235,25 +235,32 @@ export default function ActivationKeys() {
 	const orderTypeExternalReferenceCode =
 		outletContext?.placedOrder.orderTypeExternalReferenceCode;
 
-	const ActivationKeysComponent =
-		orderTypeExternalReferenceCode === OrderTypes.DXP
-			? ActivationKeysDXP
-			: () => (
-					<Licenses
-						actions={(row, licenseActions) => (
-							<ClayButton
-								displayType="secondary"
-								onClick={() =>
-									licenseActions.onDownloadLicenseKey(row)
-								}
-								size="sm"
-							>
-								{i18n.translate('download')}
-							</ClayButton>
-						)}
-						readOnly
-					/>
-				);
+	const getActivationKeysComponent = () => {
+		if (orderTypeExternalReferenceCode === OrderTypes.DXP) {
+			return ActivationKeysDXP;
+		}
+
+		if (orderTypeExternalReferenceCode === OrderTypes.CMP) {
+			return () => <Licenses />;
+		}
+
+		return () => (
+			<Licenses
+				actions={(row, licenseActions) => (
+					<ClayButton
+						displayType="secondary"
+						onClick={() => licenseActions.onDownloadLicenseKey(row)}
+						size="sm"
+					>
+						{i18n.translate('download')}
+					</ClayButton>
+				)}
+				readOnly
+			/>
+		);
+	};
+
+	const ActivationKeysComponent = getActivationKeysComponent();
 
 	return (
 		<div className="mt-5">

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProduct.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProduct.tsx
@@ -30,9 +30,12 @@ const LiferayProduct = () => {
 	}
 
 	if (
-		[OrderTypes.CMP, OrderTypes.DSR, OrderTypes.DXP].includes(
-			orderTypeExternalReferenceCode
-		)
+		[
+			OrderTypes.CMP,
+			OrderTypes.CMP_BETA,
+			OrderTypes.DSR,
+			OrderTypes.DXP,
+		].includes(orderTypeExternalReferenceCode)
 	) {
 		return <ActivationKeysDetails />;
 	}

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProductsOutlet.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProductsOutlet.tsx
@@ -9,6 +9,7 @@ import ClayIcon from '@clayui/icon';
 import {NavbarProps} from '../../../../components/Navbar';
 import {useMarketplaceContext} from '../../../../context/MarketplaceContext';
 import {
+	CMP_ORDER_TYPES,
 	OrderCustomFields,
 	OrderTypes,
 	OrderWorkflowStatusCode,
@@ -32,7 +33,9 @@ const getTabs = (data: ProductAndOrderPayload): NavbarProps['routes'] => {
 		return [];
 	}
 
-	const isCMP = orderTypeExternalReferenceCode === OrderTypes.CMP;
+	const isCMP = CMP_ORDER_TYPES.includes(
+		orderTypeExternalReferenceCode as OrderTypes
+	);
 	const isDSR = orderTypeExternalReferenceCode === OrderTypes.DSR;
 	const isDXP = orderTypeExternalReferenceCode === OrderTypes.DXP;
 
@@ -93,6 +96,7 @@ const LiferayProductsOutlet = () => {
 						OrderTypes.ADDONS,
 						OrderTypes.AI_HUB,
 						OrderTypes.CMP,
+						OrderTypes.CMP_BETA,
 						OrderTypes.DSR,
 						OrderTypes.DXP,
 					].includes(orderType)
@@ -132,7 +136,7 @@ const LiferayProductsOutlet = () => {
 									</ClayButton>
 								)}
 
-							{[OrderTypes.CMP, OrderTypes.DXP].includes(
+							{[OrderTypes.CMP_BETA, OrderTypes.DXP].includes(
 								orderType
 							) && (
 								<ClayButton
@@ -148,6 +152,23 @@ const LiferayProductsOutlet = () => {
 									{i18n.translate('new-activation-key')}
 								</ClayButton>
 							)}
+
+							{orderType === OrderTypes.CMP &&
+								orderStatus ===
+									OrderWorkflowStatusCode.COMPLETED && (
+									<ClayButton
+										displayType="primary"
+										onClick={() => {
+											Liferay.Util.navigate(
+												`${getSiteURL()}/customer-dashboard#/order/${props?.placedOrder?.id}/create-license`
+											);
+										}}
+										outline
+										size="regular"
+									>
+										{i18n.translate('create-license-key')}
+									</ClayButton>
+								)}
 
 							{groupId && (
 								<ClayButton

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/index.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/index.tsx
@@ -27,6 +27,7 @@ const searchParams = new URLSearchParams({
 		OrderTypes.ADDONS,
 		OrderTypes.AI_HUB,
 		OrderTypes.CMP,
+		OrderTypes.CMP_BETA,
 		OrderTypes.DSR,
 		OrderTypes.DXP,
 	]),
@@ -102,9 +103,17 @@ const LiferayProductsListView = () => {
 							},
 							{
 								hidden: (row: PlacedOrder) =>
+									row.orderTypeExternalReferenceCode !==
+									OrderTypes.CMP,
+								name: i18n.translate('create-license-key'),
+								onClick: (placedOrder: PlacedOrder) =>
+									navigate(getViewDetailsPath(placedOrder)),
+							},
+							{
+								hidden: (row: PlacedOrder) =>
 									![
 										OrderTypes.AI_HUB,
-										OrderTypes.CMP,
+										OrderTypes.CMP_BETA,
 										OrderTypes.DSR,
 									].includes(
 										row.orderTypeExternalReferenceCode as OrderTypes

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/ProductPurchase/services/ProductPurchaseCMP.ts
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/ProductPurchase/services/ProductPurchaseCMP.ts
@@ -15,7 +15,7 @@ type GenerateLicenseKeyForm = z.infer<typeof zodSchema.generateLicenseKey>;
 
 export class ProductPurchaseCMP extends ProductPurchase {
 	private form?: GenerateLicenseKeyForm;
-	protected orderTypeExternalReferenceCode = OrderTypes.CMP;
+	protected orderTypeExternalReferenceCode = OrderTypes.CMP_BETA;
 
 	setForm(form: GenerateLicenseKeyForm) {
 		this.form = form;
@@ -56,7 +56,7 @@ export class ProductPurchaseCMP extends ProductPurchase {
 	}
 
 	public async getNextStepsLink(cart: Cart) {
-		if (cart.orderTypeExternalReferenceCode !== OrderTypes.CMP) {
+		if (cart.orderTypeExternalReferenceCode !== OrderTypes.CMP_BETA) {
 			return super.getNextStepsLink(cart);
 		}
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
@@ -50,7 +50,7 @@ import org.springframework.stereotype.Service;
 public class MarketplaceTopicSubscriber {
 
 	@PostConstruct
-	public void postConstruct() {
+	public void postConstruct() throws Exception {
 		GoogleCredentials googleCredentials;
 
 		try {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99238

## What Is Being Fixed

CMP GA orders had no way to create license keys from the customer dashboard: the activation tab was a read-only list with a download button, the create license wizard was only reachable for paid app orders, and the dashboard could not tell a GA order from a beta order since both shared the `CMP_BETA` order type.

## How It Is Being Fixed

A dedicated `CMP` order type identifies GA orders — created by the provisioning pipeline when a sale closes — while the beta checkout keeps creating `CMP_BETA` orders. The activation tab of a CMP GA order now renders the same license management paid apps use: the create license wizard reachable from the empty state and from a header button, a Create License Key action on the products listing kebab, and view, download, and deactivate actions per key. Beta orders keep the read-only tab, and the New Activation Key button stays on beta orders only since it points to the beta checkout. The wizard returns to the product details page when the order is a Liferay product, and the subscription step shows an informative message when the order has no subscriptions to offer. The branch also carries the pub/sub topic subscriber compile fix shipped in the backend pull request (#1321) so the workspace builds independently; whichever merges second drops the duplicate on rebase.

## Why Are There No Tests?

The marketplace custom element has no unit test infrastructure (no test script or Jest setup in the workspace). The change is routing and gating over order types, verified by the TypeScript compiler and the workspace build, and manually against the dev environment.

## PR Check

**pr-check: PASS** — tested on `3826b3a3f1a4d3981dba0fb51ae0bbec5e525cf1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Workspace Build | PASS |

<!-- pr-check {"result": "success", "sha": "3826b3a3f1a4d3981dba0fb51ae0bbec5e525cf1"} -->
