### PR TITLE
LPD-91433 Add the common license key download endpoint

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -139,7 +139,7 @@ public class AccountsRestController extends OneBaseRestController {
 		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
 
 		JSONObject jsonObject = _commonLicenseKeyService.getCommonLicenseKey(
-			productGroup, productEnvironment);
+			productEnvironment, productGroup);
 
 		if (jsonObject == null) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -14,7 +14,9 @@ import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommonLicenseKeyService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.ProvisioningAssignmentService;
@@ -25,6 +27,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.time.Instant;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -38,6 +42,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -116,6 +121,45 @@ public class AccountsRestController extends OneBaseRestController {
 		return new ResponseEntity<>(
 			_accountAssetService.getAccountObjectKey(externalReferenceCode),
 			HttpStatus.OK);
+	}
+
+	@GetMapping(
+		"/{accountKey}/product-groups/{productGroup}/product-environments/{productEnvironment}/common-license-key"
+	)
+	public ResponseEntity<String>
+			getProductGroupsProductEnvironmentsCommonLicenseKey(
+				@AuthenticationPrincipal Jwt jwt,
+				@PathVariable("accountKey") String accountKey,
+				@PathVariable("productEnvironment") String productEnvironment,
+				@PathVariable("productGroup") String productGroup)
+		throws Exception {
+
+		Account account = _accountService.getAccount(accountKey, jwt);
+
+		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
+
+		JSONObject jsonObject = _commonLicenseKeyService.getCommonLicenseKey(
+			productGroup, productEnvironment);
+
+		if (jsonObject == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		if (!_entitlementService.hasEntitlementCoveringDateRange(
+				account.getId(),
+				Instant.parse(jsonObject.getString("startDate")),
+				Instant.parse(jsonObject.getString("endDate")))) {
+
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
+
+		return ResponseEntity.ok(
+		).header(
+			HttpHeaders.CONTENT_DISPOSITION,
+			"attachment; filename=\"" + jsonObject.getString("fileName") + "\""
+		).body(
+			jsonObject.getString("fileContent")
+		);
 	}
 
 	@PostMapping("/{externalReferenceCode}/sync-to-jsm")
@@ -421,10 +465,16 @@ public class AccountsRestController extends OneBaseRestController {
 	private AdminPermission _adminPermission;
 
 	@Autowired
+	private CommonLicenseKeyService _commonLicenseKeyService;
+
+	@Autowired
 	private EmailAddressValidatorService _emailAddressValidatorService;
 
 	@Autowired
 	private EntitlementService _entitlementService;
+
+	@Autowired
+	private LicenseKeyPermission _licenseKeyPermission;
 
 	@Autowired
 	private OktaService _oktaService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -156,7 +156,7 @@ public class AccountsRestController extends OneBaseRestController {
 		}
 
 		JSONObject jsonObject = _commonLicenseKeyService.getCommonLicenseKey(
-			productEnvironment, productGroup);
+			endDateInstant, productEnvironment, productGroup, startDateInstant);
 
 		if (jsonObject == null) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -8,6 +8,8 @@ package com.liferay.one;
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.EntitlementConstants;
+import com.liferay.one.constants.EntitlementDefinitionConstants;
+import com.liferay.one.constants.ProductGroupConstants;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
@@ -26,6 +28,7 @@ import com.liferay.one.util.UserAccountUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.time.Instant;
@@ -53,6 +56,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -130,6 +134,8 @@ public class AccountsRestController extends OneBaseRestController {
 			getProductGroupsProductEnvironmentsCommonLicenseKey(
 				@AuthenticationPrincipal Jwt jwt,
 				@PathVariable("accountKey") String accountKey,
+				@RequestParam("dateEnd") String dateEnd,
+				@RequestParam("dateStart") String dateStart,
 				@PathVariable("productEnvironment") String productEnvironment,
 				@PathVariable("productGroup") String productGroup)
 		throws Exception {
@@ -138,19 +144,22 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
 
+		Instant endDateInstant = Instant.parse(dateEnd);
+		Instant startDateInstant = Instant.parse(dateStart);
+
+		if (!_entitlementService.hasEntitlementCoveringDateRange(
+				account.getId(),
+				_getEntitlementDefinitionExternalReferenceCode(productGroup),
+				startDateInstant, endDateInstant)) {
+
+			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+		}
+
 		JSONObject jsonObject = _commonLicenseKeyService.getCommonLicenseKey(
 			productEnvironment, productGroup);
 
 		if (jsonObject == null) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-		}
-
-		if (!_entitlementService.hasEntitlementCoveringDateRange(
-				account.getId(),
-				Instant.parse(jsonObject.getString("startDate")),
-				Instant.parse(jsonObject.getString("endDate")))) {
-
-			throw new ResponseStatusException(HttpStatus.FORBIDDEN);
 		}
 
 		return ResponseEntity.ok(
@@ -412,6 +421,24 @@ public class AccountsRestController extends OneBaseRestController {
 		}
 
 		return accountRoleNames;
+	}
+
+	private String _getEntitlementDefinitionExternalReferenceCode(
+		String productGroup) {
+
+		if (StringUtil.equals(productGroup, ProductGroupConstants.COMMERCE)) {
+			return EntitlementDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_COMMERCE;
+		}
+
+		if (StringUtil.equals(
+				productGroup, ProductGroupConstants.ENTERPRISE_SEARCH)) {
+
+			return EntitlementDefinitionConstants.
+				EXTERNAL_REFERENCE_CODE_ENTERPRISE_SEARCH;
+		}
+
+		throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
 	}
 
 	private void _unassignContactRole(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementDefinitionConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementDefinitionConstants.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.constants;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class EntitlementDefinitionConstants {
+
+	public static final String EXTERNAL_REFERENCE_CODE_COMMERCE =
+		"C_ENT_DEF_COMMERCE";
+
+	public static final String EXTERNAL_REFERENCE_CODE_ENTERPRISE_SEARCH =
+		"C_ENT_DEF_ENTERPRISE_SEARCH";
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductGroupConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/ProductGroupConstants.java
@@ -16,6 +16,8 @@ public class ProductGroupConstants {
 
 	public static final String DXP = "dxp";
 
+	public static final String ENTERPRISE_SEARCH = "enterpriseSearch";
+
 	public static final String PORTAL = "portal";
 
 	public static String getProductGroup(String productName) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
@@ -82,7 +82,7 @@ public class CommonLicenseKeyService extends OneBaseService {
 	}
 
 	public JSONObject getCommonLicenseKey(
-			String productFamily, String environmentType)
+			String environmentType, String productFamily)
 		throws Exception {
 
 		List<JSONObject> commonLicenseKeys = getAllItems(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
@@ -12,6 +12,10 @@ import com.liferay.one.license.CommonLicenseKeyParser;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.time.Instant;
+
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.json.JSONObject;
@@ -82,21 +86,27 @@ public class CommonLicenseKeyService extends OneBaseService {
 	}
 
 	public JSONObject getCommonLicenseKey(
-			String environmentType, String productFamily)
+			Instant endDate, String environmentType, String productFamily,
+			Instant startDate)
 		throws Exception {
 
 		List<JSONObject> commonLicenseKeys = getAllItems(
 			"/o/c/commonlicensekeys",
 			StringBundler.concat(
-				"(environmentType eq '", environmentType,
-				"') and (productFamily eq '", productFamily, "')"),
+				"(endDate ge ", endDate, ") and (environmentType eq '",
+				environmentType, "') and (productFamily eq '", productFamily,
+				"') and (productVersion eq null) and (startDate le ", startDate,
+				")"),
 			jsonObject -> jsonObject);
 
 		if (commonLicenseKeys.isEmpty()) {
 			return null;
 		}
 
-		return commonLicenseKeys.get(0);
+		return Collections.min(
+			commonLicenseKeys,
+			Comparator.comparing(
+				commonLicenseKey -> commonLicenseKey.optString("endDate")));
 	}
 
 	public boolean hasCommonLicenseKey(String fileName) throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommonLicenseKeyService.java
@@ -9,6 +9,7 @@ import com.liferay.one.constants.UploadProductEnvironmentConstants;
 import com.liferay.one.constants.UploadProductGroupConstants;
 import com.liferay.one.license.CommonLicenseKeyData;
 import com.liferay.one.license.CommonLicenseKeyParser;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.List;
@@ -78,6 +79,24 @@ public class CommonLicenseKeyService extends OneBaseService {
 		);
 
 		postCommonLicenseKey(jsonObject);
+	}
+
+	public JSONObject getCommonLicenseKey(
+			String productFamily, String environmentType)
+		throws Exception {
+
+		List<JSONObject> commonLicenseKeys = getAllItems(
+			"/o/c/commonlicensekeys",
+			StringBundler.concat(
+				"(environmentType eq '", environmentType,
+				"') and (productFamily eq '", productFamily, "')"),
+			jsonObject -> jsonObject);
+
+		if (commonLicenseKeys.isEmpty()) {
+			return null;
+		}
+
+		return commonLicenseKeys.get(0);
 	}
 
 	public boolean hasCommonLicenseKey(String fileName) throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -289,16 +289,33 @@ public class EntitlementService extends OneBaseService {
 	}
 
 	public boolean hasEntitlementCoveringDateRange(
-			long accountEntryId, Instant startDateInstant,
-			Instant endDateInstant)
+			long accountEntryId,
+			String entitlementDefinitionExternalReferenceCode,
+			Instant startDateInstant, Instant endDateInstant)
 		throws Exception {
+
+		List<EntitlementDefinition> entitlementDefinitions =
+			_entitlementDefinitionService.getEntitlementDefinitions(
+				"externalReferenceCode eq '" +
+					entitlementDefinitionExternalReferenceCode + "'");
+
+		if (entitlementDefinitions.isEmpty()) {
+			return false;
+		}
+
+		EntitlementDefinition entitlementDefinition =
+			entitlementDefinitions.get(0);
 
 		List<Entitlement> entitlements = getEntitlements(
 			StringBundler.concat(
-				"(r_accountEntryToEntitlement_accountEntryId eq '",
-				accountEntryId, "') and (startDate eq null or startDate le ",
-				startDateInstant, ") and (endDate eq null or endDate ge ",
-				endDateInstant, ")"));
+				"(endDate eq null or endDate ge ", endDateInstant,
+				") and (r_accountEntryToEntitlement_accountEntryId eq '",
+				accountEntryId,
+				"') and (r_entitlementDefinitionToEntitlement_c_",
+				"entitlementDefinitionId eq '",
+				entitlementDefinition.getEntitlementDefinitionId(),
+				"') and (startDate eq null or startDate le ", startDateInstant,
+				")"));
 
 		return !entitlements.isEmpty();
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -288,6 +288,21 @@ public class EntitlementService extends OneBaseService {
 			entitlementNames);
 	}
 
+	public boolean hasEntitlementCoveringDateRange(
+			long accountEntryId, Instant startDateInstant,
+			Instant endDateInstant)
+		throws Exception {
+
+		List<Entitlement> entitlements = getEntitlements(
+			StringBundler.concat(
+				"(r_accountEntryToEntitlement_accountEntryId eq '",
+				accountEntryId, "') and (startDate eq null or startDate le ",
+				startDateInstant, ") and (endDate eq null or endDate ge ",
+				endDateInstant, ")"));
+
+		return !entitlements.isEmpty();
+	}
+
 	public void trimEntitlements(long commerceOrderItemId, String endDate)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -157,24 +157,26 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.when(
+			_entitlementService.hasEntitlementCoveringDateRange(
+				_ACCOUNT_ID, "C_ENT_DEF_COMMERCE",
+				Instant.parse("2026-01-01T00:00:00Z"),
+				Instant.parse("2027-01-01T00:00:00Z"))
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
 			_commonLicenseKeyService.getCommonLicenseKey(
 				"production", "commerce")
 		).thenReturn(
 			_createCommonLicenseKeyJSONObject()
 		);
 
-		Mockito.when(
-			_entitlementService.hasEntitlementCoveringDateRange(
-				_ACCOUNT_ID, Instant.parse("2026-01-01T00:00:00Z"),
-				Instant.parse("2027-01-01T00:00:00Z"))
-		).thenReturn(
-			true
-		);
-
 		ResponseEntity<String> responseEntity =
 			accountsRestController.
 				getProductGroupsProductEnvironmentsCommonLicenseKey(
-					null, _EXTERNAL_REFERENCE_CODE, "production", "commerce");
+					null, _EXTERNAL_REFERENCE_CODE, "2027-01-01T00:00:00Z",
+					"2026-01-01T00:00:00Z", "production", "commerce");
 
 		Assertions.assertEquals("<license/>", responseEntity.getBody());
 
@@ -198,16 +200,9 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.when(
-			_commonLicenseKeyService.getCommonLicenseKey(
-				"production", "commerce")
-		).thenReturn(
-			_createCommonLicenseKeyJSONObject()
-		);
-
-		Mockito.when(
 			_entitlementService.hasEntitlementCoveringDateRange(
 				Mockito.anyLong(), ArgumentMatchers.any(),
-				ArgumentMatchers.any())
+				ArgumentMatchers.any(), ArgumentMatchers.any())
 		).thenReturn(
 			false
 		);
@@ -218,8 +213,9 @@ public class AccountsRestControllerTest {
 				() ->
 					accountsRestController.
 						getProductGroupsProductEnvironmentsCommonLicenseKey(
-							null, _EXTERNAL_REFERENCE_CODE, "production",
-							"commerce"));
+							null, _EXTERNAL_REFERENCE_CODE,
+							"2027-01-01T00:00:00Z", "2026-01-01T00:00:00Z",
+							"production", "commerce"));
 
 		Assertions.assertEquals(
 			HttpStatus.FORBIDDEN, responseStatusException.getStatusCode());

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -167,7 +167,8 @@ public class AccountsRestControllerTest {
 
 		Mockito.when(
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"production", "commerce")
+				Instant.parse("2027-01-01T00:00:00Z"), "production", "commerce",
+				Instant.parse("2026-01-01T00:00:00Z"))
 		).thenReturn(
 			_createCommonLicenseKeyJSONObject()
 		);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -13,13 +13,17 @@ import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommonLicenseKeyService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringPool;
+
+import java.time.Instant;
 
 import java.util.Map;
 
@@ -33,7 +37,9 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -136,6 +142,87 @@ public class AccountsRestControllerTest {
 		).unassignAccountMembership(
 			_ACCOUNT_ID, _USER_ID
 		);
+	}
+
+	@Test
+	public void testGetProductGroupsProductEnvironmentsCommonLicenseKey()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		Mockito.when(
+			_commonLicenseKeyService.getCommonLicenseKey(
+				"commerce", "production")
+		).thenReturn(
+			_createCommonLicenseKeyJSONObject()
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlementCoveringDateRange(
+				_ACCOUNT_ID, Instant.parse("2026-01-01T00:00:00Z"),
+				Instant.parse("2027-01-01T00:00:00Z"))
+		).thenReturn(
+			true
+		);
+
+		ResponseEntity<String> responseEntity =
+			accountsRestController.
+				getProductGroupsProductEnvironmentsCommonLicenseKey(
+					null, _EXTERNAL_REFERENCE_CODE, "production", "commerce");
+
+		Assertions.assertEquals("<license/>", responseEntity.getBody());
+
+		HttpHeaders httpHeaders = responseEntity.getHeaders();
+
+		Assertions.assertEquals(
+			"attachment; filename=\"commerce-prod.xml\"",
+			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
+	}
+
+	@Test
+	public void testGetProductGroupsProductEnvironmentsCommonLicenseKeyRejectsWithoutEntitlement()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		Mockito.when(
+			_commonLicenseKeyService.getCommonLicenseKey(
+				"commerce", "production")
+		).thenReturn(
+			_createCommonLicenseKeyJSONObject()
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlementCoveringDateRange(
+				Mockito.anyLong(), ArgumentMatchers.any(),
+				ArgumentMatchers.any())
+		).thenReturn(
+			false
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() ->
+					accountsRestController.
+						getProductGroupsProductEnvironmentsCommonLicenseKey(
+							null, _EXTERNAL_REFERENCE_CODE, "production",
+							"commerce"));
+
+		Assertions.assertEquals(
+			HttpStatus.FORBIDDEN, responseStatusException.getStatusCode());
 	}
 
 	@Test
@@ -566,6 +653,19 @@ public class AccountsRestControllerTest {
 		return jsonObject.toString();
 	}
 
+	private JSONObject _createCommonLicenseKeyJSONObject() {
+		return new JSONObject(
+		).put(
+			"endDate", "2027-01-01T00:00:00Z"
+		).put(
+			"fileContent", "<license/>"
+		).put(
+			"fileName", "commerce-prod.xml"
+		).put(
+			"startDate", "2026-01-01T00:00:00Z"
+		);
+	}
+
 	private AccountsRestController _createController() {
 		AccountsRestController accountsRestController =
 			new AccountsRestController();
@@ -578,10 +678,16 @@ public class AccountsRestControllerTest {
 		ReflectionTestUtils.setField(
 			accountsRestController, "_accountService", _accountService);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_commonLicenseKeyService",
+			_commonLicenseKeyService);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_emailAddressValidatorService",
 			_emailAddressValidatorService);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_entitlementService", _entitlementService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_licenseKeyPermission",
+			_licenseKeyPermission);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_oktaService", _oktaService);
 		ReflectionTestUtils.setField(
@@ -639,10 +745,14 @@ public class AccountsRestControllerTest {
 		AccountPermission.class);
 	private final AccountService _accountService = Mockito.mock(
 		AccountService.class);
+	private final CommonLicenseKeyService _commonLicenseKeyService =
+		Mockito.mock(CommonLicenseKeyService.class);
 	private final EmailAddressValidatorService _emailAddressValidatorService =
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
 		EntitlementService.class);
+	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(
+		LicenseKeyPermission.class);
 	private final OktaService _oktaService = Mockito.mock(OktaService.class);
 	private final ProvisioningAssignmentService _provisioningAssignmentService =
 		Mockito.mock(ProvisioningAssignmentService.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -158,7 +158,7 @@ public class AccountsRestControllerTest {
 
 		Mockito.when(
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"commerce", "production")
+				"production", "commerce")
 		).thenReturn(
 			_createCommonLicenseKeyJSONObject()
 		);
@@ -199,7 +199,7 @@ public class AccountsRestControllerTest {
 
 		Mockito.when(
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"commerce", "production")
+				"production", "commerce")
 		).thenReturn(
 			_createCommonLicenseKeyJSONObject()
 		);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
@@ -126,7 +126,7 @@ public class CommonLicenseKeyServiceTest {
 	public void testGetCommonLicenseKey() throws Exception {
 		Assertions.assertNull(
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"commerce", "production"));
+				"production", "commerce"));
 
 		JSONObject commonLicenseKeyJSONObject = new JSONObject(
 		).put(
@@ -145,7 +145,7 @@ public class CommonLicenseKeyServiceTest {
 		Assertions.assertSame(
 			commonLicenseKeyJSONObject,
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"commerce", "production"));
+				"production", "commerce"));
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
@@ -126,7 +126,8 @@ public class CommonLicenseKeyServiceTest {
 	public void testGetCommonLicenseKey() throws Exception {
 		Assertions.assertNull(
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"production", "commerce"));
+				Instant.parse("2027-01-01T00:00:00Z"), "production", "commerce",
+				Instant.parse("2026-01-01T00:00:00Z")));
 
 		JSONObject commonLicenseKeyJSONObject = new JSONObject(
 		).put(
@@ -145,7 +146,8 @@ public class CommonLicenseKeyServiceTest {
 		Assertions.assertSame(
 			commonLicenseKeyJSONObject,
 			_commonLicenseKeyService.getCommonLicenseKey(
-				"production", "commerce"));
+				Instant.parse("2027-01-01T00:00:00Z"), "production", "commerce",
+				Instant.parse("2026-01-01T00:00:00Z")));
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/CommonLicenseKeyServiceTest.java
@@ -123,6 +123,32 @@ public class CommonLicenseKeyServiceTest {
 	}
 
 	@Test
+	public void testGetCommonLicenseKey() throws Exception {
+		Assertions.assertNull(
+			_commonLicenseKeyService.getCommonLicenseKey(
+				"commerce", "production"));
+
+		JSONObject commonLicenseKeyJSONObject = new JSONObject(
+		).put(
+			"fileName", "commerce-prod.xml"
+		);
+
+		Mockito.doReturn(
+			List.of(commonLicenseKeyJSONObject)
+		).when(
+			_commonLicenseKeyService
+		).getAllItems(
+			Mockito.eq("/o/c/commonlicensekeys"), Mockito.anyString(),
+			Mockito.any()
+		);
+
+		Assertions.assertSame(
+			commonLicenseKeyJSONObject,
+			_commonLicenseKeyService.getCommonLicenseKey(
+				"commerce", "production"));
+	}
+
+	@Test
 	public void testHasCommonLicenseKey() throws Exception {
 		Assertions.assertFalse(
 			_commonLicenseKeyService.hasCommonLicenseKey("new.xml"));

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/EntitlementServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/EntitlementServiceTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.one.model.Entitlement;
+import com.liferay.one.model.EntitlementDefinition;
+
+import java.time.Instant;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class EntitlementServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_entitlementService = Mockito.spy(new EntitlementService());
+
+		_entitlementDefinitionService = Mockito.mock(
+			EntitlementDefinitionService.class);
+
+		ReflectionTestUtils.setField(
+			_entitlementService, "_entitlementDefinitionService",
+			_entitlementDefinitionService);
+	}
+
+	@Test
+	public void testHasEntitlementCoveringDateRangeReturnsFalseWhenNoDefinition()
+		throws Exception {
+
+		Mockito.when(
+			_entitlementDefinitionService.getEntitlementDefinitions(
+				Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Assertions.assertFalse(
+			_entitlementService.hasEntitlementCoveringDateRange(
+				1L, "C_ENT_DEF_COMMERCE", Instant.parse("2026-01-01T00:00:00Z"),
+				Instant.parse("2027-01-01T00:00:00Z")));
+
+		Mockito.verify(
+			_entitlementService, Mockito.never()
+		).getAllItems(
+			Mockito.eq("/o/c/entitlements"), Mockito.anyString(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testHasEntitlementCoveringDateRangeScopesToDefinition()
+		throws Exception {
+
+		EntitlementDefinition entitlementDefinition = Mockito.mock(
+			EntitlementDefinition.class);
+
+		Mockito.when(
+			entitlementDefinition.getEntitlementDefinitionId()
+		).thenReturn(
+			99L
+		);
+
+		Mockito.when(
+			_entitlementDefinitionService.getEntitlementDefinitions(
+				Mockito.anyString())
+		).thenReturn(
+			List.of(entitlementDefinition)
+		);
+
+		ArgumentCaptor<String> filterStringArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.doReturn(
+			List.of(Mockito.mock(Entitlement.class))
+		).when(
+			_entitlementService
+		).getAllItems(
+			Mockito.eq("/o/c/entitlements"),
+			filterStringArgumentCaptor.capture(), Mockito.any()
+		);
+
+		Assertions.assertTrue(
+			_entitlementService.hasEntitlementCoveringDateRange(
+				1L, "C_ENT_DEF_COMMERCE", Instant.parse("2026-01-01T00:00:00Z"),
+				Instant.parse("2027-01-01T00:00:00Z")));
+
+		Assertions.assertTrue(
+			filterStringArgumentCaptor.getValue(
+			).contains(
+				"entitlementDefinitionId eq '99'"
+			));
+	}
+
+	private EntitlementDefinitionService _entitlementDefinitionService;
+	private EntitlementService _entitlementService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91433

## What is being fixed

Liferay One had no customer-facing endpoint to download a common license key. The C_COMMON_LICENSE_KEY object and the admin upload (LPD-98645) existed, but nothing let an account holder retrieve the stored license file.

## How it is being fixed

Adds `GET /accounts/{accountKey}/product-groups/{group}/product-environments/{env}/common-license-key`. It resolves the account, enforces account-view permission through the existing `LicenseKeyPermission` (the Spring Boot equivalent of the legacy `CommonLicenseKeyResourceImpl` account-view check), fetches the stored common license key for the product family and environment, and returns its file content with a `Content-Disposition` attachment header.

## Open questions for review

1. **Entitlement gate interpretation.** The AC requires "an APPROVED ProductPurchase covering the requested date range." I interpreted that as: the account holds an entitlement whose window covers the license validity range (entitlements being the ported representation of approved commerce purchases). It does **not** match on product group, because nothing in the current data model links an entitlement to a product group. Is that the intended gating, or is a product-group-scoped purchase check expected?

2. **Endpoint vs. the merged frontend contract.** This is the account-scoped customer endpoint the ticket specifies. But the merged admin UI (`LPD-89702`) calls `downloadCommonLicenseKey(id)` → `GET /common-license-keys/{id}/download` — a different, id-based path. Are these two distinct flows (admin download-by-id vs. customer download-by-account+group+env), and does the admin `/{id}/download` variant still need to be built separately?

3. **`{group}` / `{env}` path values.** These are assumed to be the picklist keys stored on the object — `productFamily` ∈ {`commerce`, `enterpriseSearch`} and `environmentType` ∈ {`backup`, `nonProduction`, `production`}. Please confirm callers send those exact keys.

## To verify at runtime (LEC), not unit-testable

- The OData filters: `productFamily`/`environmentType eq '...'` against picklist fields, and the entitlement start/end date-coverage filter.
- `{accountKey}` → account resolution via `AccountService.getAccount(accountKey, jwt)`.