### PR TITLE
LPD-90495 LPD-99486 Fix race between concurrent JSM asset syncs

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AdminRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AdminRestController.java
@@ -5,6 +5,7 @@
 
 package com.liferay.one;
 
+import com.liferay.one.jira.synchronizer.TeamRoleSynchronizer;
 import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.pubsub.Message;
 import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
@@ -70,6 +71,24 @@ public class AdminRestController extends OneBaseRestController {
 		}
 
 		return new ResponseEntity<>(jsonArray.toString(), HttpStatus.OK);
+	}
+
+	@PostMapping("/jira/team-roles/sync")
+	public ResponseEntity<String> postJiraTeamRolesSync(
+			@AuthenticationPrincipal Jwt jwt)
+		throws Exception {
+
+		_adminPermission.check(jwt);
+
+		_teamRoleSynchronizer.syncTeamRoles();
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"firstLineSupportTeamRoleObjectId",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId()
+		);
+
+		return new ResponseEntity<>(jsonObject.toString(), HttpStatus.OK);
 	}
 
 	@PostMapping("/pubsub/dispatch")
@@ -150,5 +169,8 @@ public class AdminRestController extends OneBaseRestController {
 	@Autowired(required = false)
 	private List<BasePubsubSubscriber> _basePubsubSubscribers =
 		Collections.emptyList();
+
+	@Autowired
+	private TeamRoleSynchronizer _teamRoleSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -10,14 +10,11 @@ import com.liferay.one.jira.constants.TeamRoleConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
 import com.liferay.one.jira.converter.TeamConverter;
-import com.liferay.one.jira.converter.TeamRoleConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.petra.string.StringBundler;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -66,13 +63,7 @@ public class AccountOrganizationSynchronizer {
 
 		jiraAssetObject.setAttributeValue(
 			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM_ROLE,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_teamRoleConverter,
-				Collections.singletonList(
-					TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT),
-				Function.identity(),
-				externalKey ->
-					_teamRoleConverter.toFirstLineSupportAssetObject()));
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
 
 		jiraAssetObject.setAttributeValue(
 			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM,
@@ -104,6 +95,6 @@ public class AccountOrganizationSynchronizer {
 	private TeamConverter _teamConverter;
 
 	@Autowired
-	private TeamRoleConverter _teamRoleConverter;
+	private TeamRoleSynchronizer _teamRoleSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -12,6 +12,7 @@ import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
@@ -32,20 +33,25 @@ public class AccountOrganizationSynchronizer {
 			String organizationExternalKey, String accountExternalKey)
 		throws Exception {
 
-		_syncAssignment(organizationExternalKey, accountExternalKey, false);
+		_jiraSyncLock.withLock(
+			accountExternalKey,
+			() -> _syncAssignment(
+				organizationExternalKey, accountExternalKey, false));
 	}
 
 	public void syncUnassignOrganization(
 			String organizationExternalKey, String accountExternalKey)
 		throws Exception {
 
-		_syncAssignment(organizationExternalKey, accountExternalKey, true);
+		_jiraSyncLock.withLock(
+			accountExternalKey,
+			() -> _syncAssignment(
+				organizationExternalKey, accountExternalKey, true));
 	}
 
 	private void _syncAssignment(
-			String organizationExternalKey, String accountExternalKey,
-			boolean deleted)
-		throws Exception {
+		String organizationExternalKey, String accountExternalKey,
+		boolean deleted) {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -90,6 +96,9 @@ public class AccountOrganizationSynchronizer {
 
 	@Autowired
 	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 	@Autowired
 	private TeamConverter _teamConverter;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -24,6 +24,7 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.model.JiraBusinessEvent;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.service.JiraBusinessEventService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.model.AccountSupportInfo;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.Project;
@@ -67,12 +68,18 @@ import org.springframework.stereotype.Component;
 public class AccountSynchronizer {
 
 	public void deleteAccount(String externalReferenceCode) {
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				"Deleting account " + externalReferenceCode + " from JSM");
-		}
+		_jiraSyncLock.withLock(
+			externalReferenceCode,
+			() -> {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Deleting account " + externalReferenceCode +
+							" from JSM");
+				}
 
-		_jiraAssetService.delete(_accountConverter, externalReferenceCode);
+				_jiraAssetService.delete(
+					_accountConverter, externalReferenceCode);
+			});
 	}
 
 	public void syncAccount(Account account) throws Exception {
@@ -374,7 +381,9 @@ public class AccountSynchronizer {
 			assetObject.setAttributeValue(entry.getKey(), entry.getValue());
 		}
 
-		_jiraAssetService.upsert(_accountConverter, assetObject);
+		_jiraSyncLock.withLock(
+			externalKey,
+			() -> _jiraAssetService.upsert(_accountConverter, assetObject));
 	}
 
 	private void _syncAccountOrganizationAssignments(
@@ -557,6 +566,9 @@ public class AccountSynchronizer {
 
 	@Autowired
 	private JiraBusinessEventService _jiraBusinessEventService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 	@Autowired
 	private OrganizationService _organizationService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
@@ -12,6 +12,7 @@ import com.liferay.one.jira.converter.ContactConverter;
 import com.liferay.one.jira.converter.ContactRoleConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
@@ -50,6 +51,17 @@ public class AccountUserAccountRoleSynchronizer {
 			String roleExternalKey, String userAccountExternalKey,
 			String accountExternalKey, boolean deleted)
 		throws Exception {
+
+		_jiraSyncLock.withLock(
+			userAccountExternalKey,
+			() -> _syncAssignmentWithinLock(
+				roleExternalKey, userAccountExternalKey, accountExternalKey,
+				deleted));
+	}
+
+	private void _syncAssignmentWithinLock(
+		String roleExternalKey, String userAccountExternalKey,
+		String accountExternalKey, boolean deleted) {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -100,5 +112,8 @@ public class AccountUserAccountRoleSynchronizer {
 
 	@Autowired
 	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
@@ -15,6 +15,7 @@ import com.liferay.one.jira.converter.ExternalLinkConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.model.Property;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
@@ -44,7 +45,10 @@ public class OrganizationSynchronizer {
 				"Deleting organization " + externalReferenceCode + " from JSM");
 		}
 
-		_jiraAssetService.delete(_teamConverter, externalReferenceCode);
+		_jiraSyncLock.withLock(
+			externalReferenceCode,
+			() -> _jiraAssetService.delete(
+				_teamConverter, externalReferenceCode));
 	}
 
 	public void syncOrganization(Organization organization) throws Exception {
@@ -94,7 +98,9 @@ public class OrganizationSynchronizer {
 					GetterUtil.getLong(organization.getId())),
 				UserAccount::getExternalReferenceCode));
 
-		_jiraAssetService.upsert(_teamConverter, jiraAssetObject);
+		_jiraSyncLock.withLock(
+			organization.getExternalReferenceCode(),
+			() -> _jiraAssetService.upsert(_teamConverter, jiraAssetObject));
 
 		_syncOrganizationAssignments(organization, accountBriefs);
 	}
@@ -152,6 +158,9 @@ public class OrganizationSynchronizer {
 
 	@Autowired
 	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 	@Autowired
 	private PropertyService _propertyService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
@@ -9,12 +9,10 @@ import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.constants.TeamConstants;
-import com.liferay.one.jira.constants.TeamRoleConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
 import com.liferay.one.jira.converter.ExternalLinkConverter;
 import com.liferay.one.jira.converter.TeamConverter;
-import com.liferay.one.jira.converter.TeamRoleConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.model.Property;
@@ -27,7 +25,6 @@ import com.liferay.portal.kernel.util.ListUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -76,13 +73,8 @@ public class OrganizationSynchronizer {
 		List<String> teamRoleObjectIds = Collections.emptyList();
 
 		if (!accountBriefs.isEmpty()) {
-			teamRoleObjectIds = _jiraAssetService.getOrCreateReferenceObjectIds(
-				_teamRoleConverter,
-				Collections.singletonList(
-					TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT),
-				Function.identity(),
-				externalKey ->
-					_teamRoleConverter.toFirstLineSupportAssetObject());
+			teamRoleObjectIds = Collections.singletonList(
+				_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
 		}
 
 		jiraAssetObject.setAttributeValue(
@@ -168,7 +160,7 @@ public class OrganizationSynchronizer {
 	private TeamConverter _teamConverter;
 
 	@Autowired
-	private TeamRoleConverter _teamRoleConverter;
+	private TeamRoleSynchronizer _teamRoleSynchronizer;
 
 	@Autowired
 	private UserAccountService _userAccountService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizer.java
@@ -12,6 +12,7 @@ import com.liferay.one.jira.converter.TeamContactRoleAssignmentConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
@@ -52,6 +53,17 @@ public class OrganizationUserAccountRoleSynchronizer {
 			String roleExternalKey, String userAccountExternalKey,
 			String organizationExternalKey, boolean deleted)
 		throws Exception {
+
+		_jiraSyncLock.withLock(
+			userAccountExternalKey,
+			() -> _syncAssignmentWithinLock(
+				roleExternalKey, userAccountExternalKey,
+				organizationExternalKey, deleted));
+	}
+
+	private void _syncAssignmentWithinLock(
+		String roleExternalKey, String userAccountExternalKey,
+		String organizationExternalKey, boolean deleted) {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -95,6 +107,9 @@ public class OrganizationUserAccountRoleSynchronizer {
 
 	@Autowired
 	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 	@Autowired
 	private TeamContactRoleAssignmentConverter

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/TeamRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/TeamRoleSynchronizer.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.TeamRoleConstants;
+import com.liferay.one.jira.converter.TeamRoleConverter;
+import com.liferay.one.jira.exception.JiraAssetObjectException;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.petra.string.StringBundler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class TeamRoleSynchronizer {
+
+	public String getFirstLineSupportTeamRoleObjectId() {
+		String objectId = _firstLineSupportTeamRoleObjectId;
+
+		if (objectId != null) {
+			return objectId;
+		}
+
+		return _jiraSyncLock.withLock(
+			TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT,
+			() -> {
+				if (_firstLineSupportTeamRoleObjectId != null) {
+					return _firstLineSupportTeamRoleObjectId;
+				}
+
+				String resolvedObjectId = _resolveOrCreate();
+
+				if (resolvedObjectId == null) {
+					throw new JiraAssetObjectException(
+						StringBundler.concat(
+							"No \"", _teamRoleConverter.getObjectTypeName(),
+							"\" asset object exists for external key ",
+							TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT));
+				}
+
+				_firstLineSupportTeamRoleObjectId = resolvedObjectId;
+
+				return resolvedObjectId;
+			});
+	}
+
+	@Async
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationReady() {
+		try {
+			getFirstLineSupportTeamRoleObjectId();
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync team roles on application startup", exception);
+		}
+	}
+
+	@Scheduled(cron = "${liferay.one.jira.team.role.sync.cron}")
+	public void syncTeamRoles() {
+		String objectId = _jiraAssetService.fetchReferenceObjectId(
+			_teamRoleConverter,
+			TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT);
+
+		if (objectId == null) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to find the ",
+					TeamRoleConstants.NAME_FIRST_LINE_SUPPORT,
+					" team role asset object for external key ",
+					TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT,
+					", recreating it"));
+
+			objectId = _jiraSyncLock.withLock(
+				TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT,
+				this::_resolveOrCreate);
+		}
+
+		_firstLineSupportTeamRoleObjectId = objectId;
+	}
+
+	private String _resolveOrCreate() {
+		String objectId = _jiraAssetService.fetchReferenceObjectId(
+			_teamRoleConverter,
+			TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT);
+
+		if (objectId != null) {
+			return objectId;
+		}
+
+		_jiraAssetService.upsert(
+			_teamRoleConverter,
+			_teamRoleConverter.toFirstLineSupportAssetObject());
+
+		return _jiraAssetService.fetchReferenceObjectId(
+			_teamRoleConverter,
+			TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT);
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		TeamRoleSynchronizer.class);
+
+	private volatile String _firstLineSupportTeamRoleObjectId;
+
+	@Autowired
+	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
+
+	@Autowired
+	private TeamRoleConverter _teamRoleConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
@@ -21,6 +21,7 @@ import com.liferay.one.jira.converter.PhoneConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.Property;
 import com.liferay.one.service.EntitlementService;
@@ -45,72 +46,24 @@ import org.springframework.stereotype.Component;
 public class UserAccountSynchronizer {
 
 	public void deleteUserAccount(String externalReferenceCode) {
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				"Deleting user account " + externalReferenceCode + " from JSM");
-		}
+		_jiraSyncLock.withLock(
+			externalReferenceCode,
+			() -> {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						"Deleting user account " + externalReferenceCode +
+							" from JSM");
+				}
 
-		_jiraAssetService.delete(_contactConverter, externalReferenceCode);
+				_jiraAssetService.delete(
+					_contactConverter, externalReferenceCode);
+			});
 	}
 
 	public void syncUserAccount(UserAccount userAccount) throws Exception {
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				"Syncing user account " +
-					userAccount.getExternalReferenceCode() + " to JSM");
-		}
-
-		List<AccountBrief> accountBriefs = ListUtil.fromArray(
-			userAccount.getAccountBriefs());
-		List<OrganizationBrief> organizationBriefs = ListUtil.fromArray(
-			userAccount.getOrganizationBriefs());
-
-		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
-			userAccount);
-
-		List<RoleBrief> roleBriefs = new ArrayList<>(
-			_getAccountRoleBriefs(accountBriefs));
-
-		roleBriefs.addAll(_getOrganizationRoleBriefs(organizationBriefs));
-
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
-			_jiraAssetService.fetchReferenceObjectIds(
-				_accountConverter, accountBriefs,
-				AccountBrief::getExternalReferenceCode));
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
-			_jiraAssetService.fetchReferenceObjectIds(
-				_contactRoleConverter, roleBriefs,
-				RoleBrief::getExternalReferenceCode));
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_entitlementConverter,
-				_getEntitlementDefinitions(accountBriefs),
-				EntitlementDefinition::getDisplayName,
-				_entitlementConverter::toAssetObject));
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_LINKS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_externalLinkConverter, _getExternalLinkProperties(userAccount),
-				Property::getExternalReferenceCode,
-				_externalLinkConverter::toAssetObject));
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_TEAMS,
-			_jiraAssetService.fetchReferenceObjectIds(
-				_teamConverter, organizationBriefs,
-				OrganizationBrief::getExternalReferenceCode));
-		jiraAssetObject.setAttributeValue(
-			ContactConstants.ATTRIBUTE_NAME_PHONES,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_phoneConverter, _getTelephones(userAccount),
-				Phone::getPhoneNumber, _phoneConverter::toAssetObject));
-
-		_jiraAssetService.upsert(_contactConverter, jiraAssetObject);
-
-		_syncContactRoleAssignments(userAccount, accountBriefs);
-		_syncOrganizationRoleAssignments(userAccount, organizationBriefs);
+		_jiraSyncLock.withLock(
+			userAccount.getExternalReferenceCode(),
+			() -> _syncUserAccount(userAccount));
 	}
 
 	private List<RoleBrief> _getAccountRoleBriefs(
@@ -247,6 +200,66 @@ public class UserAccountSynchronizer {
 		}
 	}
 
+	private void _syncUserAccount(UserAccount userAccount) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing user account " +
+					userAccount.getExternalReferenceCode() + " to JSM");
+		}
+
+		List<AccountBrief> accountBriefs = ListUtil.fromArray(
+			userAccount.getAccountBriefs());
+		List<OrganizationBrief> organizationBriefs = ListUtil.fromArray(
+			userAccount.getOrganizationBriefs());
+
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		List<RoleBrief> roleBriefs = new ArrayList<>(
+			_getAccountRoleBriefs(accountBriefs));
+
+		roleBriefs.addAll(_getOrganizationRoleBriefs(organizationBriefs));
+
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_accountConverter, accountBriefs,
+				AccountBrief::getExternalReferenceCode));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_contactRoleConverter, roleBriefs,
+				RoleBrief::getExternalReferenceCode));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_entitlementConverter,
+				_getEntitlementDefinitions(accountBriefs),
+				EntitlementDefinition::getDisplayName,
+				_entitlementConverter::toAssetObject));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_LINKS,
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_externalLinkConverter, _getExternalLinkProperties(userAccount),
+				Property::getExternalReferenceCode,
+				_externalLinkConverter::toAssetObject));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_TEAMS,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_teamConverter, organizationBriefs,
+				OrganizationBrief::getExternalReferenceCode));
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_PHONES,
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_phoneConverter, _getTelephones(userAccount),
+				Phone::getPhoneNumber, _phoneConverter::toAssetObject));
+
+		_jiraAssetService.upsert(_contactConverter, jiraAssetObject);
+
+		_syncContactRoleAssignments(userAccount, accountBriefs);
+		_syncOrganizationRoleAssignments(userAccount, organizationBriefs);
+	}
+
 	private static final Log _log = LogFactory.getLog(
 		UserAccountSynchronizer.class);
 
@@ -274,6 +287,9 @@ public class UserAccountSynchronizer {
 
 	@Autowired
 	private JiraAssetService _jiraAssetService;
+
+	@Autowired
+	private JiraSyncLock _jiraSyncLock;
 
 	@Autowired
 	private OrganizationUserAccountRoleSynchronizer

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/JiraSyncLock.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/JiraSyncLock.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.util;
+
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class JiraSyncLock {
+
+	public JiraSyncLock() {
+		for (int i = 0; i < _reentrantLocks.length; i++) {
+			_reentrantLocks[i] = new ReentrantLock();
+		}
+	}
+
+	public <E extends Throwable> void withLock(
+			String key, UnsafeRunnable<E> unsafeRunnable)
+		throws E {
+
+		if (Validator.isNull(key)) {
+			unsafeRunnable.run();
+
+			return;
+		}
+
+		ReentrantLock reentrantLock =
+			_reentrantLocks
+				[Math.floorMod(key.hashCode(), _reentrantLocks.length)];
+
+		reentrantLock.lock();
+
+		try {
+			unsafeRunnable.run();
+		}
+		finally {
+			reentrantLock.unlock();
+		}
+	}
+
+	private final ReentrantLock[] _reentrantLocks = new ReentrantLock[64];
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/JiraSyncLock.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/JiraSyncLock.java
@@ -6,6 +6,7 @@
 package com.liferay.one.jira.util;
 
 import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.function.UnsafeSupplier;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.concurrent.locks.ReentrantLock;
@@ -28,10 +29,21 @@ public class JiraSyncLock {
 			String key, UnsafeRunnable<E> unsafeRunnable)
 		throws E {
 
-		if (Validator.isNull(key)) {
-			unsafeRunnable.run();
+		withLock(
+			key,
+			() -> {
+				unsafeRunnable.run();
 
-			return;
+				return null;
+			});
+	}
+
+	public <T, E extends Throwable> T withLock(
+			String key, UnsafeSupplier<T, E> unsafeSupplier)
+		throws E {
+
+		if (Validator.isNull(key)) {
+			return unsafeSupplier.get();
 		}
 
 		ReentrantLock reentrantLock =
@@ -41,7 +53,7 @@ public class JiraSyncLock {
 		reentrantLock.lock();
 
 		try {
-			unsafeRunnable.run();
+			return unsafeSupplier.get();
 		}
 		finally {
 			reentrantLock.unlock();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -40,6 +40,7 @@ liferay.one.jira.project.support.fls.url=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_FLS_
 liferay.one.jira.project.support.hc=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_HC}
 liferay.one.jira.project.support.hc.url=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_HC_URL}
 liferay.one.jira.request.provisioning.id=${LIFERAY_ONE_JIRA_REQUEST_PROVISIONING_ID}
+liferay.one.jira.team.role.sync.cron=0 0 * * * *
 liferay.one.jira.url=${LIFERAY_ONE_JIRA_URL}
 liferay.one.jira.workspace.id=${LIFERAY_ONE_JIRA_WORKSPACE_ID}
 liferay.one.portal.url=${LIFERAY_ONE_PORTAL_URL}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AdminRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AdminRestControllerTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.one;
 
+import com.liferay.one.jira.synchronizer.TeamRoleSynchronizer;
 import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.pubsub.Message;
 import com.liferay.one.pubsub.subscriber.BasePubsubSubscriber;
@@ -78,6 +79,42 @@ public class AdminRestControllerTest {
 				).keySet()));
 		Assertions.assertEquals("1", message.get("a"));
 		Assertions.assertEquals("2", message.get("b"));
+	}
+
+	@Test
+	public void testPostJiraTeamRolesSyncRefreshesAndReturnsObjectId()
+		throws Exception {
+
+		AdminRestController adminRestController = _createController();
+
+		TeamRoleSynchronizer teamRoleSynchronizer = Mockito.mock(
+			TeamRoleSynchronizer.class);
+
+		Mockito.when(
+			teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId()
+		).thenReturn(
+			"12345"
+		);
+
+		ReflectionTestUtils.setField(
+			adminRestController, "_teamRoleSynchronizer", teamRoleSynchronizer);
+
+		ResponseEntity<String> responseEntity =
+			adminRestController.postJiraTeamRolesSync(null);
+
+		Assertions.assertEquals(
+			HttpStatus.OK.value(),
+			responseEntity.getStatusCode(
+			).value());
+
+		JSONObject jsonObject = new JSONObject(responseEntity.getBody());
+
+		Assertions.assertEquals(
+			"12345", jsonObject.getString("firstLineSupportTeamRoleObjectId"));
+
+		Mockito.verify(
+			teamRoleSynchronizer
+		).syncTeamRoles();
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -1,0 +1,146 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountOrganizationSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_accountOrganizationSynchronizer =
+			new AccountOrganizationSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		AccountTeamRoleAssignmentConverter accountTeamRoleAssignmentConverter =
+			Mockito.mock(AccountTeamRoleAssignmentConverter.class);
+
+		Mockito.when(
+			accountTeamRoleAssignmentConverter.toAssetObject(
+				Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.anyBoolean(), Mockito.any())
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer, "_accountConverter",
+			Mockito.mock(AccountConverter.class));
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer,
+			"_accountTeamRoleAssignmentConverter",
+			accountTeamRoleAssignmentConverter);
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer, "_jiraAssetService",
+			_jiraAssetService);
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer, "_jiraSyncLock",
+			new JiraSyncLock());
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer, "_teamConverter",
+			Mockito.mock(TeamConverter.class));
+		ReflectionTestUtils.setField(
+			_accountOrganizationSynchronizer, "_teamRoleSynchronizer",
+			Mockito.mock(TeamRoleSynchronizer.class));
+	}
+
+	@Test
+	public void testSyncAssignOrganizationSerializesPerAccount()
+		throws Exception {
+
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch firstUpsertEnteredLatch = new CountDownLatch(1);
+		AtomicInteger invocationCount = new AtomicInteger();
+		CountDownLatch releaseFirstUpsertLatch = new CountDownLatch(1);
+
+		Mockito.doAnswer(
+			invocation -> {
+				if (invocationCount.incrementAndGet() == 1) {
+					firstUpsertEnteredLatch.countDown();
+
+					releaseFirstUpsertLatch.await(10, TimeUnit.SECONDS);
+				}
+
+				events.add("upsert");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+
+		Thread firstThread = new Thread(
+			() -> {
+				try {
+					_accountOrganizationSynchronizer.syncAssignOrganization(
+						"organization-erc", "account-erc");
+				}
+				catch (Exception exception) {
+					Assertions.fail(exception);
+				}
+			});
+
+		firstThread.start();
+
+		Assertions.assertTrue(
+			firstUpsertEnteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread secondThread = new Thread(
+			() -> {
+				try {
+					_accountOrganizationSynchronizer.syncAssignOrganization(
+						"organization-erc", "account-erc");
+				}
+				catch (Exception exception) {
+					Assertions.fail(exception);
+				}
+			});
+
+		secondThread.start();
+
+		secondThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), events);
+
+		releaseFirstUpsertLatch.countDown();
+
+		firstThread.join(10000);
+		secondThread.join(10000);
+
+		Assertions.assertEquals(Arrays.asList("upsert", "upsert"), events);
+	}
+
+	private AccountOrganizationSynchronizer _accountOrganizationSynchronizer;
+	private JiraAssetService _jiraAssetService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -12,15 +12,6 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.util.JiraSyncLock;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,71 +64,26 @@ public class AccountOrganizationSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncAssignOrganizationSerializesPerAccount()
+	public void testSyncAssignOrganizationWaitsForSyncAssignOrganization()
 		throws Exception {
 
-		List<String> events = Collections.synchronizedList(new ArrayList<>());
-		CountDownLatch firstUpsertEnteredLatch = new CountDownLatch(1);
-		AtomicInteger invocationCount = new AtomicInteger();
-		CountDownLatch releaseFirstUpsertLatch = new CountDownLatch(1);
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
 
 		Mockito.doAnswer(
-			invocation -> {
-				if (invocationCount.incrementAndGet() == 1) {
-					firstUpsertEnteredLatch.countDown();
-
-					releaseFirstUpsertLatch.await(10, TimeUnit.SECONDS);
-				}
-
-				events.add("upsert");
-
-				return null;
-			}
+			lockSerializationTestHelper.block("upsert")
 		).when(
 			_jiraAssetService
 		).upsert(
 			Mockito.any(), Mockito.any()
 		);
 
-		Thread firstThread = new Thread(
-			() -> {
-				try {
-					_accountOrganizationSynchronizer.syncAssignOrganization(
-						"organization-erc", "account-erc");
-				}
-				catch (Exception exception) {
-					Assertions.fail(exception);
-				}
-			});
-
-		firstThread.start();
-
-		Assertions.assertTrue(
-			firstUpsertEnteredLatch.await(10, TimeUnit.SECONDS));
-
-		Thread secondThread = new Thread(
-			() -> {
-				try {
-					_accountOrganizationSynchronizer.syncAssignOrganization(
-						"organization-erc", "account-erc");
-				}
-				catch (Exception exception) {
-					Assertions.fail(exception);
-				}
-			});
-
-		secondThread.start();
-
-		secondThread.join(200);
-
-		Assertions.assertEquals(Collections.emptyList(), events);
-
-		releaseFirstUpsertLatch.countDown();
-
-		firstThread.join(10000);
-		secondThread.join(10000);
-
-		Assertions.assertEquals(Arrays.asList("upsert", "upsert"), events);
+		lockSerializationTestHelper.assertSerialized(
+			() -> _accountOrganizationSynchronizer.syncAssignOrganization(
+				"organization-erc", "account-erc"),
+			() -> _accountOrganizationSynchronizer.syncAssignOrganization(
+				"organization-erc", "account-erc"),
+			"upsert", "upsert");
 	}
 
 	private AccountOrganizationSynchronizer _accountOrganizationSynchronizer;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -1,0 +1,241 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.EntitlementConverter;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.jira.converter.PostalAddressConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.service.JiraBusinessEventService;
+import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.OrganizationService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_accountSynchronizer = new AccountSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		AccountConverter accountConverter = Mockito.mock(
+			AccountConverter.class);
+
+		Mockito.when(
+			accountConverter.toAssetObject(
+				Mockito.any(Account.class), Mockito.any(), Mockito.any())
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		CommerceOrderService commerceOrderService = Mockito.mock(
+			CommerceOrderService.class);
+
+		Mockito.when(
+			commerceOrderService.getAccountSupportInfo(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			Mockito.mock(AccountSupportInfo.class)
+		);
+
+		JiraBusinessEventService jiraBusinessEventService = Mockito.mock(
+			JiraBusinessEventService.class);
+
+		Mockito.when(
+			jiraBusinessEventService.getJiraBusinessEvents(Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		OrganizationService organizationService = Mockito.mock(
+			OrganizationService.class);
+
+		Mockito.when(
+			organizationService.getAccountOrganizations(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ProjectService projectService = Mockito.mock(ProjectService.class);
+
+		Mockito.when(
+			projectService.getProjects(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		PropertyService propertyService = Mockito.mock(PropertyService.class);
+
+		Mockito.when(
+			propertyService.getAccountProperties(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		UserAccountService userAccountService = Mockito.mock(
+			UserAccountService.class);
+
+		Mockito.when(
+			userAccountService.getAccountUserAccounts(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_accountConverter", accountConverter);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_accountOrganizationSynchronizer",
+			Mockito.mock(AccountOrganizationSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_accountUserAccountRoleSynchronizer",
+			Mockito.mock(AccountUserAccountRoleSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_commerceOrderService",
+			commerceOrderService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_contactConverter",
+			Mockito.mock(ContactConverter.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_entitlementConverter",
+			Mockito.mock(EntitlementConverter.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_entitlementService",
+			Mockito.mock(EntitlementService.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_externalLinkConverter",
+			Mockito.mock(ExternalLinkConverter.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_jiraAssetService", _jiraAssetService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_jiraBusinessEventService",
+			jiraBusinessEventService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_jiraSyncLock", new JiraSyncLock());
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_organizationService", organizationService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_postalAddressConverter",
+			Mockito.mock(PostalAddressConverter.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_projectService", projectService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_propertyService", propertyService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_teamConverter",
+			Mockito.mock(TeamConverter.class));
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_userAccountService", userAccountService);
+	}
+
+	@Test
+	public void testDeleteAccountWaitsForInFlightSyncAccount()
+		throws Exception {
+
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
+		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+
+		Mockito.doAnswer(
+			invocation -> {
+				syncEnteredLatch.countDown();
+
+				releaseSyncLatch.await(10, TimeUnit.SECONDS);
+
+				events.add("upsert");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.doAnswer(
+			invocation -> {
+				events.add("delete");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.any()
+		);
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		account.setId(1L);
+		account.setName("Test Account");
+
+		Thread syncThread = new Thread(
+			() -> {
+				try {
+					_accountSynchronizer.syncAccount(account);
+				}
+				catch (Exception exception) {
+					Assertions.fail(exception);
+				}
+			});
+
+		syncThread.start();
+
+		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread deleteThread = new Thread(
+			() -> _accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE));
+
+		deleteThread.start();
+
+		deleteThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), events);
+
+		releaseSyncLatch.countDown();
+
+		syncThread.join(10000);
+		deleteThread.join(10000);
+
+		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+	}
+
+	private static final String _EXTERNAL_REFERENCE_CODE =
+		"test-external-reference-code";
+
+	private AccountSynchronizer _accountSynchronizer;
+	private JiraAssetService _jiraAssetService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -24,14 +24,8 @@ import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -160,23 +154,12 @@ public class AccountSynchronizerTest {
 	}
 
 	@Test
-	public void testDeleteAccountWaitsForInFlightSyncAccount()
-		throws Exception {
-
-		List<String> events = Collections.synchronizedList(new ArrayList<>());
-		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
-		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+	public void testDeleteAccountWaitsForSyncAccount() throws Exception {
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
 
 		Mockito.doAnswer(
-			invocation -> {
-				syncEnteredLatch.countDown();
-
-				releaseSyncLatch.await(10, TimeUnit.SECONDS);
-
-				events.add("upsert");
-
-				return null;
-			}
+			lockSerializationTestHelper.block("upsert")
 		).when(
 			_jiraAssetService
 		).upsert(
@@ -184,11 +167,7 @@ public class AccountSynchronizerTest {
 		);
 
 		Mockito.doAnswer(
-			invocation -> {
-				events.add("delete");
-
-				return null;
-			}
+			lockSerializationTestHelper.record("delete")
 		).when(
 			_jiraAssetService
 		).delete(
@@ -201,35 +180,10 @@ public class AccountSynchronizerTest {
 		account.setId(1L);
 		account.setName("Test Account");
 
-		Thread syncThread = new Thread(
-			() -> {
-				try {
-					_accountSynchronizer.syncAccount(account);
-				}
-				catch (Exception exception) {
-					Assertions.fail(exception);
-				}
-			});
-
-		syncThread.start();
-
-		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
-
-		Thread deleteThread = new Thread(
-			() -> _accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE));
-
-		deleteThread.start();
-
-		deleteThread.join(200);
-
-		Assertions.assertEquals(Collections.emptyList(), events);
-
-		releaseSyncLatch.countDown();
-
-		syncThread.join(10000);
-		deleteThread.join(10000);
-
-		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+		lockSerializationTestHelper.assertSerialized(
+			() -> _accountSynchronizer.syncAccount(account),
+			() -> _accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE),
+			"upsert", "delete");
 	}
 
 	private static final String _EXTERNAL_REFERENCE_CODE =

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/LockSerializationTestHelper.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/LockSerializationTestHelper.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.petra.function.UnsafeRunnable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Assertions;
+
+import org.mockito.stubbing.Answer;
+
+/**
+ * Asserts that two operations serialize on a shared
+ * {@link com.liferay.one.jira.util.JiraSyncLock} key: the first operation
+ * blocks inside a call stubbed with {@link #block}, the second operation is
+ * started while the first is still blocked and must not record any event
+ * until the first is released, and the recorded events must land in the
+ * expected order. Use one instance per test.
+ *
+ * @author Drew Brokke
+ */
+public class LockSerializationTestHelper {
+
+	public void assertSerialized(
+			UnsafeRunnable<Exception> firstUnsafeRunnable,
+			UnsafeRunnable<Exception> secondUnsafeRunnable,
+			String... expectedEvents)
+		throws Exception {
+
+		Thread firstThread = _startThread(firstUnsafeRunnable);
+
+		Assertions.assertTrue(_enteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread secondThread = _startThread(secondUnsafeRunnable);
+
+		secondThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), _events);
+
+		_releaseLatch.countDown();
+
+		firstThread.join(10000);
+		secondThread.join(10000);
+
+		if (!_throwables.isEmpty()) {
+			Assertions.fail(_throwables.get(0));
+		}
+
+		Assertions.assertEquals(Arrays.asList(expectedEvents), _events);
+	}
+
+	public Answer<Object> block(String event) {
+		return invocation -> {
+			if (_blocked.compareAndSet(false, true)) {
+				_enteredLatch.countDown();
+
+				_releaseLatch.await(10, TimeUnit.SECONDS);
+			}
+
+			_events.add(event);
+
+			return null;
+		};
+	}
+
+	public Answer<Object> record(String event) {
+		return invocation -> {
+			_events.add(event);
+
+			return null;
+		};
+	}
+
+	private Thread _startThread(UnsafeRunnable<Exception> unsafeRunnable) {
+		Thread thread = new Thread(
+			() -> {
+				try {
+					unsafeRunnable.run();
+				}
+				catch (Throwable throwable) {
+					_throwables.add(throwable);
+				}
+			});
+
+		thread.start();
+
+		return thread;
+	}
+
+	private final AtomicBoolean _blocked = new AtomicBoolean();
+	private final CountDownLatch _enteredLatch = new CountDownLatch(1);
+	private final List<String> _events = Collections.synchronizedList(
+		new ArrayList<>());
+	private final CountDownLatch _releaseLatch = new CountDownLatch(1);
+	private final List<Throwable> _throwables = Collections.synchronizedList(
+		new ArrayList<>());
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
@@ -16,14 +16,8 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -96,23 +90,14 @@ public class OrganizationSynchronizerTest {
 	}
 
 	@Test
-	public void testDeleteOrganizationWaitsForInFlightSyncOrganization()
+	public void testDeleteOrganizationWaitsForSyncOrganization()
 		throws Exception {
 
-		List<String> events = Collections.synchronizedList(new ArrayList<>());
-		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
-		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
 
 		Mockito.doAnswer(
-			invocation -> {
-				syncEnteredLatch.countDown();
-
-				releaseSyncLatch.await(10, TimeUnit.SECONDS);
-
-				events.add("upsert");
-
-				return null;
-			}
+			lockSerializationTestHelper.block("upsert")
 		).when(
 			_jiraAssetService
 		).upsert(
@@ -120,11 +105,7 @@ public class OrganizationSynchronizerTest {
 		);
 
 		Mockito.doAnswer(
-			invocation -> {
-				events.add("delete");
-
-				return null;
-			}
+			lockSerializationTestHelper.record("delete")
 		).when(
 			_jiraAssetService
 		).delete(
@@ -135,36 +116,11 @@ public class OrganizationSynchronizerTest {
 
 		organization.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
 
-		Thread syncThread = new Thread(
-			() -> {
-				try {
-					_organizationSynchronizer.syncOrganization(organization);
-				}
-				catch (Exception exception) {
-					Assertions.fail(exception);
-				}
-			});
-
-		syncThread.start();
-
-		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
-
-		Thread deleteThread = new Thread(
+		lockSerializationTestHelper.assertSerialized(
+			() -> _organizationSynchronizer.syncOrganization(organization),
 			() -> _organizationSynchronizer.deleteOrganization(
-				_EXTERNAL_REFERENCE_CODE));
-
-		deleteThread.start();
-
-		deleteThread.join(200);
-
-		Assertions.assertEquals(Collections.emptyList(), events);
-
-		releaseSyncLatch.countDown();
-
-		syncThread.join(10000);
-		deleteThread.join(10000);
-
-		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+				_EXTERNAL_REFERENCE_CODE),
+			"upsert", "delete");
 	}
 
 	private static final String _EXTERNAL_REFERENCE_CODE =

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class OrganizationSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_organizationSynchronizer = new OrganizationSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		PropertyService propertyService = Mockito.mock(PropertyService.class);
+
+		Mockito.when(
+			propertyService.getOrganizationProperties(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		TeamConverter teamConverter = Mockito.mock(TeamConverter.class);
+
+		Mockito.when(
+			teamConverter.toAssetObject(Mockito.any(Organization.class))
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		UserAccountService userAccountService = Mockito.mock(
+			UserAccountService.class);
+
+		Mockito.when(
+			userAccountService.getOrganizationUserAccounts(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_accountConverter",
+			Mockito.mock(AccountConverter.class));
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_accountOrganizationSynchronizer",
+			Mockito.mock(AccountOrganizationSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_contactConverter",
+			Mockito.mock(ContactConverter.class));
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_externalLinkConverter",
+			Mockito.mock(ExternalLinkConverter.class));
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_jiraAssetService", _jiraAssetService);
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_jiraSyncLock", new JiraSyncLock());
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_propertyService", propertyService);
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_teamConverter", teamConverter);
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_teamRoleSynchronizer",
+			Mockito.mock(TeamRoleSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_organizationSynchronizer, "_userAccountService",
+			userAccountService);
+	}
+
+	@Test
+	public void testDeleteOrganizationWaitsForInFlightSyncOrganization()
+		throws Exception {
+
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
+		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+
+		Mockito.doAnswer(
+			invocation -> {
+				syncEnteredLatch.countDown();
+
+				releaseSyncLatch.await(10, TimeUnit.SECONDS);
+
+				events.add("upsert");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.doAnswer(
+			invocation -> {
+				events.add("delete");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.any()
+		);
+
+		Organization organization = new Organization();
+
+		organization.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+
+		Thread syncThread = new Thread(
+			() -> {
+				try {
+					_organizationSynchronizer.syncOrganization(organization);
+				}
+				catch (Exception exception) {
+					Assertions.fail(exception);
+				}
+			});
+
+		syncThread.start();
+
+		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread deleteThread = new Thread(
+			() -> _organizationSynchronizer.deleteOrganization(
+				_EXTERNAL_REFERENCE_CODE));
+
+		deleteThread.start();
+
+		deleteThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), events);
+
+		releaseSyncLatch.countDown();
+
+		syncThread.join(10000);
+		deleteThread.join(10000);
+
+		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+	}
+
+	private static final String _EXTERNAL_REFERENCE_CODE =
+		"test-external-reference-code";
+
+	private JiraAssetService _jiraAssetService;
+	private OrganizationSynchronizer _organizationSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/TeamRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/TeamRoleSynchronizerTest.java
@@ -1,0 +1,161 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.TeamRoleConstants;
+import com.liferay.one.jira.converter.TeamRoleConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class TeamRoleSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_teamRoleSynchronizer = new TeamRoleSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		_teamRoleConverter = Mockito.mock(TeamRoleConverter.class);
+
+		Mockito.when(
+			_teamRoleConverter.toFirstLineSupportAssetObject()
+		).thenReturn(
+			_jiraAssetObject
+		);
+
+		ReflectionTestUtils.setField(
+			_teamRoleSynchronizer, "_jiraAssetService", _jiraAssetService);
+		ReflectionTestUtils.setField(
+			_teamRoleSynchronizer, "_jiraSyncLock", new JiraSyncLock());
+		ReflectionTestUtils.setField(
+			_teamRoleSynchronizer, "_teamRoleConverter", _teamRoleConverter);
+	}
+
+	@Test
+	public void testGetFirstLineSupportTeamRoleObjectIdCachesObjectId() {
+		_mockFetchReferenceObjectId("12345");
+
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.times(1)
+		).fetchReferenceObjectId(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testGetFirstLineSupportTeamRoleObjectIdCreatesMissingObject() {
+		_mockFetchReferenceObjectId(null, "12345");
+
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			_teamRoleConverter, _jiraAssetObject
+		);
+	}
+
+	@Test
+	public void testOnApplicationReadyCachesObjectId() {
+		_mockFetchReferenceObjectId("12345");
+
+		_teamRoleSynchronizer.onApplicationReady();
+
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.times(1)
+		).fetchReferenceObjectId(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSyncTeamRolesRecreatesMissingObject() {
+		_mockFetchReferenceObjectId(null, null, "12345");
+
+		_teamRoleSynchronizer.syncTeamRoles();
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			_teamRoleConverter, _jiraAssetObject
+		);
+
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+	}
+
+	@Test
+	public void testSyncTeamRolesRefreshesCachedObjectId() {
+		_mockFetchReferenceObjectId("12345", "67890");
+
+		Assertions.assertEquals(
+			"12345",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+
+		_teamRoleSynchronizer.syncTeamRoles();
+
+		Assertions.assertEquals(
+			"67890",
+			_teamRoleSynchronizer.getFirstLineSupportTeamRoleObjectId());
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	private void _mockFetchReferenceObjectId(
+		String objectId, String... objectIds) {
+
+		Mockito.when(
+			_jiraAssetService.fetchReferenceObjectId(
+				_teamRoleConverter,
+				TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT)
+		).thenReturn(
+			objectId, objectIds
+		);
+	}
+
+	private final JiraAssetObject _jiraAssetObject = Mockito.mock(
+		JiraAssetObject.class);
+	private JiraAssetService _jiraAssetService;
+	private TeamRoleConverter _teamRoleConverter;
+	private TeamRoleSynchronizer _teamRoleSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -1,0 +1,178 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.ContactRoleConverter;
+import com.liferay.one.jira.converter.EntitlementConverter;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.jira.converter.PhoneConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.PropertyService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class UserAccountSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_userAccountSynchronizer = new UserAccountSynchronizer();
+
+		_contactConverter = Mockito.mock(ContactConverter.class);
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		PropertyService propertyService = Mockito.mock(PropertyService.class);
+
+		Mockito.when(
+			propertyService.getUserAccountProperties(Mockito.anyLong())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.when(
+			_contactConverter.toAssetObject(Mockito.any(UserAccount.class))
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_accountConverter",
+			Mockito.mock(AccountConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_accountUserAccountRoleSynchronizer",
+			Mockito.mock(AccountUserAccountRoleSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_contactConverter", _contactConverter);
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_contactRoleConverter",
+			Mockito.mock(ContactRoleConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_entitlementConverter",
+			Mockito.mock(EntitlementConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_entitlementService",
+			Mockito.mock(EntitlementService.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_externalLinkConverter",
+			Mockito.mock(ExternalLinkConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_jiraAssetService", _jiraAssetService);
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer,
+			"_organizationUserAccountRoleSynchronizer",
+			Mockito.mock(OrganizationUserAccountRoleSynchronizer.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_phoneConverter",
+			Mockito.mock(PhoneConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_propertyService", propertyService);
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_teamConverter",
+			Mockito.mock(TeamConverter.class));
+	}
+
+	@Test
+	public void testDeleteUserAccountWaitsForInFlightSyncUserAccount()
+		throws Exception {
+
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
+		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+
+		Mockito.doAnswer(
+			invocation -> {
+				syncEnteredLatch.countDown();
+
+				releaseSyncLatch.await(10, TimeUnit.SECONDS);
+
+				events.add("upsert");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.doAnswer(
+			invocation -> {
+				events.add("delete");
+
+				return null;
+			}
+		).when(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.any()
+		);
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		userAccount.setId(1L);
+
+		Thread syncThread = new Thread(
+			() -> {
+				try {
+					_userAccountSynchronizer.syncUserAccount(userAccount);
+				}
+				catch (Exception exception) {
+					Assertions.fail(exception);
+				}
+			});
+
+		syncThread.start();
+
+		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread deleteThread = new Thread(
+			() -> _userAccountSynchronizer.deleteUserAccount(
+				_EXTERNAL_REFERENCE_CODE));
+
+		deleteThread.start();
+
+		deleteThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), events);
+
+		releaseSyncLatch.countDown();
+
+		syncThread.join(10000);
+		deleteThread.join(10000);
+
+		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+	}
+
+	private static final String _EXTERNAL_REFERENCE_CODE =
+		"test-external-reference-code";
+
+	private ContactConverter _contactConverter;
+	private JiraAssetService _jiraAssetService;
+	private UserAccountSynchronizer _userAccountSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -19,14 +19,8 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.PropertyService;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -99,23 +93,14 @@ public class UserAccountSynchronizerTest {
 	}
 
 	@Test
-	public void testDeleteUserAccountWaitsForInFlightSyncUserAccount()
+	public void testDeleteUserAccountWaitsForSyncUserAccount()
 		throws Exception {
 
-		List<String> events = Collections.synchronizedList(new ArrayList<>());
-		CountDownLatch releaseSyncLatch = new CountDownLatch(1);
-		CountDownLatch syncEnteredLatch = new CountDownLatch(1);
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
 
 		Mockito.doAnswer(
-			invocation -> {
-				syncEnteredLatch.countDown();
-
-				releaseSyncLatch.await(10, TimeUnit.SECONDS);
-
-				events.add("upsert");
-
-				return null;
-			}
+			lockSerializationTestHelper.block("upsert")
 		).when(
 			_jiraAssetService
 		).upsert(
@@ -123,11 +108,7 @@ public class UserAccountSynchronizerTest {
 		);
 
 		Mockito.doAnswer(
-			invocation -> {
-				events.add("delete");
-
-				return null;
-			}
+			lockSerializationTestHelper.record("delete")
 		).when(
 			_jiraAssetService
 		).delete(
@@ -139,36 +120,11 @@ public class UserAccountSynchronizerTest {
 		userAccount.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
 		userAccount.setId(1L);
 
-		Thread syncThread = new Thread(
-			() -> {
-				try {
-					_userAccountSynchronizer.syncUserAccount(userAccount);
-				}
-				catch (Exception exception) {
-					Assertions.fail(exception);
-				}
-			});
-
-		syncThread.start();
-
-		Assertions.assertTrue(syncEnteredLatch.await(10, TimeUnit.SECONDS));
-
-		Thread deleteThread = new Thread(
+		lockSerializationTestHelper.assertSerialized(
+			() -> _userAccountSynchronizer.syncUserAccount(userAccount),
 			() -> _userAccountSynchronizer.deleteUserAccount(
-				_EXTERNAL_REFERENCE_CODE));
-
-		deleteThread.start();
-
-		deleteThread.join(200);
-
-		Assertions.assertEquals(Collections.emptyList(), events);
-
-		releaseSyncLatch.countDown();
-
-		syncThread.join(10000);
-		deleteThread.join(10000);
-
-		Assertions.assertEquals(Arrays.asList("upsert", "delete"), events);
+				_EXTERNAL_REFERENCE_CODE),
+			"upsert", "delete");
 	}
 
 	private static final String _EXTERNAL_REFERENCE_CODE =

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -15,6 +15,7 @@ import com.liferay.one.jira.converter.PhoneConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.PropertyService;
 
@@ -81,6 +82,8 @@ public class UserAccountSynchronizerTest {
 			Mockito.mock(ExternalLinkConverter.class));
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_jiraAssetService", _jiraAssetService);
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_jiraSyncLock", new JiraSyncLock());
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer,
 			"_organizationUserAccountRoleSynchronizer",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/util/JiraSyncLockTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/util/JiraSyncLockTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraSyncLockTest {
+
+	@BeforeEach
+	public void setUp() {
+		_jiraSyncLock = new JiraSyncLock();
+	}
+
+	@Test
+	public void testWithLockIsReentrant() throws Exception {
+		List<String> events = new ArrayList<>();
+
+		_jiraSyncLock.withLock(
+			"key",
+			() -> _jiraSyncLock.withLock("key", () -> events.add("ran")));
+
+		Assertions.assertEquals(Collections.singletonList("ran"), events);
+	}
+
+	@Test
+	public void testWithLockReleasesLockAfterException() throws Exception {
+		Exception exception = Assertions.assertThrows(
+			Exception.class,
+			() -> _jiraSyncLock.withLock(
+				"key",
+				() -> {
+					throw new Exception("expected");
+				}));
+
+		Assertions.assertEquals("expected", exception.getMessage());
+
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+
+		Thread thread = new Thread(
+			() -> _jiraSyncLock.withLock("key", () -> events.add("ran")));
+
+		thread.start();
+
+		thread.join(10000);
+
+		Assertions.assertEquals(Collections.singletonList("ran"), events);
+	}
+
+	@Test
+	public void testWithLockRunsWithNullKey() throws Exception {
+		List<String> events = new ArrayList<>();
+
+		_jiraSyncLock.withLock(null, () -> events.add("ran"));
+
+		Assertions.assertEquals(Collections.singletonList("ran"), events);
+	}
+
+	@Test
+	public void testWithLockSerializesSameKey() throws Exception {
+		CountDownLatch enteredLatch = new CountDownLatch(1);
+		List<String> events = Collections.synchronizedList(new ArrayList<>());
+		CountDownLatch releaseLatch = new CountDownLatch(1);
+
+		Thread firstThread = new Thread(
+			() -> {
+				try {
+					_jiraSyncLock.withLock(
+						"key",
+						() -> {
+							enteredLatch.countDown();
+
+							releaseLatch.await(10, TimeUnit.SECONDS);
+
+							events.add("first");
+						});
+				}
+				catch (InterruptedException interruptedException) {
+					Thread currentThread = Thread.currentThread();
+
+					currentThread.interrupt();
+				}
+			});
+
+		firstThread.start();
+
+		Assertions.assertTrue(enteredLatch.await(10, TimeUnit.SECONDS));
+
+		Thread secondThread = new Thread(
+			() -> _jiraSyncLock.withLock("key", () -> events.add("second")));
+
+		secondThread.start();
+
+		secondThread.join(200);
+
+		Assertions.assertEquals(Collections.emptyList(), events);
+
+		releaseLatch.countDown();
+
+		firstThread.join(10000);
+		secondThread.join(10000);
+
+		Assertions.assertEquals(Arrays.asList("first", "second"), events);
+	}
+
+	private JiraSyncLock _jiraSyncLock;
+
+}


### PR DESCRIPTION
Story: [LPD-90495](https://liferay.atlassian.net/browse/LPD-90495)
Task: [LPD-99486](https://liferay.atlassian.net/browse/LPD-99486)

## What is being fixed

Two threads syncing the same object to JSM Assets can race — for example, an asynchronous delete running while a role-assignment sync for the same object is still in flight. Each synchronizer reads the current asset state and then writes, so the interleaving can clobber the other thread's work and fail the JSM asset creation.

## How it is being fixed

A new JiraSyncLock component provides striped locking by key: each synchronizer wraps its read-then-write section in a lock keyed on the asset's identity, so concurrent syncs of the same object are serialized while unrelated objects still run in parallel. The race is reproduced first with a test case, and the lock is applied to the synchronizers where the issue was observed, then to AccountOrganizationSynchronizer, AccountSynchronizer, and OrganizationSynchronizer, with the shared lock-serialization test logic extracted into a helper. Along the way, calls for the well-known FLS Team Role object are minimized, and an admin endpoint now allows forcing a re-fetch of it.


[LPD-90495]: https://liferay.atlassian.net/browse/LPD-90495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-99486]: https://liferay.atlassian.net/browse/LPD-99486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ