### PR TITLE
LPD-99336 Link generated entitlements to the order's project

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/specs/data-model.md
+++ b/workspaces/liferay-one-workspace/.agents/specs/data-model.md
@@ -299,6 +299,7 @@ Materialized grant records derived from CommerceOrderItems via EntitlementDefini
 | FK `entitlementDefinitionId` | long | |
 | FK `orderItemId` | long | Parent CommerceOrderItem that grants this entitlement |
 | FK `contractId` | long | Denormalized for fast lookup |
+| FK `projectId` | long | Project scoping the grant (`projectToEntitlement`), from the order's `salesforceProjectId` custom field; empty for project-less orders |
 | FK `usageDefinitionId` | long | For metered entitlements |
 | `name` | string | e.g. `database-size` · `vcpu` · `maxServers` · `licenseGeneration` |
 | `grantType` | string | `fixed` · `rollover` · `prepaid` · `metered` |

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/02-system-object-field.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/02-system-object-field.batch-engine-data.json
@@ -57,7 +57,7 @@
 			"objectActions": [
 				{
 					"active": true,
-					"description": "Triggers Spring Boot CX to generate Entitlements per the matching EntitlementDefinitions on the order item's product.",
+					"description": "Triggers Spring Boot CX to generate Entitlements per the matching EntitlementDefinitions on the order item's product, linked to the order's account and project.",
 					"externalReferenceCode": "OA_COMMERCE_ORDER_ITEM_ENTITLEMENT_GENERATION",
 					"name": "EntitlementGeneration",
 					"objectActionExecutorKey": "function#liferay-one-etc-spring-boot-object-action-commerce-order-item-entitlement-generation",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/04-object-relationship.batch-engine-data.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-batch/batch/04-object-relationship.batch-engine-data.json
@@ -409,6 +409,17 @@
 		},
 		{
 			"deletionType": "disassociate",
+			"externalReferenceCode": "R_PROJECT_TO_ENTITLEMENT",
+			"label": {
+				"en_US": "Project to Entitlement"
+			},
+			"name": "projectToEntitlement",
+			"objectDefinitionExternalReferenceCode1": "C_PROJECT",
+			"objectDefinitionExternalReferenceCode2": "C_ENTITLEMENT",
+			"type": "oneToMany"
+		},
+		{
+			"deletionType": "disassociate",
 			"externalReferenceCode": "R_PROJECT_TO_LICENSE_KEY",
 			"label": {
 				"en_US": "Project to License Key"

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useProjectCommerce.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useProjectCommerce.ts
@@ -7,12 +7,10 @@ import {format} from 'date-fns';
 import {useMemo} from 'react';
 import useSWR from 'swr';
 import {useFetch} from '~/hooks/useFetch';
-import {usePlacedOrders} from '~/hooks/usePlacedOrder';
 import {getProductContactRoleExternalReferenceCodes} from '~/pages/MyAccount/ProjectMembers/projectRoles';
 import {isUnassignedProject} from '~/pages/MyAccount/Projects/projects';
 import HeadlessCommerceDeliveryCatalog from '~/services/headless/HeadlessCommerceDeliveryCatalog';
 import {Liferay} from '~/services/liferay/liferay';
-import {OrderCustomFields} from '~/utils/orderUtils';
 
 import type {APIResponse} from '~/types/api';
 import type {
@@ -56,6 +54,7 @@ type EntitlementNode = {
 	};
 	externalReferenceCode: string;
 	name: string;
+	r_projectToEntitlement_c_projectERC?: string;
 	startDate?: string;
 };
 
@@ -74,13 +73,14 @@ type ContractNode = {
 type ProjectNode = {
 	name?: string;
 	projectToContract?: ContractNode[];
+	projectToEntitlement?: EntitlementNode[];
 };
 
 type ProductEntitlement = {
 	endDate?: string;
 	orderExternalReferenceCode?: string;
 	productExternalReferenceCode?: string;
-	projectName?: string;
+	projectExternalReferenceCode?: string;
 	startDate?: string;
 };
 
@@ -127,9 +127,9 @@ function getEntitlementStatus(endDate?: string): string {
 }
 
 function toProductEntitlements(
-	contractNode?: ContractNode
+	entitlementNodes?: EntitlementNode[]
 ): ProductEntitlement[] {
-	return (contractNode?.contractToEntitlement ?? [])
+	return (entitlementNodes ?? [])
 		.map((entitlement) => ({
 			endDate: entitlement.endDate,
 			orderExternalReferenceCode:
@@ -138,6 +138,8 @@ function toProductEntitlements(
 			productExternalReferenceCode:
 				entitlement.entitlementDefinitionToEntitlement
 					?.commerceProductToEntitlementDefinitionERC,
+			projectExternalReferenceCode:
+				entitlement.r_projectToEntitlement_c_projectERC,
 			startDate: entitlement.startDate,
 		}))
 		.filter((entitlement) => entitlement.productExternalReferenceCode);
@@ -199,7 +201,7 @@ export function useProjectCommerce(
 		{
 			params: {
 				nestedFields:
-					'projectToContract,contractToEntitlement,entitlementDefinitionToEntitlement',
+					'projectToContract,projectToEntitlement,contractToEntitlement,entitlementDefinitionToEntitlement',
 				nestedFieldsDepth: 3,
 			},
 		}
@@ -247,8 +249,8 @@ export function useProjectCommerce(
 	const contract = contractNode ? toProjectContract(contractNode) : undefined;
 
 	const entitlements = usingAccountFallback
-		? []
-		: toProductEntitlements(contractNode);
+		? toProductEntitlements(data?.projectToEntitlement)
+		: toProductEntitlements(contractNode?.contractToEntitlement);
 
 	return {
 		contract,
@@ -259,34 +261,6 @@ export function useProjectCommerce(
 		projectName: data?.name,
 		usingAccountFallback,
 	};
-}
-
-function useOrderProjectNames(enabled = true) {
-	const accountId = Liferay.CommerceContext?.account?.accountId;
-
-	const {data, isLoading: loading} = usePlacedOrders({
-		accountId: accountId ?? -1,
-		page: 1,
-		pageSize: 100,
-		shouldFetch: enabled && Boolean(accountId),
-	});
-
-	const orderProjectNames = useMemo(() => {
-		const map = new Map<string, string>();
-
-		(data?.items ?? []).forEach((order) => {
-			if (order.externalReferenceCode) {
-				map.set(
-					order.externalReferenceCode,
-					order.customFields?.[OrderCustomFields.PROJECT_NAME] ?? ''
-				);
-			}
-		});
-
-		return map;
-	}, [data]);
-
-	return {loading, orderProjectNames};
 }
 
 function useAccountOrderEntitlements(enabled = true) {
@@ -309,25 +283,17 @@ function useAccountOrderEntitlements(enabled = true) {
 		}
 	);
 
-	const {loading: orderProjectNamesLoading, orderProjectNames} =
-		useOrderProjectNames(enabled);
-
 	const entitlements = useMemo(
 		() =>
 			(data?.items ?? [])
 				.filter((contract) => !contract.r_projectToContract_c_projectId)
-				.flatMap((contract) => toProductEntitlements(contract))
-				.map((entitlement) => ({
-					...entitlement,
-					projectName:
-						orderProjectNames.get(
-							entitlement.orderExternalReferenceCode ?? ''
-						) ?? '',
-				})),
-		[data, orderProjectNames]
+				.flatMap((contract) =>
+					toProductEntitlements(contract.contractToEntitlement)
+				),
+		[data]
 	);
 
-	return {entitlements, error, loading: loading || orderProjectNamesLoading};
+	return {entitlements, error, loading};
 }
 
 export function useUnassignedCommerce(enabled = true) {
@@ -335,7 +301,7 @@ export function useUnassignedCommerce(enabled = true) {
 
 	return {
 		entitlements: entitlements.filter(
-			(entitlement) => !entitlement.projectName
+			(entitlement) => !entitlement.projectExternalReferenceCode
 		),
 		error,
 		loading,
@@ -371,15 +337,20 @@ export function useAccountProducts() {
 		const accountProducts = new Map<string, DeliveryProduct>();
 
 		(contractsData?.items ?? []).forEach((contract) => {
-			toProductEntitlements(contract).forEach((entitlement) => {
-				const product = productsByExternalReferenceCode.get(
-					entitlement.productExternalReferenceCode as string
-				);
+			toProductEntitlements(contract.contractToEntitlement).forEach(
+				(entitlement) => {
+					const product = productsByExternalReferenceCode.get(
+						entitlement.productExternalReferenceCode as string
+					);
 
-				if (product) {
-					accountProducts.set(product.externalReferenceCode, product);
+					if (product) {
+						accountProducts.set(
+							product.externalReferenceCode,
+							product
+						);
+					}
 				}
-			});
+			);
 		});
 
 		return [...accountProducts.values()];
@@ -430,21 +401,23 @@ export function useAccountProjectContactRoles() {
 				externalReferenceCodesByProjectId.get(projectId) ??
 				new Set<string>();
 
-			toProductEntitlements(contract).forEach((entitlement) => {
-				const product = productsByExternalReferenceCode.get(
-					entitlement.productExternalReferenceCode as string
-				);
+			toProductEntitlements(contract.contractToEntitlement).forEach(
+				(entitlement) => {
+					const product = productsByExternalReferenceCode.get(
+						entitlement.productExternalReferenceCode as string
+					);
 
-				if (!product) {
-					return;
+					if (!product) {
+						return;
+					}
+
+					getProductContactRoleExternalReferenceCodes(
+						product.productSpecifications ?? []
+					).forEach((externalReferenceCode) =>
+						externalReferenceCodes.add(externalReferenceCode)
+					);
 				}
-
-				getProductContactRoleExternalReferenceCodes(
-					product.productSpecifications ?? []
-				).forEach((externalReferenceCode) =>
-					externalReferenceCodes.add(externalReferenceCode)
-				);
-			});
+			);
 
 			externalReferenceCodesByProjectId.set(
 				projectId,
@@ -480,8 +453,6 @@ export function useProjectProducts(
 		entitlements: projectEntitlements,
 		error: projectError,
 		loading: projectLoading,
-		projectName,
-		usingAccountFallback,
 	} = useProjectCommerce(
 		unassigned ? '' : projectExternalReferenceCode,
 		contractExternalReferenceCode
@@ -491,29 +462,17 @@ export function useProjectProducts(
 		entitlements: accountOrderEntitlements,
 		error: accountError,
 		loading: accountLoading,
-	} = useAccountOrderEntitlements(unassigned || usingAccountFallback);
+	} = useAccountOrderEntitlements(unassigned);
 
 	const entitlements = useMemo(() => {
 		if (unassigned) {
 			return accountOrderEntitlements.filter(
-				(entitlement) => !entitlement.projectName
-			);
-		}
-
-		if (usingAccountFallback) {
-			return accountOrderEntitlements.filter(
-				(entitlement) => entitlement.projectName === projectName
+				(entitlement) => !entitlement.projectExternalReferenceCode
 			);
 		}
 
 		return projectEntitlements;
-	}, [
-		accountOrderEntitlements,
-		projectEntitlements,
-		projectName,
-		unassigned,
-		usingAccountFallback,
-	]);
+	}, [accountOrderEntitlements, projectEntitlements, unassigned]);
 
 	const commerceError = projectError ?? accountError;
 	const commerceLoading = projectLoading || accountLoading;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/types.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/services/spring-boot/types.ts
@@ -124,11 +124,6 @@ export type Properties2 = {
 	version: string;
 };
 
-export type Entitlement = {
-	entitlementDefinitionKey: string;
-	name: string;
-};
-
 export type PostalAddress = {
 	addressCountry: string;
 	addressLocality: string;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -324,9 +324,9 @@ public class AccountSynchronizer {
 	}
 
 	private Map<String, Object> _getProjectAttributeValues(
-			List<ProjectMembership> projectMemberships,
 			Map<String, Object> accountAttributeValues,
-			Map<String, Role> accountRolesByExternalReferenceCode)
+			Map<String, Role> accountRolesByExternalReferenceCode,
+			Project project, List<ProjectMembership> projectMemberships)
 		throws Exception {
 
 		List<UserAccount> customerUserAccounts = new ArrayList<>();
@@ -354,6 +354,14 @@ public class AccountSynchronizer {
 			_jiraAssetService.fetchReferenceObjectIds(
 				_contactConverter, customerUserAccounts,
 				UserAccount::getExternalReferenceCode)
+		).put(
+			AccountConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_entitlementConverter,
+				_entitlementService.getActiveEntitlementDefinitions(
+					project.getExternalReferenceCode()),
+				EntitlementDefinition::getDisplayName,
+				_entitlementConverter::toAssetObject)
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
 			_jiraAssetService.fetchReferenceObjectIds(
@@ -448,8 +456,8 @@ public class AccountSynchronizer {
 		_syncAccountAsset(
 			account,
 			_getProjectAttributeValues(
-				projectMemberships, accountAttributeValues,
-				accountRolesByExternalReferenceCode),
+				accountAttributeValues, accountRolesByExternalReferenceCode,
+				project, projectMemberships),
 			project.getExternalReferenceCode(), project.getName());
 
 		_syncProjectMemberships(project, projectMemberships);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Entitlement.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/Entitlement.java
@@ -27,6 +27,8 @@ public class Entitlement {
 		_grantType = jsonObject.optString("grantType");
 		_maxQuantity = jsonObject.optDoubleObject("maxQuantity", null);
 		_name = jsonObject.optString("name");
+		_projectExternalReferenceCode = jsonObject.optString(
+			"r_projectToEntitlement_c_projectERC");
 		_quantity = jsonObject.optDoubleObject("quantity", null);
 
 		String endDate = jsonObject.optString("endDate");
@@ -80,6 +82,10 @@ public class Entitlement {
 		return _name;
 	}
 
+	public String getProjectExternalReferenceCode() {
+		return _projectExternalReferenceCode;
+	}
+
 	public Double getQuantity() {
 		return _quantity;
 	}
@@ -104,6 +110,7 @@ public class Entitlement {
 	private final String _grantType;
 	private final Double _maxQuantity;
 	private final String _name;
+	private final String _projectExternalReferenceCode;
 	private final Double _quantity;
 	private final Instant _startDateInstant;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ContractService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ContractService.java
@@ -251,12 +251,20 @@ public class ContractService extends OneBaseService {
 						"eq '", orderItem.getId(), "'"));
 
 			for (Entitlement entitlement : entitlements) {
-				if (entitlement.getContractId() > 0) {
-					continue;
+				if (entitlement.getContractId() <= 0) {
+					_entitlementService.updateEntitlementContract(
+						entitlement.getEntitlementId(),
+						existingContract.getId());
 				}
 
-				_entitlementService.updateEntitlementContract(
-					entitlement.getEntitlementId(), existingContract.getId());
+				if (Validator.isNotNull(projectExternalReferenceCode) &&
+					Validator.isNull(
+						entitlement.getProjectExternalReferenceCode())) {
+
+					_entitlementService.updateEntitlementProject(
+						entitlement.getEntitlementId(),
+						projectExternalReferenceCode);
+				}
 			}
 		}
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -15,6 +15,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -44,7 +45,9 @@ public class EntitlementService extends OneBaseService {
 	public Entitlement addEntitlement(
 			long accountEntryId, long commerceOrderItemId, long contractId,
 			long entitlementDefinitionId, String endDate, String grantType,
-			Double maxQuantity, String name, Double quantity, String startDate)
+			Double maxQuantity, String name,
+			String projectExternalReferenceCode, Double quantity,
+			String startDate)
 		throws Exception {
 
 		Entitlement entitlement = fetchEntitlement(
@@ -87,6 +90,12 @@ public class EntitlementService extends OneBaseService {
 		if (contractId > 0) {
 			entitlementJSONObject.put(
 				"r_contractToEntitlement_c_contractId", contractId);
+		}
+
+		if (Validator.isNotNull(projectExternalReferenceCode)) {
+			entitlementJSONObject.put(
+				"r_projectToEntitlement_c_projectERC",
+				projectExternalReferenceCode);
 		}
 
 		String response = post(
@@ -164,6 +173,8 @@ public class EntitlementService extends OneBaseService {
 
 		long accountEntryId = _getAccountEntryId(order);
 		long contractId = _getContractId(order);
+		String projectExternalReferenceCode = _getProjectExternalReferenceCode(
+			order);
 
 		Instant endDateInstant = OrderItemUtil.getEndDateInstant(orderItem);
 		Instant startDateInstant = OrderItemUtil.getStartDateInstant(orderItem);
@@ -184,12 +195,21 @@ public class EntitlementService extends OneBaseService {
 				entitlementDefinitions) {
 
 			try {
-				addEntitlement(
+				Entitlement entitlement = addEntitlement(
 					accountEntryId, commerceOrderItemId, contractId,
 					entitlementDefinition.getEntitlementDefinitionId(), endDate,
 					entitlementDefinition.getGrantType(), null,
 					entitlementDefinition.getName(),
+					projectExternalReferenceCode,
 					entitlementDefinition.getDefaultQuantity(), startDate);
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Created entitlement ",
+							entitlement.getEntitlementId(), " for order item ",
+							commerceOrderItemId));
+				}
 			}
 			catch (Exception exception) {
 				_log.error(
@@ -206,46 +226,33 @@ public class EntitlementService extends OneBaseService {
 			long accountEntryId)
 		throws Exception {
 
-		List<Entitlement> entitlements = getActiveEntitlements(accountEntryId);
+		return _getActiveEntitlementDefinitions(
+			getActiveEntitlements(accountEntryId));
+	}
 
-		Set<Long> entitlementDefinitionIds = new LinkedHashSet<>();
+	public List<EntitlementDefinition> getActiveEntitlementDefinitions(
+			String projectExternalReferenceCode)
+		throws Exception {
 
-		for (Entitlement entitlement : entitlements) {
-			long entitlementDefinitionId =
-				entitlement.getEntitlementDefinitionId();
-
-			if (entitlementDefinitionId > 0) {
-				entitlementDefinitionIds.add(entitlementDefinitionId);
-			}
-		}
-
-		if (entitlementDefinitionIds.isEmpty()) {
-			return Collections.emptyList();
-		}
-
-		List<String> statements = TransformUtil.transform(
-			entitlementDefinitionIds,
-			entitlementDefinitionId ->
-				"(id eq '" + entitlementDefinitionId + "')");
-
-		return _entitlementDefinitionService.getEntitlementDefinitions(
-			StringUtil.merge(statements, " or "));
+		return _getActiveEntitlementDefinitions(
+			getActiveEntitlements(projectExternalReferenceCode));
 	}
 
 	public List<Entitlement> getActiveEntitlements(long accountEntryId)
 		throws Exception {
 
-		Instant instant = Instant.now(
-		).truncatedTo(
-			ChronoUnit.MILLIS
-		);
+		return _getActiveEntitlements(
+			"r_accountEntryToEntitlement_accountEntryId eq '" + accountEntryId +
+				"'");
+	}
 
-		return getEntitlements(
-			StringBundler.concat(
-				"(endDate eq null or endDate ge ", instant,
-				") and (r_accountEntryToEntitlement_accountEntryId eq '",
-				accountEntryId, "') and (startDate eq null or startDate le ",
-				instant, ")"));
+	public List<Entitlement> getActiveEntitlements(
+			String projectExternalReferenceCode)
+		throws Exception {
+
+		return _getActiveEntitlements(
+			"r_projectToEntitlement_c_projectERC eq '" +
+				projectExternalReferenceCode + "'");
 	}
 
 	public List<Entitlement> getEntitlements(long commerceOrderItemId)
@@ -266,37 +273,19 @@ public class EntitlementService extends OneBaseService {
 	public boolean hasEntitlement(long accountId, String... entitlementNames)
 		throws Exception {
 
-		if (entitlementNames.length == 0) {
-			return false;
-		}
+		return _hasEntitlement(
+			"r_accountEntryToEntitlement_accountEntryId eq '" + accountId + "'",
+			entitlementNames);
+	}
 
-		StringBundler sb = new StringBundler();
+	public boolean hasEntitlement(
+			String projectExternalReferenceCode, String... entitlementNames)
+		throws Exception {
 
-		sb.append("(r_accountEntryToEntitlement_accountEntryId eq '");
-		sb.append(accountId);
-		sb.append("') and (");
-
-		for (int i = 0; i < entitlementNames.length; i++) {
-			if (i > 0) {
-				sb.append(" or ");
-			}
-
-			sb.append("name eq '");
-			sb.append(entitlementNames[i]);
-			sb.append("'");
-		}
-
-		sb.append(")");
-
-		List<Entitlement> entitlements = getEntitlements(sb.toString());
-
-		for (Entitlement entitlement : entitlements) {
-			if (!entitlement.isExpired()) {
-				return true;
-			}
-		}
-
-		return false;
+		return _hasEntitlement(
+			"r_projectToEntitlement_c_projectERC eq '" +
+				projectExternalReferenceCode + "'",
+			entitlementNames);
 	}
 
 	public void trimEntitlements(long commerceOrderItemId, String endDate)
@@ -339,6 +328,19 @@ public class EntitlementService extends OneBaseService {
 			new JSONObject(
 			).put(
 				"r_contractToEntitlement_c_contractId", contractId
+			));
+	}
+
+	public void updateEntitlementProject(
+			long entitlementId, String projectExternalReferenceCode)
+		throws Exception {
+
+		_patchEntitlement(
+			entitlementId,
+			new JSONObject(
+			).put(
+				"r_projectToEntitlement_c_projectERC",
+				projectExternalReferenceCode
 			));
 	}
 
@@ -404,6 +406,49 @@ public class EntitlementService extends OneBaseService {
 		return order.getAccountId();
 	}
 
+	private List<EntitlementDefinition> _getActiveEntitlementDefinitions(
+			List<Entitlement> entitlements)
+		throws Exception {
+
+		Set<Long> entitlementDefinitionIds = new LinkedHashSet<>();
+
+		for (Entitlement entitlement : entitlements) {
+			long entitlementDefinitionId =
+				entitlement.getEntitlementDefinitionId();
+
+			if (entitlementDefinitionId > 0) {
+				entitlementDefinitionIds.add(entitlementDefinitionId);
+			}
+		}
+
+		if (entitlementDefinitionIds.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		List<String> statements = TransformUtil.transform(
+			entitlementDefinitionIds,
+			entitlementDefinitionId ->
+				"(id eq '" + entitlementDefinitionId + "')");
+
+		return _entitlementDefinitionService.getEntitlementDefinitions(
+			StringUtil.merge(statements, " or "));
+	}
+
+	private List<Entitlement> _getActiveEntitlements(String filterString)
+		throws Exception {
+
+		Instant instant = Instant.now(
+		).truncatedTo(
+			ChronoUnit.MILLIS
+		);
+
+		return getEntitlements(
+			StringBundler.concat(
+				"(endDate eq null or endDate ge ", instant, ") and (",
+				filterString, ") and (startDate eq null or startDate le ",
+				instant, ")"));
+	}
+
 	private long _getContractId(Order order) {
 		if (order == null) {
 			return 0;
@@ -429,6 +474,58 @@ public class EntitlementService extends OneBaseService {
 		}
 
 		return endDateInstant;
+	}
+
+	private String _getProjectExternalReferenceCode(Order order) {
+		if (order == null) {
+			return null;
+		}
+
+		Map<String, Object> customFields =
+			(Map<String, Object>)order.getCustomFields();
+
+		if (customFields == null) {
+			return null;
+		}
+
+		return GetterUtil.getString(customFields.get("salesforceProjectId"));
+	}
+
+	private boolean _hasEntitlement(
+			String filterString, String... entitlementNames)
+		throws Exception {
+
+		if (entitlementNames.length == 0) {
+			return false;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("(");
+		sb.append(filterString);
+		sb.append(") and (");
+
+		for (int i = 0; i < entitlementNames.length; i++) {
+			if (i > 0) {
+				sb.append(" or ");
+			}
+
+			sb.append("name eq '");
+			sb.append(entitlementNames[i]);
+			sb.append("'");
+		}
+
+		sb.append(")");
+
+		List<Entitlement> entitlements = getEntitlements(sb.toString());
+
+		for (Entitlement entitlement : entitlements) {
+			if (!entitlement.isExpired()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private void _patchEntitlement(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-site-initializer/site-initializer/expando-columns.json
@@ -706,6 +706,7 @@
 	},
 	{
 		"dataType": 5,
+		"defaultValue": 0,
 		"modelResource": "com.liferay.commerce.model.CommerceOrderItem",
 		"name": "spendLimit",
 		"properties": {

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_AI_HUB.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_AI_HUB.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_AI_HUB",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_AI_HUB",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_AIHUB",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-026",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ANALYTICS_CLOUD.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ANALYTICS_CLOUD.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_ANALYTICS_CLOUD",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_ANALYTICS_CLOUD",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_ANALYTICS_CLOUD",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-013",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_APP_DEMO.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_APP_DEMO.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_APP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_DXP",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_APP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-006",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_BUSINESS_PLAN.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_BUSINESS_PLAN.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_BUSINESS_PLAN_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_BUSINESS_PLAN",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS_BUSINESS_PLAN",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-008",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_CLOUD_NATIVE.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_CLOUD_NATIVE.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_CLOUD_NATIVE",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_CLOUD_NATIVE",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CLOUD_NATIVE",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-007",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_COMMERCE.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_COMMERCE.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_COMMERCE",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_COMMERCE",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_COMMERCE",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-012",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_COMMERCE_CLOUD.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_COMMERCE_CLOUD.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_COMMERCE_CLOUD",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_COMMERCE_CLOUD",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_COMMERCE_CLOUD",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-023",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_CONTENT_MARKETING.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_CONTENT_MARKETING.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_CONTENT_MARKETING",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_CONTENT_MARKETING",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CONTENT_MARKETING",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-027",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DATA_PLATFORM.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DATA_PLATFORM.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_DATA_PLATFORM",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_DATA_PLATFORM",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DATA_PLATFORM",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-028",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DSR.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DSR.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_DSR",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_DSR",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DSR",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-029",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DXP.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_DXP.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_DXP",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-006",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ENTERPRISE_PLAN.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ENTERPRISE_PLAN.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_ENTERPRISE_PLAN_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_ENTERPRISE_PLAN",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS_ENTERPRISE_PLAN",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-010",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ENTERPRISE_SEARCH.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_ENTERPRISE_SEARCH.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_ENTERPRISE_SEARCH",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_ENTERPRISE_SEARCH",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_ENTERPRISE_SEARCH",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-014",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_EWSA_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_EWSA",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PORTAL_EWSA",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-019",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA_2.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA_2.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_EWSA_CLOUD_NATIVE",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_EWSA",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CLOUD_NATIVE",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-019-2",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA_3.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_EWSA_3.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_EWSA_DATA_PLATFORM",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_EWSA",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DATA_PLATFORM",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-019-3",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_LIFERAY_SUPPLIER.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_LIFERAY_SUPPLIER.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_LIFERAY_SUPPLIER_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_LIFERAY_SUPPLIER",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-020",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_MULTI_1.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_MULTI_1.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_MULTI_1_AIHUB",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_MULTI_1",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_AIHUB",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-025",
 			"startDate": "2024-07-01T00:00:00Z"
 		},
 		{
@@ -24,6 +25,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_MULTI_1_CONTENT_MARKETING",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_MULTI_1",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CONTENT_MARKETING",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-025",
 			"startDate": "2022-01-01T00:00:00Z"
 		},
 		{
@@ -37,6 +39,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_MULTI_1_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_MULTI_1",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-025",
 			"startDate": "2024-07-01T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_MULTI_2.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_MULTI_2.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_MULTI_2_DSR",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_MULTI_2",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DSR",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-025",
 			"startDate": "2025-07-01T00:00:00Z"
 		},
 		{
@@ -24,6 +25,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_MULTI_2_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_MULTI_2",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-025",
 			"startDate": "2025-07-01T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_AI_HUB",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_AIHUB",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -24,6 +25,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_ANALYTICS_CLOUD",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_ANALYTICS_CLOUD",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -37,6 +39,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_CLOUD_NATIVE",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CLOUD_NATIVE",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -50,6 +53,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_COMMERCE",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_COMMERCE",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -63,6 +67,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_COMMERCE_CLOUD",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_COMMERCE_CLOUD",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -76,6 +81,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_CONTENT_MARKETING",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_CONTENT_MARKETING",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -89,6 +95,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_DATA_PLATFORM",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DATA_PLATFORM",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -102,6 +109,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_DSR",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DSR",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -115,6 +123,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -128,6 +137,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_ENTERPRISE_SEARCH",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_ENTERPRISE_SEARCH",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -141,6 +151,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_PAAS",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PAAS",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -154,6 +165,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_PAAS_LEGACY",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PAAS_LEGACY",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -167,6 +179,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_PORTAL",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PORTAL",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -180,6 +193,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_PORTAL_EWSA",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PORTAL_EWSA",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -193,6 +207,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_SAAS",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -206,6 +221,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_SAAS_BUSINESS_PLAN",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS_BUSINESS_PLAN",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -219,6 +235,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_SAAS_ENTERPRISE_PLAN",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS_ENTERPRISE_PLAN",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI_2.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI_2.json
@@ -14,6 +14,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_2_AIHUB",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI_2",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_AIHUB",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001-2",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -27,6 +28,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_2_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI_2",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001-2",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI_APPS.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_OMNI_APPS.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_TEST_APP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_TEST_APP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -24,6 +25,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_TEST_CRM_ACCELERATOR",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_TEST_CRM_ACCELERATOR",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -37,6 +39,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_TEST_PARTNER_PORTAL",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_TEST_PARTNER_PORTAL",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -50,6 +53,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_TEST_SLACK_CONNECTOR",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_TEST_SLACK_CONNECTOR",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -63,6 +67,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_OMNI_TEST_THEME_PACK",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_OMNI",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_TEST_THEME_PACK",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-001",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PAAS_EXPERIENCE.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PAAS_EXPERIENCE.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PAAS",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PAAS_EXPERIENCE",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PAAS",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-004",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PAAS_LEGACY.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PAAS_LEGACY.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PAAS_LEGACY",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PAAS_LEGACY",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PAAS_LEGACY",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-005",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PARTNER_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PARTNER",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-016",
 			"startDate": "2026-08-09T00:00:00Z"
 		},
 		{
@@ -24,6 +25,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PARTNER_SOLUTION_RESELLER",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PARTNER",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PARTNERSHIP_SOLUTION_RESELLER",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-016",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER_FLS.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER_FLS.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PARTNER_FLS_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PARTNER_FLS",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-017",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER_OEM.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PARTNER_OEM.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PARTNER_OEM_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PARTNER_OEM",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-018",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PORTAL.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PORTAL.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PORTAL",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PORTAL",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_PORTAL",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-015",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PRO_PLAN.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_PRO_PLAN.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_PRO_PLAN_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_PRO_PLAN",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-009",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SAAS_EXPERIENCE.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SAAS_EXPERIENCE.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_SAAS",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_SAAS_EXPERIENCE",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-002",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SAAS_LEGACY.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SAAS_LEGACY.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_SAAS_LEGACY",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_SAAS_LEGACY",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_SAAS_ENTERPRISE_PLAN",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-003",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SELF_HOSTED.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_SELF_HOSTED.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_SELF_HOSTED_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_SELF_HOSTED",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-011",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_TEST_SUPPLIER.json
+++ b/workspaces/liferay-one-workspace/scripts/seed/data/orders/C_ORDER_TEST_SUPPLIER.json
@@ -11,6 +11,7 @@
 			"r_commerceOrderItemToEntitlement_commerceOrderItemERC": "C_ORDER_ITEM_TEST_SUPPLIER_DXP",
 			"r_contractToEntitlement_c_contractERC": "C_CONTRACT_TEST_SUPPLIER",
 			"r_entitlementDefinitionToEntitlement_c_entitlementDefinitionERC": "C_ENT_DEF_DXP",
+			"r_projectToEntitlement_c_projectERC": "PRJCT-021",
 			"startDate": "2026-08-09T00:00:00Z"
 		}
 	],

--- a/workspaces/liferay-one-workspace/scripts/seed/populate_orders.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/populate_orders.sh
@@ -15,10 +15,13 @@ source ../_common.sh
 #
 # Each file under data/orders/ describes one order: the order with its nested order
 # items, the entitlements granted by those order items, and the license keys
-# those entitlements unlock. This runs as a bootstrap step after Liferay is
-# healthy and the client extensions (including the site initializer) have been
-# deployed, once the accounts, projects, contracts, products, and entitlement
-# definitions the orders reference exist.
+# those entitlements unlock. Entitlements carry the order's account, contract,
+# and project links directly (see the projectToEntitlement object
+# relationship), matching what the EntitlementGeneration object action produces
+# at runtime. This runs as a bootstrap step after Liferay is healthy and the
+# client extensions (including the site initializer) have been deployed, once
+# the accounts, projects, contracts, products, and entitlement definitions the
+# orders reference exist.
 #
 # Orders are placed through a bounded pool of concurrent workers, since each is
 # independent of the others. The entitlements and license keys are then applied

--- a/workspaces/liferay-one-workspace/scripts/seed/teardown_records.sh
+++ b/workspaces/liferay-one-workspace/scripts/seed/teardown_records.sh
@@ -53,9 +53,10 @@ function _delete_commerce_orders {
 function _delete_entitlements {
 
 	# Entitlements (accountEntryToEntitlement is "prevent") must be gone before
-	# their accounts. Deleting an order item only disassociates its
-	# entitlements (commerceOrderItemToEntitlement is "disassociate"), so the
-	# orders above leave the entitlement entries behind for this step.
+	# their accounts. Deleting an order item or a project only disassociates
+	# its entitlements (commerceOrderItemToEntitlement and projectToEntitlement
+	# are "disassociate"), so the orders above leave the entitlement entries
+	# behind for this step.
 
 	_log "Deleting entitlements..."
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99336

## What is being fixed

Entitlements generated from order items were linked only to the order's account and contract, so nothing tied an entitlement to the project it was purchased for. The UI compensated by reaching entitlements through project contracts and matching account entitlements to projects by comparing the order's projectName custom field against the project name, and the Jira asset sync gave every project asset the account's entire entitlement list. Separately, the EntitlementGeneration object action never actually fired for order items: the spendLimit expando column is created with a NaN default (a missing defaultValue read through JSONObject.getDouble), which poisons the object action payload serialization so the portal drops the call before it reaches the extension.

## How it is being fixed

A projectToEntitlement relationship (C_PROJECT to C_ENTITLEMENT) is added to the batch client extension, and entitlement generation reads the order's salesforceProjectId custom field — the same field ContractService uses to link contracts to projects — and stamps the project external reference code on each entitlement it creates, keeping the account link intact. The contract sync backfills the project on entitlements that missed it, and project-scoped query variants on EntitlementService let the Jira asset sync scope each project asset to its own entitlements instead of inheriting the account's. The frontend reads project entitlements through the new relationship directly and keys the one-time purchases detection on the entitlement's project link instead of the projectName string. Seeded entitlements carry the project external reference code so local data matches what generation produces, and the spendLimit expando column gets a finite default so order item object action payloads serialize and the generation action fires automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)