### PR TITLE
LPD-93349 Reprocess provisioned opportunities instead of skipping them

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -148,7 +148,7 @@ public class AccountsRestController extends OneBaseRestController {
 		_provisioningAssignmentService.assignCustomerGroup(userId);
 
 		if (!hasAccount) {
-			_provisioningEmailService.sendAssignedWelcomeEmail(userId, account);
+			_provisioningEmailService.sendAssignedWelcomeEmail(account, userId);
 		}
 	}
 
@@ -267,7 +267,7 @@ public class AccountsRestController extends OneBaseRestController {
 		}
 
 		if (!hasAccount) {
-			_provisioningEmailService.sendAssignedWelcomeEmail(userId, account);
+			_provisioningEmailService.sendAssignedWelcomeEmail(account, userId);
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderItemConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/CommerceOrderItemConstants.java
@@ -5,10 +5,14 @@
 
 package com.liferay.one.constants;
 
+import java.time.Duration;
+
 /**
  * @author Felipe Veloso
  */
 public class CommerceOrderItemConstants {
+
+	public static final Duration EFFECTIVE_END_DATE_GRACE = Duration.ofDays(30);
 
 	public static final String STATUS_APPROVED = "Approved";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriber.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriber.java
@@ -9,6 +9,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Sku;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.constants.OpportunityConstants;
 import com.liferay.one.model.Contract;
@@ -25,6 +26,7 @@ import com.liferay.one.service.CommerceOrderItemService;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.CommerceSkuService;
 import com.liferay.one.service.ContractService;
+import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.ProvisioningContactService;
 import com.liferay.one.service.ProvisioningEmailService;
@@ -32,6 +34,7 @@ import com.liferay.one.service.ProvisioningIssueService;
 import com.liferay.one.service.ProvisioningOrderService;
 import com.liferay.one.service.ProvisioningSubdomainService;
 import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.OrderItemUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -230,6 +233,16 @@ public class SalesforceOpportunityPubsubSubscriber
 		return false;
 	}
 
+	private boolean _isCompleted(Order order) {
+		if (order == null) {
+			return false;
+		}
+
+		return Objects.equals(
+			order.getOrderStatus(),
+			CommerceOrderConstants.ORDER_STATUS_COMPLETED);
+	}
+
 	private boolean _isProvisioned(Order order) {
 		if (order == null) {
 			return false;
@@ -301,28 +314,11 @@ public class SalesforceOpportunityPubsubSubscriber
 		Order order = _commerceOrderService.fetchOrderByExternalReferenceCode(
 			salesforceOpportunity.getId());
 
-		if (_isProvisioned(order)) {
-			_addWarning(
-				warningMessages,
-				StringBundler.concat(
-					"The opportunity ", salesforceOpportunity.getId(),
-					" was not provisioned automatically since an order with ",
-					"this opportunity already exists"));
+		boolean reprocessing = _isProvisioned(order);
 
-			Account account =
-				_accountService.fetchAccountByExternalReferenceCode(
-					salesforceOpportunity.getAccountId());
-
-			if ((account != null) &&
-				!Objects.equals(
-					salesforceOpportunity.getProductFamily(), "P")) {
-
-				_provisioningIssueService.addOpportunityInvoicedIssue(
-					account, salesforceAccount, salesforceOpportunity,
-					salesforceOpportunityLineItems, warningMessages);
-			}
-
-			return;
+		if (reprocessing && _log.isInfoEnabled()) {
+			_log.info(
+				"Reprocessing opportunity " + salesforceOpportunity.getId());
 		}
 
 		List<SalesforceOpportunityLineItem>
@@ -548,6 +544,22 @@ public class SalesforceOpportunityPubsubSubscriber
 					salesforceOpportunity.getStageName());
 
 				provisionedOrderItemCount++;
+
+				OrderItem existingOrderItem = OrderItemUtil.fetchOrderItem(
+					provisionableSalesforceOpportunityLineItem.getId(), order);
+
+				if (existingOrderItem != null) {
+					try {
+						_entitlementService.updateEntitlements(
+							existingOrderItem.getId());
+					}
+					catch (Exception exception) {
+						_log.error(
+							"Unable to update entitlements for order item " +
+								existingOrderItem.getId(),
+							exception);
+					}
+				}
 			}
 			catch (Exception exception) {
 				String productName =
@@ -568,7 +580,7 @@ public class SalesforceOpportunityPubsubSubscriber
 			}
 		}
 
-		if (provisionedOrderItemCount > 0) {
+		if ((provisionedOrderItemCount > 0) && !_isCompleted(order)) {
 			try {
 				_commerceOrderService.completeOrder(
 					newOrder.getId(),
@@ -602,10 +614,18 @@ public class SalesforceOpportunityPubsubSubscriber
 				salesforceProject, warningMessages);
 		}
 
-		_provisioningEmailService.sendWelcomeEmails(
-			account, salesforceOpportunity.getType(), userIds);
+		if (reprocessing) {
+			_provisioningEmailService.sendAssignedWelcomeEmails(
+				account, userIds);
+		}
+		else {
+			_provisioningEmailService.sendWelcomeEmails(
+				account, salesforceOpportunity.getType(), userIds);
+		}
 
-		if (!Objects.equals(salesforceOpportunity.getProductFamily(), "P")) {
+		if (!reprocessing &&
+			!Objects.equals(salesforceOpportunity.getProductFamily(), "P")) {
+
 			_provisioningIssueService.addOpportunityInvoicedIssue(
 				account, salesforceAccount, salesforceOpportunity,
 				provisionableSalesforceOpportunityLineItems, warningMessages);
@@ -637,6 +657,9 @@ public class SalesforceOpportunityPubsubSubscriber
 
 	@Autowired
 	private ContractService _contractService;
+
+	@Autowired
+	private EntitlementService _entitlementService;
 
 	@Value("${liferay.one.salesforce.opportunity.pubsub.subscriber.project.id}")
 	private String _projectId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
@@ -11,18 +11,17 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.headless.commerce.admin.order.client.problem.Problem;
 import com.liferay.headless.commerce.admin.order.client.resource.v1_0.OrderItemResource;
+import com.liferay.one.constants.CommerceOrderItemConstants;
 import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
 import com.liferay.one.util.OrderItemUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.math.BigDecimal;
 
-import java.time.Duration;
 import java.time.Instant;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -130,16 +129,16 @@ public class CommerceOrderItemService extends OneBaseService {
 		Map<String, Object> customFieldValues = _getCustomFieldValues(
 			salesforceOpportunityLineItem, stageName);
 
-		OrderItem existingOrderItem = _getExistingOrderItem(
-			order, salesforceOpportunityLineItem.getId());
+		OrderItem existingOrderItem = OrderItemUtil.fetchOrderItem(
+			salesforceOpportunityLineItem.getId(), order);
 
 		if (existingOrderItem != null) {
 			if (OrderItemUtil.isCanceled(existingOrderItem)) {
 				customFieldValues.remove("customStatus");
 			}
 
-			if (Objects.equals(
-					OrderItemUtil.getEndDateInstant(existingOrderItem),
+			if (!OrderItemUtil.isUpdateEffectiveEndDate(
+					existingOrderItem,
 					salesforceOpportunityLineItem.getEndDateInstant())) {
 
 				customFieldValues.remove("effectiveEndDate");
@@ -191,7 +190,7 @@ public class CommerceOrderItemService extends OneBaseService {
 
 		if (endDateInstant != null) {
 			Instant effectiveEndDateInstant = endDateInstant.plus(
-				Duration.ofDays(30));
+				CommerceOrderItemConstants.EFFECTIVE_END_DATE_GRACE);
 
 			customFieldValues.put(
 				"effectiveEndDate", effectiveEndDateInstant.toString());
@@ -242,27 +241,6 @@ public class CommerceOrderItemService extends OneBaseService {
 		}
 
 		return "On Hold";
-	}
-
-	private OrderItem _getExistingOrderItem(
-		Order order, String externalReferenceCode) {
-
-		OrderItem[] orderItems = order.getOrderItems();
-
-		if (orderItems == null) {
-			return null;
-		}
-
-		for (OrderItem orderItem : orderItems) {
-			if (Objects.equals(
-					orderItem.getExternalReferenceCode(),
-					externalReferenceCode)) {
-
-				return orderItem;
-			}
-		}
-
-		return null;
 	}
 
 	private CustomField[] _toCustomFields(Map<String, ?> customFieldValues) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -248,6 +248,15 @@ public class EntitlementService extends OneBaseService {
 				instant, ")"));
 	}
 
+	public List<Entitlement> getEntitlements(long commerceOrderItemId)
+		throws Exception {
+
+		return getEntitlements(
+			StringBundler.concat(
+				"r_commerceOrderItemToEntitlement_commerceOrderItemId eq '",
+				commerceOrderItemId, "'"));
+	}
+
 	public List<Entitlement> getEntitlements(String filterString)
 		throws Exception {
 
@@ -293,10 +302,7 @@ public class EntitlementService extends OneBaseService {
 	public void trimEntitlements(long commerceOrderItemId, String endDate)
 		throws Exception {
 
-		List<Entitlement> entitlements = getEntitlements(
-			StringBundler.concat(
-				"r_commerceOrderItemToEntitlement_commerceOrderItemId eq '",
-				commerceOrderItemId, "'"));
+		List<Entitlement> entitlements = getEntitlements(commerceOrderItemId);
 
 		Instant endDateInstant = Instant.parse(endDate);
 
@@ -309,46 +315,85 @@ public class EntitlementService extends OneBaseService {
 				continue;
 			}
 
-			Instant trimmedEndDateInstant = endDateInstant;
-
-			Instant startDateInstant = entitlement.getStartDateInstant();
-
-			if ((startDateInstant != null) &&
-				startDateInstant.isAfter(endDateInstant)) {
-
-				trimmedEndDateInstant = startDateInstant;
-			}
+			Instant trimmedEndDateInstant = _getLatestInstant(
+				endDateInstant, entitlement.getStartDateInstant());
 
 			if (Objects.equals(curEndDateInstant, trimmedEndDateInstant)) {
 				continue;
 			}
 
-			patch(
-				getAuthorization(),
+			_patchEntitlement(
+				entitlement.getEntitlementId(),
 				new JSONObject(
 				).put(
 					"endDate", trimmedEndDateInstant.toString()
-				).toString(),
-				UriComponentsBuilder.fromPath(
-					"/o/c/entitlements/" + entitlement.getEntitlementId()
-				).build(
-				).toUri());
+				));
 		}
 	}
 
 	public void updateEntitlementContract(long entitlementId, long contractId)
 		throws Exception {
 
-		patch(
-			getAuthorization(),
+		_patchEntitlement(
+			entitlementId,
 			new JSONObject(
 			).put(
 				"r_contractToEntitlement_c_contractId", contractId
-			).toString(),
-			UriComponentsBuilder.fromPath(
-				"/o/c/entitlements/" + entitlementId
-			).build(
-			).toUri());
+			));
+	}
+
+	public void updateEntitlements(long commerceOrderItemId) throws Exception {
+		OrderItem orderItem = _commerceOrderItemService.fetchCommerceOrderItem(
+			commerceOrderItemId);
+
+		if ((orderItem == null) || OrderItemUtil.isCanceled(orderItem)) {
+			return;
+		}
+
+		Instant endDateInstant = OrderItemUtil.getEntitlementEndDateInstant(
+			orderItem);
+		Instant startDateInstant = OrderItemUtil.getStartDateInstant(orderItem);
+
+		List<Entitlement> entitlements = getEntitlements(commerceOrderItemId);
+
+		for (Entitlement entitlement : entitlements) {
+			JSONObject entitlementJSONObject = new JSONObject();
+
+			if ((startDateInstant != null) &&
+				!Objects.equals(
+					entitlement.getStartDateInstant(), startDateInstant)) {
+
+				entitlementJSONObject.put(
+					"startDate", startDateInstant.toString());
+			}
+
+			if (endDateInstant != null) {
+				Instant effectiveStartDateInstant = startDateInstant;
+
+				if (effectiveStartDateInstant == null) {
+					effectiveStartDateInstant =
+						entitlement.getStartDateInstant();
+				}
+
+				Instant targetEndDateInstant = _getLatestInstant(
+					endDateInstant, effectiveStartDateInstant);
+
+				if (!Objects.equals(
+						entitlement.getEndDateInstant(),
+						targetEndDateInstant)) {
+
+					entitlementJSONObject.put(
+						"endDate", targetEndDateInstant.toString());
+				}
+			}
+
+			if (entitlementJSONObject.length() == 0) {
+				continue;
+			}
+
+			_patchEntitlement(
+				entitlement.getEntitlementId(), entitlementJSONObject);
+		}
 	}
 
 	private long _getAccountEntryId(Order order) {
@@ -372,6 +417,30 @@ public class EntitlementService extends OneBaseService {
 		}
 
 		return GetterUtil.getLong(customFields.get("contractId"));
+	}
+
+	private Instant _getLatestInstant(
+		Instant endDateInstant, Instant startDateInstant) {
+
+		if ((startDateInstant != null) &&
+			startDateInstant.isAfter(endDateInstant)) {
+
+			return startDateInstant;
+		}
+
+		return endDateInstant;
+	}
+
+	private void _patchEntitlement(
+			long entitlementId, JSONObject entitlementJSONObject)
+		throws Exception {
+
+		patch(
+			getAuthorization(), entitlementJSONObject.toString(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/entitlements/" + entitlementId
+			).build(
+			).toUri());
 	}
 
 	private static final Log _log = LogFactory.getLog(EntitlementService.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningEmailService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProvisioningEmailService.java
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProvisioningEmailService extends OneBaseService {
 
-	public void sendAssignedWelcomeEmail(long userId, Account account)
+	public void sendAssignedWelcomeEmail(Account account, long userId)
 		throws Exception {
 
 		UserAccount userAccount = _userAccountService.getUserAccount(userId);
@@ -63,6 +63,20 @@ public class ProvisioningEmailService extends OneBaseService {
 		_sendWelcomeEmail(
 			userAccount, List.of(account),
 			_getProjects(account.getId(), userId));
+	}
+
+	public void sendAssignedWelcomeEmails(Account account, List<Long> userIds) {
+		for (Long userId : userIds) {
+			try {
+				sendAssignedWelcomeEmail(account, userId);
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to send the assigned welcome email to user " +
+						userId,
+					exception);
+			}
+		}
 	}
 
 	public void sendAutoProvisionedWelcomeEmail(Account account)
@@ -154,17 +168,7 @@ public class ProvisioningEmailService extends OneBaseService {
 					opportunityType,
 					OpportunityConstants.TYPE_EXISTING_BUSINESS)) {
 
-			for (Long userId : userIds) {
-				try {
-					sendAssignedWelcomeEmail(userId, account);
-				}
-				catch (Exception exception) {
-					_log.error(
-						"Unable to send the assigned welcome email to user " +
-							userId,
-						exception);
-				}
-			}
+			sendAssignedWelcomeEmails(account, userIds);
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/OrderItemUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/OrderItemUtil.java
@@ -7,6 +7,7 @@ package com.liferay.one.util;
 
 import com.liferay.headless.commerce.admin.order.client.custom.field.CustomField;
 import com.liferay.headless.commerce.admin.order.client.custom.field.CustomValue;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
 import com.liferay.one.constants.CommerceOrderItemConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -30,12 +31,56 @@ import org.json.JSONObject;
  */
 public class OrderItemUtil {
 
+	public static OrderItem fetchOrderItem(
+		String externalReferenceCode, Order order) {
+
+		if (order == null) {
+			return null;
+		}
+
+		OrderItem[] orderItems = order.getOrderItems();
+
+		if (orderItems == null) {
+			return null;
+		}
+
+		for (OrderItem orderItem : orderItems) {
+			if (Objects.equals(
+					orderItem.getExternalReferenceCode(),
+					externalReferenceCode)) {
+
+				return orderItem;
+			}
+		}
+
+		return null;
+	}
+
 	public static Instant getEffectiveEndDateInstant(OrderItem orderItem) {
 		return _getCustomFieldInstant(orderItem, "effectiveEndDate");
 	}
 
 	public static Instant getEndDateInstant(OrderItem orderItem) {
 		return _getCustomFieldInstant(orderItem, "endDate");
+	}
+
+	public static Instant getEntitlementEndDateInstant(OrderItem orderItem) {
+		Instant endDateInstant = getEndDateInstant(orderItem);
+		Instant effectiveEndDateInstant = getEffectiveEndDateInstant(orderItem);
+
+		if (endDateInstant == null) {
+			return effectiveEndDateInstant;
+		}
+
+		if (effectiveEndDateInstant == null) {
+			return endDateInstant;
+		}
+
+		if (effectiveEndDateInstant.isBefore(endDateInstant)) {
+			return effectiveEndDateInstant;
+		}
+
+		return endDateInstant;
 	}
 
 	public static Map<String, String> getProductOptions(OrderItem orderItem) {
@@ -86,6 +131,25 @@ public class OrderItemUtil {
 	public static boolean isCanceled(OrderItem orderItem) {
 		return CommerceOrderItemConstants.STATUS_CANCELED.equals(
 			getStatus(orderItem));
+	}
+
+	public static boolean isUpdateEffectiveEndDate(
+		OrderItem existingOrderItem, Instant messageEndDateInstant) {
+
+		if (messageEndDateInstant == null) {
+			return false;
+		}
+
+		if (_isEffectiveEndDateTrimmed(existingOrderItem)) {
+			Instant messageEffectiveEndDateInstant = messageEndDateInstant.plus(
+				CommerceOrderItemConstants.EFFECTIVE_END_DATE_GRACE);
+
+			return messageEffectiveEndDateInstant.isBefore(
+				getEffectiveEndDateInstant(existingOrderItem));
+		}
+
+		return !Objects.equals(
+			messageEndDateInstant, getEndDateInstant(existingOrderItem));
 	}
 
 	private static Instant _getCustomFieldInstant(
@@ -139,6 +203,19 @@ public class OrderItemUtil {
 		}
 
 		return optionJSONObject.optString("value", null);
+	}
+
+	private static boolean _isEffectiveEndDateTrimmed(OrderItem orderItem) {
+		Instant effectiveEndDateInstant = getEffectiveEndDateInstant(orderItem);
+		Instant endDateInstant = getEndDateInstant(orderItem);
+
+		if ((effectiveEndDateInstant == null) || (endDateInstant == null)) {
+			return false;
+		}
+
+		return effectiveEndDateInstant.isBefore(
+			endDateInstant.plus(
+				CommerceOrderItemConstants.EFFECTIVE_END_DATE_GRACE));
 	}
 
 	private static final Log _log = LogFactory.getLog(OrderItemUtil.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -218,7 +218,7 @@ public class AccountsRestControllerTest {
 		Mockito.verify(
 			_provisioningEmailService
 		).sendAssignedWelcomeEmail(
-			_USER_ID, account
+			account, _USER_ID
 		);
 	}
 
@@ -288,7 +288,7 @@ public class AccountsRestControllerTest {
 		Mockito.verify(
 			_provisioningEmailService
 		).sendAssignedWelcomeEmail(
-			_USER_ID, account
+			account, _USER_ID
 		);
 	}
 
@@ -501,7 +501,7 @@ public class AccountsRestControllerTest {
 		Mockito.verify(
 			_provisioningEmailService
 		).sendAssignedWelcomeEmail(
-			_USER_ID, account
+			account, _USER_ID
 		);
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93349

## What is being fixed

The opportunity provisioning subscriber skipped any Salesforce message whose opportunity had already been provisioned, deciding on the presence of a commerce order with at least one item. When Salesforce re-sent a message with corrected or updated data, none of it was applied — the account, project, order, and order items kept their original values — and every redelivery filed another "Opportunity Invoiced" Jira issue. Reprocessing an opportunity was therefore impossible without manual intervention.

## How it is being fixed

The skip is replaced by a reprocessing flag, so a redelivered message runs the full provisioning flow and updates the already-provisioned records in place. The account, project, contract, and order upserts were already PATCH-by-external-reference-code operations, so new data lands automatically, and order items are matched by line item external reference code and patched rather than duplicated.

The interaction with amended opportunities is the delicate part. Amendments and renewals only ever move an order item's effective end date earlier, so reprocessing a base message must never push that date back out. A new order item helper decides whether the effective end date may be written: once an item has been trimmed, an incoming date is accepted only if it shortens the period further, and otherwise the trim is preserved while the contractual end date still updates. Entitlements follow the item's resolved dates through a new entitlement update that targets the earlier of the end date and the effective end date, which extends entitlements when an opportunity legitimately extends and caps them at an amendment's trim.

The remaining side effects are made idempotent: an order that is already complete is not transitioned again, the invoiced Jira issue is filed only on first provisioning, and welcome emails go to newly added contacts only, leaving existing members untouched. The entitlement service's duplicated patch plumbing, relationship filter, and end date floor were consolidated into single helpers along the way. Verification was done end to end against the local environment across the reprocessing, amendment, renewal, contract, and contact scenarios rather than with unit tests.