### PR TITLE
LPD-99659 Restrict sync to JSM to admin and provisioning roles

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -13,6 +13,7 @@ import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
+import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
@@ -122,7 +123,7 @@ public class AccountsRestController extends OneBaseRestController {
 			@PathVariable("externalReferenceCode") String externalReferenceCode)
 		throws Exception {
 
-		_accountPermission.check(externalReferenceCode, ActionKeys.UPDATE, jwt);
+		_adminPermission.check(jwt);
 
 		_accountSynchronizer.syncAccount(
 			_accountService.getAccount(externalReferenceCode));
@@ -405,6 +406,9 @@ public class AccountsRestController extends OneBaseRestController {
 	@Autowired
 	private AccountUserAccountRoleSynchronizer
 		_accountUserAccountRoleSynchronizer;
+
+	@Autowired
+	private AdminPermission _adminPermission;
 
 	@Autowired
 	private EmailAddressValidatorService _emailAddressValidatorService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/ProjectMembershipPermission.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/permission/ProjectMembershipPermission.java
@@ -94,6 +94,10 @@ public class ProjectMembershipPermission {
 			}
 		}
 
+		if (!actionId.equals(ActionKeys.VIEW)) {
+			return false;
+		}
+
 		Account account = _accountService.getAccount(
 			accountExternalReferenceCode, jwt);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99659

## What is being fixed

The sync-to-jsm endpoint on `AccountsRestController` gated on `AccountPermission` with the UPDATE action, which also passes for the account-scoped Account Administrator and Account Requester roles, and whose final organization loop returns true for any user in an organization assigned to the account regardless of the action, so a plain organization member could trigger a full write into JSM.

## How it is being fixed

The endpoint now gates on `AdminPermission`, which means Administrator or Provisioning Administrator, matching the mockup on LPD-89437. `AccountPermission` itself is left untouched so the endpoints that legitimately rely on account-scoped access are unaffected.