### PR TITLE
LPD-89437 LPD-99653 Create missing contacts and teams on sync

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -354,14 +354,16 @@ public class AccountSynchronizer {
 			accountAttributeValues
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
-			_jiraAssetService.fetchReferenceObjectIds(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_contactConverter, customerUserAccounts,
-				UserAccount::getExternalReferenceCode)
+				UserAccount::getExternalReferenceCode,
+				_contactConverter::toAssetObject)
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
-			_jiraAssetService.fetchReferenceObjectIds(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_contactConverter, workerUserAccounts,
-				UserAccount::getExternalReferenceCode)
+				UserAccount::getExternalReferenceCode,
+				_contactConverter::toAssetObject)
 		).build();
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -196,18 +196,20 @@ public class AccountSynchronizer {
 
 		return LinkedHashMapBuilder.<String, Object>put(
 			AccountConstants.ATTRIBUTE_NAME_ASSIGNED_TEAMS,
-			_jiraAssetService.fetchReferenceObjectIds(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_teamConverter, accountOrganizations,
-				Organization::getExternalReferenceCode)
+				Organization::getExternalReferenceCode,
+				_teamConverter::toAssetObject)
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_BUSINESS_EVENTS,
 			_toBusinessEventsFieldValue(account)
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
-			_jiraAssetService.fetchReferenceObjectIds(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_contactConverter,
 				accountUserAccountBucket.getCustomerUserAccounts(),
-				UserAccount::getExternalReferenceCode)
+				UserAccount::getExternalReferenceCode,
+				_contactConverter::toAssetObject)
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
@@ -247,10 +249,11 @@ public class AccountSynchronizer {
 			GetterUtil.getString(accountSupportInfo.getSupportRegion())
 		).put(
 			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
-			_jiraAssetService.fetchReferenceObjectIds(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_contactConverter,
 				accountUserAccountBucket.getWorkerUserAccounts(),
-				UserAccount::getExternalReferenceCode)
+				UserAccount::getExternalReferenceCode,
+				_contactConverter::toAssetObject)
 		).build();
 	}
 


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Task: [LPD-99653](https://liferay.atlassian.net/browse/LPD-99653)

## What is being fixed

When an account syncs to JSM Assets, its Contact and Team references were resolved with a fetch-only lookup. If a referenced user account or organization did not yet exist as an asset object, the reference was silently dropped, leaving the synced account asset incomplete.

## How it is being fixed

The account sync now resolves customer contact, worker contact, and team references with getOrCreateReferenceObjectIds instead of fetchReferenceObjectIds, passing the converter's toAssetObject factory so a missing Contact or Team asset object is created on the fly during the sync. The same change is applied to the project sync payload, which resolves contact references the same way.


[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-99653]: https://liferay.atlassian.net/browse/LPD-99653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ