### PR TITLE
LPD-91798 Add accounts endpoint and external links to the response

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/13-role.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/13-role.batch-engine-data.json
@@ -36,6 +36,11 @@
 			"roleType": "site"
 		},
 		{
+			"externalReferenceCode": "C_CLOUD_CONSOLE_SERVICE",
+			"name": "Cloud Console Service",
+			"roleType": "regular"
+		},
+		{
 			"externalReferenceCode": "C_CLOUD_NATIVE_CONTACT",
 			"name": "Cloud Native Contact",
 			"roleType": "account"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -8,14 +8,17 @@ package com.liferay.one;
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.EntitlementConstants;
+import com.liferay.one.jira.exception.AccountNotFoundException;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
+import com.liferay.one.model.Property;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
@@ -26,6 +29,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -101,6 +105,38 @@ public class AccountsRestController extends OneBaseRestController {
 		}
 
 		_unassignContactRole(account, accountRoleId, userId);
+	}
+
+	@GetMapping("/{externalReferenceCode}")
+	public ResponseEntity<String> getAccounts(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		_accountPermission.check(externalReferenceCode, ActionKeys.VIEW, jwt);
+
+		Account account = _accountService.fetchAccountByExternalReferenceCode(
+			externalReferenceCode);
+
+		if (account == null) {
+			throw new AccountNotFoundException();
+		}
+
+		List<Property> properties = _propertyService.getAccountProperties(
+			account.getId());
+
+		JSONObject accountJSONObject = new JSONObject(account.toString());
+
+		JSONArray externalLinksJSONArray = new JSONArray();
+
+		for (Property property : properties) {
+			externalLinksJSONArray.put(property.toExternalLinkJSONObject());
+		}
+
+		accountJSONObject.put("externalLinks", externalLinksJSONArray);
+
+		return new ResponseEntity<>(
+			accountJSONObject.toString(), HttpStatus.OK);
 	}
 
 	@GetMapping("/{externalReferenceCode}/jira/object-key")
@@ -414,6 +450,9 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private OktaService _oktaService;
+
+	@Autowired
+	private PropertyService _propertyService;
 
 	@Autowired
 	private ProvisioningAssignmentService _provisioningAssignmentService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/RoleConstants.java
@@ -34,6 +34,9 @@ public class RoleConstants {
 
 	public static final String NAME_ADMINISTRATOR = "Administrator";
 
+	public static final String NAME_CLOUD_CONSOLE_SERVICE =
+		"Cloud Console Service";
+
 	public static final String NAME_CLOUD_NATIVE_CONTACT =
 		"Cloud Native Contact";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Property.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Property.java
@@ -5,6 +5,8 @@
 
 package com.liferay.one.model;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 
 import org.json.JSONObject;
@@ -70,6 +72,28 @@ public class Property {
 
 	public String getValue() {
 		return _value;
+	}
+
+	public JSONObject toExternalLinkJSONObject() {
+		int index = _name.indexOf(CharPool.COLON);
+
+		String domain = _name;
+
+		String entityName = StringPool.BLANK;
+
+		if (index >= 0) {
+			domain = _name.substring(0, index);
+			entityName = _name.substring(index + 1);
+		}
+
+		return new JSONObject(
+		).put(
+			"domain", domain
+		).put(
+			"entityId", _value
+		).put(
+			"entityName", entityName
+		);
 	}
 
 	private final long _accountEntryId;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/AccountPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/AccountPermission.java
@@ -50,6 +50,13 @@ public class AccountPermission {
 
 				return true;
 			}
+
+			if (roleBriefName.equals(
+					RoleConstants.NAME_CLOUD_CONSOLE_SERVICE) &&
+				actionId.equals(ActionKeys.VIEW)) {
+
+				return true;
+			}
 		}
 
 		for (AccountBrief accountBrief : userAccount.getAccountBriefs()) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -73,6 +73,7 @@ liferay.one.email.address.validator.liferay.domains=bp.liferay.com,connect.lifer
 liferay-one-etc-spring-boot-oahs.oauth2.headless.server.client.secret=${LIFERAY_ONE_ETC_SPRING_BOOT_OAHS_CLIENT_SECRET:myfancypassword}
 
 liferay.oauth.application.external.reference.codes=\
+    external-cloud-console,\
     external-ssa,\
     external-trial,\
     liferay-one-etc-spring-boot-oahs,\

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -9,18 +9,24 @@ import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.exception.AccountNotFoundException;
 import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.model.Property;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -34,6 +40,7 @@ import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -135,6 +142,130 @@ public class AccountsRestControllerTest {
 			_provisioningAssignmentService
 		).unassignAccountMembership(
 			_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testGetAccounts() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(
+				_EXTERNAL_REFERENCE_CODE)
+		).thenReturn(
+			account
+		);
+
+		Property property1 = new Property(
+			new JSONObject(
+			).put(
+				"id", 1
+			).put(
+				"name", "domain1:entityName1"
+			).put(
+				"value", "entityId1"
+			));
+
+		Property property2 = new Property(
+			new JSONObject(
+			).put(
+				"id", 2
+			).put(
+				"name", "domain2:entityName2"
+			).put(
+				"value", "entityId2"
+			));
+
+		Mockito.when(
+			_propertyService.getAccountProperties(_ACCOUNT_ID)
+		).thenReturn(
+			Arrays.asList(property1, property2)
+		);
+
+		ResponseEntity<String> responseEntity =
+			accountsRestController.getAccounts(null, _EXTERNAL_REFERENCE_CODE);
+
+		Assertions.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+		JSONObject jsonObject = new JSONObject(responseEntity.getBody());
+
+		Assertions.assertEquals(
+			_EXTERNAL_REFERENCE_CODE,
+			jsonObject.getString("externalReferenceCode"));
+		Assertions.assertEquals(_ACCOUNT_ID, jsonObject.getLong("id"));
+
+		JSONArray externalLinksJSONArray = jsonObject.getJSONArray(
+			"externalLinks");
+
+		Assertions.assertEquals(2, externalLinksJSONArray.length());
+
+		JSONObject externalLinkJSONObject1 =
+			externalLinksJSONArray.getJSONObject(0);
+
+		Assertions.assertEquals(
+			"domain1", externalLinkJSONObject1.getString("domain"));
+		Assertions.assertEquals(
+			"entityId1", externalLinkJSONObject1.getString("entityId"));
+		Assertions.assertEquals(
+			"entityName1", externalLinkJSONObject1.getString("entityName"));
+
+		JSONObject externalLinkJSONObject2 =
+			externalLinksJSONArray.getJSONObject(1);
+
+		Assertions.assertEquals(
+			"domain2", externalLinkJSONObject2.getString("domain"));
+		Assertions.assertEquals(
+			"entityId2", externalLinkJSONObject2.getString("entityId"));
+		Assertions.assertEquals(
+			"entityName2", externalLinkJSONObject2.getString("entityName"));
+	}
+
+	@Test
+	public void testGetAccountsThrowsAccountNotFoundExceptionWhenAccountDoesNotExist()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(
+				_EXTERNAL_REFERENCE_CODE)
+		).thenReturn(
+			null
+		);
+
+		Assertions.assertThrows(
+			AccountNotFoundException.class,
+			() -> accountsRestController.getAccounts(
+				null, _EXTERNAL_REFERENCE_CODE));
+	}
+
+	@Test
+	public void testGetAccountsThrowsPrincipalExceptionWhenPermissionDenied()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.doThrow(
+			new PrincipalException()
+		).when(
+			_accountPermission
+		).check(
+			_EXTERNAL_REFERENCE_CODE, ActionKeys.VIEW, null
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> accountsRestController.getAccounts(
+				null, _EXTERNAL_REFERENCE_CODE));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).fetchAccountByExternalReferenceCode(
+			Mockito.any()
 		);
 	}
 
@@ -585,6 +716,8 @@ public class AccountsRestControllerTest {
 		ReflectionTestUtils.setField(
 			accountsRestController, "_oktaService", _oktaService);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_propertyService", _propertyService);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_provisioningAssignmentService",
 			_provisioningAssignmentService);
 		ReflectionTestUtils.setField(
@@ -644,6 +777,8 @@ public class AccountsRestControllerTest {
 	private final EntitlementService _entitlementService = Mockito.mock(
 		EntitlementService.class);
 	private final OktaService _oktaService = Mockito.mock(OktaService.class);
+	private final PropertyService _propertyService = Mockito.mock(
+		PropertyService.class);
 	private final ProvisioningAssignmentService _provisioningAssignmentService =
 		Mockito.mock(ProvisioningAssignmentService.class);
 	private final ProvisioningEmailService _provisioningEmailService =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91798

## What is being fixed

Cloud Console reads customer account data — including each account's
external links, notably the LXC "cloud-native" subdomain and the linked
Okta application — from Koroneiki's
`GET /o/koroneiki-rest/v1.0/accounts/{kor_id}`. Koroneiki is being
decommissioned as part of the one.liferay data-model migration, so Cloud
Console needs an equivalent endpoint on one.liferay to cut over to.

## How it is being fixed

Adds `GET /accounts/{externalReferenceCode}` to the
liferay-one-etc-spring-boot AccountsRestController. It resolves the
account by its external reference code (the Salesforce Account ID),
returns the full account representation, and appends an externalLinks
array reconstructed from the account's Property rows. Each Property name
is split into domain and entityName and its value becomes entityId,
mirroring the shape Koroneiki returned; that projection lives on the
Property model as toExternalLinkJSONObject(). Access is scoped through
the existing AccountPermission by granting the dedicated Cloud Console
Service role VIEW rights, and the Cloud Console OAuth application is
allow-listed as an inbound consumer of the service.
