### PR TITLE
LPD-90495 LPD-99494 Use portable env bash shebang for macOS

### DIFF
--- a/workspaces/liferay-one-workspace/scripts/_common.sh
+++ b/workspaces/liferay-one-workspace/scripts/_common.sh
@@ -1,8 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
 set -o pipefail
+
+# macOS ships bash 3.2 (frozen there for GPLv3 licensing reasons), which lacks
+# associative arrays and mishandles "$@" under nounset. These scripts require
+# bash 4.4+; fail fast here instead of letting callers hit a cryptic syntax or
+# "unbound variable" error deep in whichever script happens to run first.
+
+if ((BASH_VERSINFO[0] < 4)) || ((BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 4))
+then
+	echo "This workspace's scripts require bash 4.4 or newer (found ${BASH_VERSION})." >&2
+	echo "On macOS: brew install bash, then make sure Homebrew's bin directory precedes /bin in PATH." >&2
+
+	exit 1
+fi
 
 # Connection and authentication helpers shared by the bootstrap seed scripts and
 # the teardown scripts. The seed scripts create data through the headless and

--- a/workspaces/liferay-one-workspace/scripts/activate_user_accounts.sh
+++ b/workspaces/liferay-one-workspace/scripts/activate_user_accounts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -43,8 +43,8 @@ function main {
 
 	./gradlew clean
 
-	bash scripts/bootstrap/extract_hotfix.sh
-	bash scripts/bootstrap/extract_license.sh
+	./scripts/bootstrap/extract_hotfix.sh
+	./scripts/bootstrap/extract_license.sh
 
 	echo "Building Docker image."
 	./gradlew buildDockerImage
@@ -67,16 +67,16 @@ function main {
 	done
 
 	echo "Deploying artifacts to Liferay container."
-	bash scripts/bootstrap/deploy_client_extensions.sh
+	./scripts/bootstrap/deploy_client_extensions.sh
 
 	echo "Setting virtual hosts."
-	bash scripts/bootstrap/set_virtual_hosts.sh
+	./scripts/bootstrap/set_virtual_hosts.sh
 
 	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
-	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+	./scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
 
 	echo "Seeding data."
-	bash scripts/seed.sh
+	./scripts/seed.sh
 
 	echo "Done. Liferay is running at http://localhost."
 }

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/deploy_client_extensions.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/deploy_client_extensions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/extract_hotfix.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/extract_hotfix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/extract_license.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/extract_license.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/extract_oauth_credentials.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/extract_oauth_credentials.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/bootstrap/set_virtual_hosts.sh
+++ b/workspaces/liferay-one-workspace/scripts/bootstrap/set_virtual_hosts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/create_publisher_details.sh
+++ b/workspaces/liferay-one-workspace/scripts/create_publisher_details.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/instance_reset.sh
+++ b/workspaces/liferay-one-workspace/scripts/instance_reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -53,7 +53,7 @@ function main {
 	cd ..
 
 	echo "Tearing down seeded records and structural scaffolding."
-	bash scripts/seed/teardown.sh --full
+	./scripts/seed/teardown.sh --full
 
 	echo "Deleting the One site."
 	_delete_site
@@ -73,13 +73,13 @@ function main {
 	_wait_for_site_initializer
 
 	echo "Setting virtual hosts."
-	bash scripts/bootstrap/set_virtual_hosts.sh
+	./scripts/bootstrap/set_virtual_hosts.sh
 
 	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
-	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+	./scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
 
 	echo "Seeding data."
-	bash scripts/seed.sh
+	./scripts/seed.sh
 
 	echo "Done. The Liferay instance data has been reset."
 }

--- a/workspaces/liferay-one-workspace/scripts/link_commerce_catalogs.sh
+++ b/workspaces/liferay-one-workspace/scripts/link_commerce_catalogs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/link_commerce_products.sh
+++ b/workspaces/liferay-one-workspace/scripts/link_commerce_products.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/populate_orders.sh
+++ b/workspaces/liferay-one-workspace/scripts/populate_orders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -15,31 +15,31 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 function main {
 	echo "Seeding test data."
-	bash seed/seed_test_data.sh
+	./seed/seed_test_data.sh
 
 	echo "Ensuring product SKUs."
-	bash seed/ensure_product_skus.sh
+	./seed/ensure_product_skus.sh
 
 	echo "Seeding journal articles."
-	bash seed/seed_journal_articles.sh
+	./seed/seed_journal_articles.sh
 
 	echo "Activating seeded user accounts."
-	bash seed/activate_user_accounts.sh
+	./seed/activate_user_accounts.sh
 
 	echo "Assigning user group and role memberships."
-	bash seed/assign_user_memberships.sh
+	./seed/assign_user_memberships.sh
 
 	echo "Assigning users to the Omni Test Account."
-	bash seed/assign_omni_account_users.sh
+	./seed/assign_omni_account_users.sh
 
 	echo "Linking supplier accounts to commerce catalogs."
-	bash seed/link_commerce_catalogs.sh
+	./seed/link_commerce_catalogs.sh
 
 	echo "Creating publisher details."
-	bash seed/create_publisher_details.sh
+	./seed/create_publisher_details.sh
 
 	echo "Populating orders, order items, and entitlements."
-	bash seed/populate_orders.sh
+	./seed/populate_orders.sh
 }
 
 main "${@}"

--- a/workspaces/liferay-one-workspace/scripts/seed/_teardown_common.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/_teardown_common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Shared helpers for the teardown scripts (teardown.sh, teardown_records.sh,
 # teardown_structure.sh). These mirror the bootstrap seed scripts in reverse:

--- a/workspaces/liferay-one-workspace/scripts/seed/activate_user_accounts.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/activate_user_accounts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/assign_omni_account_users.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/assign_omni_account_users.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/assign_user_memberships.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/assign_user_memberships.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/create_publisher_details.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/create_publisher_details.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/ensure_product_skus.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/ensure_product_skus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/link_commerce_catalogs.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/link_commerce_catalogs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/populate_orders.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/populate_orders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/seed_journal_articles.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/seed_journal_articles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/seed_test_data.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/seed_test_data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/send_batch.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/send_batch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Sends a single liferay-one-batch *.batch-engine-data.json file to a Liferay
 # environment through the headless batch engine import-task endpoint, then polls

--- a/workspaces/liferay-one-workspace/scripts/seed/teardown.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/teardown.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/teardown_records.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/teardown_records.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/seed/teardown_structure.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/teardown_structure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 

--- a/workspaces/liferay-one-workspace/scripts/site_reset.sh
+++ b/workspaces/liferay-one-workspace/scripts/site_reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -42,7 +42,7 @@ function main {
 	cd ..
 
 	echo "Tearing down seeded records."
-	bash scripts/seed/teardown_records.sh
+	./scripts/seed/teardown_records.sh
 
 	echo "Deleting the One site."
 	_delete_site
@@ -56,13 +56,13 @@ function main {
 	_wait_for_site_initializer
 
 	echo "Setting virtual hosts."
-	bash scripts/bootstrap/set_virtual_hosts.sh
+	./scripts/bootstrap/set_virtual_hosts.sh
 
 	echo "Re-provisioning etc-spring-boot OAuth redirect URIs."
-	bash scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
+	./scripts/bootstrap/reprovision_etc_spring_boot_oauth.sh
 
 	echo "Seeding data."
-	bash scripts/seed.sh
+	./scripts/seed.sh
 
 	echo "Done. The One site has been reset."
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99494

## What is being fixed

Scripts under `workspaces/liferay-one-workspace/scripts` hardcoded `#!/bin/bash` and called `bash <script>` directly, which pins execution to whatever `/bin/bash` resolves to. On macOS this is always the frozen bash 3.2 (kept there for GPLv3 licensing reasons), which lacks associative arrays and mishandles `"$@"` under `nounset`, causing cryptic syntax and "unbound variable" errors when a caller's PATH doesn't already prefer a newer bash.

## How it is being fixed

Every script's shebang changes from `#!/bin/bash` to `#!/usr/bin/env bash`, and callers now invoke scripts directly (`./scripts/bootstrap/extract_hotfix.sh`) instead of via an explicit `bash` prefix, so a developer's PATH controls which bash actually runs. `_common.sh` also gains a version guard that fails fast with a clear message and a `brew install bash` remediation hint when the resolved bash is older than 4.4, rather than letting scripts fail deep inside with an opaque error.