### PR TITLE
LPD-100140 Sync account and organization membership changes to JSM

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -13,7 +13,7 @@ import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
-import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
+import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.permission.AdminPermission;
@@ -79,7 +79,7 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_unassignContactRoles(account, userAccount);
 
-		_syncContacts(account, userId);
+		_syncMembership(account, userId);
 
 		_provisioningAssignmentService.unassignAccountMembership(
 			account.getId(), userId);
@@ -109,7 +109,7 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_unassignContactRole(account, accountRoleId, userId);
 
-		_syncContacts(account, userId);
+		_syncMembership(account, userId);
 
 		if (accountRoleName != null) {
 			_provisioningAssignmentService.unassignAccountRole(
@@ -159,7 +159,7 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_accountService.addAccountUserAccount(account.getId(), jwt, userId);
 
-		_syncContacts(account, userId);
+		_syncMembership(account, userId);
 
 		_provisioningAssignmentService.assignCustomerGroup(userId);
 
@@ -185,7 +185,7 @@ public class AccountsRestController extends OneBaseRestController {
 		_accountService.addAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
 
-		_syncContacts(account, userId);
+		_syncMembership(account, userId);
 
 		String accountRoleName = _accountService.getAccountRoleName(
 			account.getId(), accountRoleId);
@@ -280,7 +280,7 @@ public class AccountsRestController extends OneBaseRestController {
 				entry.getKey(), externalReferenceCode, jwt, userId);
 		}
 
-		_syncContacts(account, userId);
+		_syncMembership(account, userId);
 
 		if (accountRoleNames.isEmpty()) {
 			_provisioningAssignmentService.assignCustomerGroup(userId);
@@ -356,24 +356,14 @@ public class AccountsRestController extends OneBaseRestController {
 		return accountRoleNames;
 	}
 
-	private void _syncContacts(Account account, long userId) {
+	private void _syncMembership(Account account, long userId) {
 		try {
-			_userAccountSynchronizer.syncUserAccount(
-				_userAccountService.getUserAccount(userId));
+			_accountUserAccountSynchronizer.syncAccountUserAccountMembership(
+				account, _userAccountService.getUserAccount(userId));
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to sync user account " + userId + " to JSM", exception);
-		}
-
-		try {
-			_accountSynchronizer.syncAccountContacts(account);
-		}
-		catch (Exception exception) {
-			_log.error(
-				"Unable to sync contacts for account " +
-					account.getExternalReferenceCode(),
-				exception);
+				"Unable to sync membership for user " + userId, exception);
 		}
 	}
 
@@ -467,6 +457,9 @@ public class AccountsRestController extends OneBaseRestController {
 		_accountUserAccountRoleSynchronizer;
 
 	@Autowired
+	private AccountUserAccountSynchronizer _accountUserAccountSynchronizer;
+
+	@Autowired
 	private AdminPermission _adminPermission;
 
 	@Autowired
@@ -486,8 +479,5 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private UserAccountService _userAccountService;
-
-	@Autowired
-	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -6,11 +6,14 @@
 package com.liferay.one;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.permission.AdminPermission;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -68,8 +72,14 @@ public class AccountsRestController extends OneBaseRestController {
 		Account account = _accountService.getAccount(
 			externalReferenceCode, jwt);
 
+		UserAccount userAccount = _userAccountService.getUserAccount(userId);
+
 		_accountService.removeAccountUserAccount(
 			externalReferenceCode, jwt, userId);
+
+		_unassignContactRoles(account, userAccount);
+
+		_syncContacts(account, userId);
 
 		_provisioningAssignmentService.unassignAccountMembership(
 			account.getId(), userId);
@@ -97,12 +107,14 @@ public class AccountsRestController extends OneBaseRestController {
 		_accountService.removeAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
 
+		_unassignContactRole(account, accountRoleId, userId);
+
+		_syncContacts(account, userId);
+
 		if (accountRoleName != null) {
 			_provisioningAssignmentService.unassignAccountRole(
 				account, userId, accountRoleName);
 		}
-
-		_unassignContactRole(account, accountRoleId, userId);
 	}
 
 	@GetMapping("/{externalReferenceCode}/jira/object-key")
@@ -147,6 +159,8 @@ public class AccountsRestController extends OneBaseRestController {
 
 		_accountService.addAccountUserAccount(account.getId(), jwt, userId);
 
+		_syncContacts(account, userId);
+
 		_provisioningAssignmentService.assignCustomerGroup(userId);
 
 		if (!hasAccount) {
@@ -171,6 +185,8 @@ public class AccountsRestController extends OneBaseRestController {
 		_accountService.addAccountUserAccountRole(
 			accountRoleId, externalReferenceCode, jwt, userId);
 
+		_syncContacts(account, userId);
+
 		String accountRoleName = _accountService.getAccountRoleName(
 			account.getId(), accountRoleId);
 
@@ -178,8 +194,6 @@ public class AccountsRestController extends OneBaseRestController {
 			_provisioningAssignmentService.assignAccountRole(
 				account, userId, accountRoleName);
 		}
-
-		_assignContactRole(account, accountRoleId, userId);
 	}
 
 	@PostMapping(
@@ -261,52 +275,24 @@ public class AccountsRestController extends OneBaseRestController {
 
 		long userId = userAccount.getId();
 
+		for (Map.Entry<Long, String> entry : accountRoleNames.entrySet()) {
+			_accountService.addAccountUserAccountRole(
+				entry.getKey(), externalReferenceCode, jwt, userId);
+		}
+
+		_syncContacts(account, userId);
+
 		if (accountRoleNames.isEmpty()) {
 			_provisioningAssignmentService.assignCustomerGroup(userId);
 		}
 
 		for (Map.Entry<Long, String> entry : accountRoleNames.entrySet()) {
-			long accountRoleId = entry.getKey();
-
-			_accountService.addAccountUserAccountRole(
-				accountRoleId, externalReferenceCode, jwt, userId);
-
 			_provisioningAssignmentService.assignAccountRole(
 				account, userId, entry.getValue());
-
-			_assignContactRole(account, accountRoleId, userId);
 		}
 
 		if (!hasAccount) {
 			_provisioningEmailService.sendAssignedWelcomeEmail(account, userId);
-		}
-	}
-
-	private void _assignContactRole(
-		Account account, long accountRoleId, long userId) {
-
-		try {
-			String accountRoleExternalReferenceCode =
-				_accountService.getAccountRoleExternalReferenceCode(
-					account.getId(), accountRoleId);
-
-			if (accountRoleExternalReferenceCode == null) {
-				return;
-			}
-
-			UserAccount userAccount = _userAccountService.getUserAccount(
-				userId);
-
-			_accountUserAccountRoleSynchronizer.syncAssignRole(
-				accountRoleExternalReferenceCode,
-				userAccount.getExternalReferenceCode(),
-				account.getExternalReferenceCode());
-		}
-		catch (Exception exception) {
-			_log.error(
-				"Unable to sync account contact role assignment for user " +
-					userId,
-				exception);
 		}
 	}
 
@@ -370,6 +356,27 @@ public class AccountsRestController extends OneBaseRestController {
 		return accountRoleNames;
 	}
 
+	private void _syncContacts(Account account, long userId) {
+		try {
+			_userAccountSynchronizer.syncUserAccount(
+				_userAccountService.getUserAccount(userId));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync user account " + userId + " to JSM", exception);
+		}
+
+		try {
+			_accountSynchronizer.syncAccountContacts(account);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync contacts for account " +
+					account.getExternalReferenceCode(),
+				exception);
+		}
+	}
+
 	private void _unassignContactRole(
 		Account account, long accountRoleId, long userId) {
 
@@ -395,6 +402,48 @@ public class AccountsRestController extends OneBaseRestController {
 				"Unable to sync account contact role unassignment for user " +
 					userId,
 				exception);
+		}
+	}
+
+	private void _unassignContactRoles(
+		Account account, UserAccount userAccount) {
+
+		AccountBrief[] accountBriefs = userAccount.getAccountBriefs();
+
+		if (accountBriefs == null) {
+			return;
+		}
+
+		for (AccountBrief accountBrief : accountBriefs) {
+			if (!Objects.equals(
+					account.getExternalReferenceCode(),
+					accountBrief.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			RoleBrief[] roleBriefs = accountBrief.getRoleBriefs();
+
+			if (roleBriefs == null) {
+				return;
+			}
+
+			for (RoleBrief roleBrief : roleBriefs) {
+				try {
+					_accountUserAccountRoleSynchronizer.syncUnassignRole(
+						roleBrief.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode(),
+						account.getExternalReferenceCode());
+				}
+				catch (Exception exception) {
+					_log.error(
+						"Unable to sync account contact role unassignment " +
+							"for role " + roleBrief.getExternalReferenceCode(),
+						exception);
+				}
+			}
+
+			return;
 		}
 	}
 
@@ -437,5 +486,8 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private UserAccountService _userAccountService;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -23,6 +23,7 @@ import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.FindUtil;
 import com.liferay.one.util.UserAccountUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -398,42 +399,35 @@ public class AccountsRestController extends OneBaseRestController {
 	private void _unassignContactRoles(
 		Account account, UserAccount userAccount) {
 
-		AccountBrief[] accountBriefs = userAccount.getAccountBriefs();
+		AccountBrief accountBrief = FindUtil.findFirst(
+			userAccount.getAccountBriefs(),
+			accountBrief1 -> Objects.equals(
+				account.getExternalReferenceCode(),
+				accountBrief1.getExternalReferenceCode()));
 
-		if (accountBriefs == null) {
+		if (accountBrief == null) {
 			return;
 		}
 
-		for (AccountBrief accountBrief : accountBriefs) {
-			if (!Objects.equals(
-					account.getExternalReferenceCode(),
-					accountBrief.getExternalReferenceCode())) {
+		RoleBrief[] roleBriefs = accountBrief.getRoleBriefs();
 
-				continue;
-			}
-
-			RoleBrief[] roleBriefs = accountBrief.getRoleBriefs();
-
-			if (roleBriefs == null) {
-				return;
-			}
-
-			for (RoleBrief roleBrief : roleBriefs) {
-				try {
-					_accountUserAccountRoleSynchronizer.syncUnassignRole(
-						roleBrief.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode(),
-						account.getExternalReferenceCode());
-				}
-				catch (Exception exception) {
-					_log.error(
-						"Unable to sync account contact role unassignment " +
-							"for role " + roleBrief.getExternalReferenceCode(),
-						exception);
-				}
-			}
-
+		if (roleBriefs == null) {
 			return;
+		}
+
+		for (RoleBrief roleBrief : roleBriefs) {
+			try {
+				_accountUserAccountRoleSynchronizer.syncUnassignRole(
+					roleBrief.getExternalReferenceCode(),
+					userAccount.getExternalReferenceCode(),
+					account.getExternalReferenceCode());
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to sync account contact role unassignment for " +
+						"role " + roleBrief.getExternalReferenceCode(),
+					exception);
+			}
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
@@ -13,6 +13,7 @@ import com.liferay.one.constants.PropertyConstants;
 import com.liferay.one.jira.synchronizer.AccountOrganizationSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationUserAccountRoleSynchronizer;
+import com.liferay.one.jira.synchronizer.OrganizationUserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AdminPermission;
@@ -79,6 +80,8 @@ public class OrganizationsRestController extends OneBaseRestController {
 			organizationId, organizationRoleId, userId);
 
 		_unassignContactRole(organizationId, organizationRoleId, userId);
+
+		_syncMembership(organizationId, userId);
 	}
 
 	@PostMapping("/{organizationId}/accounts/{accountId}")
@@ -183,6 +186,8 @@ public class OrganizationsRestController extends OneBaseRestController {
 			organizationId, organizationRoleId, userId);
 
 		_assignContactRole(organizationId, organizationRoleId, userId);
+
+		_syncMembership(organizationId, userId);
 	}
 
 	private void _assignAccount(long accountId, long organizationId) {
@@ -228,6 +233,19 @@ public class OrganizationsRestController extends OneBaseRestController {
 				"Unable to sync organization contact role assignment for " +
 					"user " + userId,
 				exception);
+		}
+	}
+
+	private void _syncMembership(long organizationId, long userId) {
+		try {
+			_organizationUserAccountSynchronizer.
+				syncOrganizationUserAccountMembership(
+					_organizationService.getOrganization(organizationId),
+					_userAccountService.getUserAccount(userId));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync membership for user " + userId, exception);
 		}
 	}
 
@@ -301,6 +319,10 @@ public class OrganizationsRestController extends OneBaseRestController {
 	@Autowired
 	private OrganizationUserAccountRoleSynchronizer
 		_organizationUserAccountRoleSynchronizer;
+
+	@Autowired
+	private OrganizationUserAccountSynchronizer
+		_organizationUserAccountSynchronizer;
 
 	@Autowired
 	private PropertyService _propertyService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
@@ -7,13 +7,16 @@ package com.liferay.one;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.Role;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.PropertyConstants;
 import com.liferay.one.jira.synchronizer.AccountOrganizationSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationUserAccountSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AdminPermission;
@@ -25,7 +28,13 @@ import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
@@ -127,7 +136,8 @@ public class OrganizationsRestController extends OneBaseRestController {
 			}
 		}
 
-		Set<String> organizationEmailAddresses = new HashSet<>();
+		Map<String, UserAccount> organizationUserAccounts =
+			new LinkedHashMap<>();
 
 		for (UserAccount userAccount :
 				_userAccountService.getOrganizationUserAccounts(
@@ -136,25 +146,70 @@ public class OrganizationsRestController extends OneBaseRestController {
 			String emailAddress = userAccount.getEmailAddress();
 
 			if (Validator.isNotNull(emailAddress)) {
-				organizationEmailAddresses.add(
-					StringUtil.toLowerCase(emailAddress));
+				organizationUserAccounts.put(
+					StringUtil.toLowerCase(emailAddress), userAccount);
 			}
 		}
+
+		Set<String> changedEmailAddresses = new LinkedHashSet<>();
 
 		for (String emailAddress : oktaEmailAddresses) {
-			if (!organizationEmailAddresses.contains(emailAddress)) {
+			if (!organizationUserAccounts.containsKey(emailAddress)) {
 				_organizationService.addOrganizationUserAccountByEmailAddress(
 					emailAddress, organizationId);
+
+				changedEmailAddresses.add(emailAddress);
 			}
 		}
 
-		for (String emailAddress : organizationEmailAddresses) {
-			if (!oktaEmailAddresses.contains(emailAddress)) {
-				_organizationService.
-					removeOrganizationUserAccountByEmailAddress(
-						emailAddress, organizationId);
+		List<UserAccount> removedUserAccounts = new ArrayList<>();
+
+		for (Map.Entry<String, UserAccount> entry :
+				organizationUserAccounts.entrySet()) {
+
+			if (oktaEmailAddresses.contains(entry.getKey())) {
+				continue;
+			}
+
+			_organizationService.removeOrganizationUserAccountByEmailAddress(
+				entry.getKey(), organizationId);
+
+			changedEmailAddresses.add(entry.getKey());
+
+			removedUserAccounts.add(entry.getValue());
+		}
+
+		if (changedEmailAddresses.isEmpty()) {
+			return;
+		}
+
+		Organization organization = _organizationService.getOrganization(
+			organizationId);
+
+		for (UserAccount userAccount : removedUserAccounts) {
+			_unassignContactRoles(organization, userAccount);
+		}
+
+		for (String emailAddress : changedEmailAddresses) {
+			try {
+				UserAccount userAccount =
+					_userAccountService.fetchUserAccountByEmailAddress(
+						emailAddress);
+
+				if (userAccount != null) {
+					_userAccountSynchronizer.syncUserAccountOrganizations(
+						userAccount);
+					_userAccountSynchronizer.syncUserAccountRoles(userAccount);
+				}
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to sync user account " + emailAddress + " to JSM",
+					exception);
 			}
 		}
+
+		_syncOrganizationUserAccounts(organization);
 	}
 
 	@PostMapping("/{organizationId}/sync-to-jsm")
@@ -249,6 +304,19 @@ public class OrganizationsRestController extends OneBaseRestController {
 		}
 	}
 
+	private void _syncOrganizationUserAccounts(Organization organization) {
+		try {
+			_organizationSynchronizer.syncOrganizationUserAccounts(
+				organization);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync user accounts for organization " +
+					organization.getExternalReferenceCode(),
+				exception);
+		}
+	}
+
 	private void _unassignAccount(long accountId, long organizationId) {
 		try {
 			Account account = _accountService.fetchAccount(accountId);
@@ -295,6 +363,50 @@ public class OrganizationsRestController extends OneBaseRestController {
 		}
 	}
 
+	private void _unassignContactRoles(
+		Organization organization, UserAccount userAccount) {
+
+		OrganizationBrief[] organizationBriefs =
+			userAccount.getOrganizationBriefs();
+
+		if (organizationBriefs == null) {
+			return;
+		}
+
+		for (OrganizationBrief organizationBrief : organizationBriefs) {
+			if (!Objects.equals(
+					organization.getExternalReferenceCode(),
+					organizationBrief.getExternalReferenceCode())) {
+
+				continue;
+			}
+
+			RoleBrief[] roleBriefs = organizationBrief.getRoleBriefs();
+
+			if (roleBriefs == null) {
+				return;
+			}
+
+			for (RoleBrief roleBrief : roleBriefs) {
+				try {
+					_organizationUserAccountRoleSynchronizer.syncUnassignRole(
+						roleBrief.getExternalReferenceCode(),
+						userAccount.getExternalReferenceCode(),
+						organization.getExternalReferenceCode());
+				}
+				catch (Exception exception) {
+					_log.error(
+						"Unable to sync organization contact role " +
+							"unassignment for role " +
+								roleBrief.getExternalReferenceCode(),
+						exception);
+				}
+			}
+
+			return;
+		}
+	}
+
 	private static final Log _log = LogFactory.getLog(
 		OrganizationsRestController.class);
 
@@ -332,5 +444,8 @@ public class OrganizationsRestController extends OneBaseRestController {
 
 	@Autowired
 	private UserAccountService _userAccountService;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OrganizationsRestController.java
@@ -25,6 +25,7 @@ import com.liferay.one.service.OrganizationService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.RoleService;
 import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.FindUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -366,44 +367,35 @@ public class OrganizationsRestController extends OneBaseRestController {
 	private void _unassignContactRoles(
 		Organization organization, UserAccount userAccount) {
 
-		OrganizationBrief[] organizationBriefs =
-			userAccount.getOrganizationBriefs();
+		OrganizationBrief organizationBrief = FindUtil.findFirst(
+			userAccount.getOrganizationBriefs(),
+			organizationBrief1 -> Objects.equals(
+				organization.getExternalReferenceCode(),
+				organizationBrief1.getExternalReferenceCode()));
 
-		if (organizationBriefs == null) {
+		if (organizationBrief == null) {
 			return;
 		}
 
-		for (OrganizationBrief organizationBrief : organizationBriefs) {
-			if (!Objects.equals(
-					organization.getExternalReferenceCode(),
-					organizationBrief.getExternalReferenceCode())) {
+		RoleBrief[] roleBriefs = organizationBrief.getRoleBriefs();
 
-				continue;
-			}
-
-			RoleBrief[] roleBriefs = organizationBrief.getRoleBriefs();
-
-			if (roleBriefs == null) {
-				return;
-			}
-
-			for (RoleBrief roleBrief : roleBriefs) {
-				try {
-					_organizationUserAccountRoleSynchronizer.syncUnassignRole(
-						roleBrief.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode(),
-						organization.getExternalReferenceCode());
-				}
-				catch (Exception exception) {
-					_log.error(
-						"Unable to sync organization contact role " +
-							"unassignment for role " +
-								roleBrief.getExternalReferenceCode(),
-						exception);
-				}
-			}
-
+		if (roleBriefs == null) {
 			return;
+		}
+
+		for (RoleBrief roleBrief : roleBriefs) {
+			try {
+				_organizationUserAccountRoleSynchronizer.syncUnassignRole(
+					roleBrief.getExternalReferenceCode(),
+					userAccount.getExternalReferenceCode(),
+					organization.getExternalReferenceCode());
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to sync organization contact role unassignment " +
+						"for role " + roleBrief.getExternalReferenceCode(),
+					exception);
+			}
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -8,6 +8,7 @@ package com.liferay.one.jira.service;
 import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
 import com.liferay.one.jira.exception.JiraAssetObjectException;
 import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -45,38 +46,9 @@ public class JiraAssetService {
 			return;
 		}
 
-		String externalKeyAttributeName =
-			converter.getExternalKeyAttributeName();
-
-		List<JiraAssetObject> jiraAssetObjects =
-			_jiraAssetPersistence.searchObjects(
-				converter.getAQLWithBuilder(
-					aqlBuilder -> aqlBuilder.andEquals(
-						externalKey, externalKeyAttributeName)),
-				converter::toJiraAssetObject);
-
-		if (jiraAssetObjects.isEmpty()) {
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					StringBundler.concat(
-						"Skipping delete of ", converter.getObjectTypeName(),
-						" asset object for external key ", externalKey,
-						" because it does not exist"));
-			}
-
-			return;
-		}
-
-		JiraAssetObject jiraAssetObject = jiraAssetObjects.get(0);
-
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				StringBundler.concat(
-					"Deleting ", converter.getObjectTypeName(),
-					" asset object for external key ", externalKey));
-		}
-
-		_jiraAssetPersistence.deleteObject(jiraAssetObject.getObjectId());
+		_jiraSyncLock.withLock(
+			_getLockKey(converter, externalKey),
+			() -> _delete(converter, externalKey));
 	}
 
 	/**
@@ -271,6 +243,75 @@ public class JiraAssetService {
 			return;
 		}
 
+		_jiraSyncLock.withLock(
+			_getLockKey(converter, externalKey),
+			() -> _upsert(
+				converter, externalKey, jiraAssetObject,
+				shouldSkipUpdateBiPredicate));
+	}
+
+	private String _createObject(
+		BaseJiraAssetObjectConverter converter, String externalKey,
+		Function<String, JiraAssetObject> createAssetObjectFunction) {
+
+		return _jiraSyncLock.withLock(
+			_getLockKey(converter, externalKey),
+			() -> {
+				String objectId = fetchReferenceObjectId(
+					converter, externalKey);
+
+				if (objectId != null) {
+					return objectId;
+				}
+
+				JiraAssetObject jiraAssetObject =
+					createAssetObjectFunction.apply(externalKey);
+
+				if (jiraAssetObject == null) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							StringBundler.concat(
+								"Unable to create ",
+								converter.getObjectTypeName(),
+								" asset object for external key ",
+								externalKey));
+					}
+
+					return null;
+				}
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Creating ", converter.getObjectTypeName(),
+							" asset object for unresolved external key ",
+							externalKey));
+				}
+
+				try {
+					JSONObject jsonObject = _jiraAssetPersistence.createObject(
+						converter.getObjectTypeId(), jiraAssetObject);
+
+					return jsonObject.optString("id", null);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to create ", converter.getObjectTypeName(),
+							" asset object for external key ", externalKey),
+						exception);
+
+					return null;
+				}
+			});
+	}
+
+	private void _delete(
+		BaseJiraAssetObjectConverter converter, String externalKey) {
+
+		String externalKeyAttributeName =
+			converter.getExternalKeyAttributeName();
+
 		List<JiraAssetObject> jiraAssetObjects =
 			_jiraAssetPersistence.searchObjects(
 				converter.getAQLWithBuilder(
@@ -282,83 +323,30 @@ public class JiraAssetService {
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					StringBundler.concat(
-						"Creating ", converter.getObjectTypeName(),
-						" asset object for external key ", externalKey));
-			}
-
-			_jiraAssetPersistence.createObject(
-				converter.getObjectTypeId(), jiraAssetObject);
-
-			return;
-		}
-
-		JiraAssetObject existingJiraAssetObject = jiraAssetObjects.get(0);
-
-		if ((shouldSkipUpdateBiPredicate != null) &&
-			shouldSkipUpdateBiPredicate.test(
-				existingJiraAssetObject, jiraAssetObject)) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"Skipping unchanged ", converter.getObjectTypeName(),
-						" asset object for external key ", externalKey));
+						"Skipping delete of ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey,
+						" because it does not exist"));
 			}
 
 			return;
 		}
+
+		JiraAssetObject jiraAssetObject = jiraAssetObjects.get(0);
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				StringBundler.concat(
-					"Updating ", converter.getObjectTypeName(),
+					"Deleting ", converter.getObjectTypeName(),
 					" asset object for external key ", externalKey));
 		}
 
-		_jiraAssetPersistence.updateObject(
-			existingJiraAssetObject.getObjectId(), jiraAssetObject);
+		_jiraAssetPersistence.deleteObject(jiraAssetObject.getObjectId());
 	}
 
-	private String _createObject(
-		BaseJiraAssetObjectConverter converter, String externalKey,
-		Function<String, JiraAssetObject> createAssetObjectFunction) {
+	private String _getLockKey(
+		BaseJiraAssetObjectConverter converter, String externalKey) {
 
-		JiraAssetObject jiraAssetObject = createAssetObjectFunction.apply(
-			externalKey);
-
-		if (jiraAssetObject == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"Unable to create ", converter.getObjectTypeName(),
-						" asset object for external key ", externalKey));
-			}
-
-			return null;
-		}
-
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				StringBundler.concat(
-					"Creating ", converter.getObjectTypeName(),
-					" asset object for unresolved external key ", externalKey));
-		}
-
-		try {
-			JSONObject jsonObject = _jiraAssetPersistence.createObject(
-				converter.getObjectTypeId(), jiraAssetObject);
-
-			return jsonObject.optString("id", null);
-		}
-		catch (Exception exception) {
-			_log.error(
-				StringBundler.concat(
-					"Unable to create ", converter.getObjectTypeName(),
-					" asset object for external key ", externalKey),
-				exception);
-
-			return null;
-		}
+		return converter.getObjectTypeName() + "#" + externalKey;
 	}
 
 	private void _putObjectIds(
@@ -463,11 +451,75 @@ public class JiraAssetService {
 		return resolvedObjectIds;
 	}
 
+	private void _upsert(
+		BaseJiraAssetObjectConverter converter, String externalKey,
+		JiraAssetObject jiraAssetObject,
+		BiPredicate<JiraAssetObject, JiraAssetObject>
+			shouldSkipUpdateBiPredicate) {
+
+		String externalKeyAttributeName =
+			converter.getExternalKeyAttributeName();
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetPersistence.searchObjects(
+				converter.getAQLWithBuilder(
+					aqlBuilder -> aqlBuilder.andEquals(
+						externalKey, externalKeyAttributeName)),
+				converter::toJiraAssetObject);
+
+		if (jiraAssetObjects.isEmpty()) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"Creating ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey));
+			}
+
+			_jiraAssetPersistence.createObject(
+				converter.getObjectTypeId(), jiraAssetObject);
+
+			return;
+		}
+
+		JiraAssetObject existingJiraAssetObject = jiraAssetObjects.get(0);
+
+		if ((shouldSkipUpdateBiPredicate != null) &&
+			shouldSkipUpdateBiPredicate.test(
+				existingJiraAssetObject, jiraAssetObject)) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Skipping unchanged ", converter.getObjectTypeName(),
+						" asset object for external key ", externalKey));
+			}
+
+			return;
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Updating ", converter.getObjectTypeName(),
+					" asset object for external key ", externalKey));
+		}
+
+		_jiraAssetPersistence.updateObject(
+			existingJiraAssetObject.getObjectId(), jiraAssetObject);
+	}
+
 	private static final int _CHUNK_SIZE = 50;
 
 	private static final Log _log = LogFactory.getLog(JiraAssetService.class);
 
 	@Autowired
 	private JiraAssetPersistence _jiraAssetPersistence;
+
+	// Deliberately not the shared JiraSyncLock component: the synchronizers
+	// hold entity-level locks from that component around calls into this
+	// class, and nesting two lock levels on one striped pool can deadlock
+	// when unrelated keys hash to each other's stripes.
+
+	private final JiraSyncLock _jiraSyncLock = new JiraSyncLock();
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -39,6 +39,7 @@ import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.RoleService;
 import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.FindUtil;
 import com.liferay.one.util.role.EmployeeRoles;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -48,12 +49,10 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -199,28 +198,6 @@ public class AccountSynchronizer {
 		lines.add(fieldName + ": " + value);
 	}
 
-	private <T> T _findFirst(List<T> list, Predicate<T> predicate) {
-		if (ListUtil.isEmpty(list)) {
-			return null;
-		}
-
-		for (T t : list) {
-			if (predicate.test(t)) {
-				return t;
-			}
-		}
-
-		return null;
-	}
-
-	private <T> T _findFirst(T[] arr, Predicate<T> predicate) {
-		if (arr == null) {
-			return null;
-		}
-
-		return _findFirst(Arrays.asList(arr), predicate);
-	}
-
 	private Map<String, Object> _getAccountAttributeValues(
 			Account account, List<UserAccount> accountUserAccounts,
 			List<Organization> accountOrganizations)
@@ -316,8 +293,8 @@ public class AccountSynchronizer {
 		UserAccountBucket accountUserAccountBucket = new UserAccountBucket();
 
 		for (UserAccount accountUserAccount : accountUserAccounts) {
-			AccountBrief accountBrief = _findFirst(
-				Arrays.asList(accountUserAccount.getAccountBriefs()),
+			AccountBrief accountBrief = FindUtil.findFirst(
+				accountUserAccount.getAccountBriefs(),
 				accountBrief1 -> Objects.equals(
 					account.getExternalReferenceCode(),
 					accountBrief1.getExternalReferenceCode()));
@@ -330,7 +307,7 @@ public class AccountSynchronizer {
 				continue;
 			}
 
-			RoleBrief roleBrief = _findFirst(
+			RoleBrief roleBrief = FindUtil.findFirst(
 				accountBrief.getRoleBriefs(),
 				roleBrief1 -> _employeeRoleNames.contains(
 					roleBrief1.getName()));
@@ -455,8 +432,8 @@ public class AccountSynchronizer {
 		Account account, List<UserAccount> accountUserAccounts) {
 
 		for (UserAccount accountUserAccount : accountUserAccounts) {
-			AccountBrief accountBrief = _findFirst(
-				Arrays.asList(accountUserAccount.getAccountBriefs()),
+			AccountBrief accountBrief = FindUtil.findFirst(
+				accountUserAccount.getAccountBriefs(),
 				accountBrief1 -> Objects.equals(
 					account.getExternalReferenceCode(),
 					accountBrief1.getExternalReferenceCode()));

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -126,6 +126,38 @@ public class AccountSynchronizer {
 		}
 	}
 
+	public void syncAccountUserAccounts(Account account) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing user accounts for account " +
+					account.getExternalReferenceCode() + " to JSM");
+		}
+
+		UserAccountBucket accountUserAccountBucket =
+			_getAccountUserAccountBucket(
+				account,
+				_userAccountService.getAccountUserAccounts(account.getId()));
+
+		_syncAccountAsset(
+			account,
+			LinkedHashMapBuilder.<String, Object>put(
+				AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
+				_jiraAssetService.getOrCreateReferenceObjectIds(
+					_contactConverter,
+					accountUserAccountBucket.getCustomerUserAccounts(),
+					UserAccount::getExternalReferenceCode,
+					_contactConverter::toAssetObject)
+			).put(
+				AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
+				_jiraAssetService.getOrCreateReferenceObjectIds(
+					_contactConverter,
+					accountUserAccountBucket.getWorkerUserAccounts(),
+					UserAccount::getExternalReferenceCode,
+					_contactConverter::toAssetObject)
+			).build(),
+			account.getExternalReferenceCode(), account.getName());
+	}
+
 	public void syncProject(Project project) throws Exception {
 		if (_log.isInfoEnabled()) {
 			_log.info(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountSynchronizer.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class AccountUserAccountSynchronizer {
+
+	public void syncAccountUserAccountMembership(
+		Account account, UserAccount userAccount) {
+
+		try {
+			_accountSynchronizer.syncAccountUserAccounts(account);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync user accounts for account " +
+					account.getExternalReferenceCode(),
+				exception);
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountAccounts(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync accounts for user account " +
+					userAccount.getExternalReferenceCode(),
+				exception);
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountRoles(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync roles for user account " +
+					userAccount.getExternalReferenceCode(),
+				exception);
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		AccountUserAccountSynchronizer.class);
+
+	@Autowired
+	private AccountSynchronizer _accountSynchronizer;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
@@ -105,6 +105,31 @@ public class OrganizationSynchronizer {
 		_syncOrganizationAssignments(organization, accountBriefs);
 	}
 
+	public void syncOrganizationUserAccounts(Organization organization)
+		throws Exception {
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing user accounts for organization " +
+					organization.getExternalReferenceCode() + " to JSM");
+		}
+
+		JiraAssetObject jiraAssetObject = _teamConverter.toAssetObject(
+			organization);
+
+		jiraAssetObject.setAttributeValue(
+			TeamConstants.ATTRIBUTE_NAME_CONTACTS,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_contactConverter,
+				_userAccountService.getOrganizationUserAccounts(
+					GetterUtil.getLong(organization.getId())),
+				UserAccount::getExternalReferenceCode));
+
+		_jiraSyncLock.withLock(
+			organization.getExternalReferenceCode(),
+			() -> _jiraAssetService.upsert(_teamConverter, jiraAssetObject));
+	}
+
 	private List<Property> _getExternalLinkProperties(Organization organization)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountSynchronizer.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class OrganizationUserAccountSynchronizer {
+
+	public void syncOrganizationUserAccountMembership(
+		Organization organization, UserAccount userAccount) {
+
+		try {
+			_organizationSynchronizer.syncOrganizationUserAccounts(
+				organization);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync user accounts for organization " +
+					organization.getExternalReferenceCode(),
+				exception);
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountOrganizations(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync organizations for user account " +
+					userAccount.getExternalReferenceCode(),
+				exception);
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountRoles(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync roles for user account " +
+					userAccount.getExternalReferenceCode(),
+				exception);
+		}
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrganizationUserAccountSynchronizer.class);
+
+	@Autowired
+	private OrganizationSynchronizer _organizationSynchronizer;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
@@ -66,20 +66,69 @@ public class UserAccountSynchronizer {
 			() -> _syncUserAccount(userAccount));
 	}
 
-	private List<RoleBrief> _getAccountRoleBriefs(
-		List<AccountBrief> accountBriefs) {
-
-		List<RoleBrief> roleBriefs = new ArrayList<>();
-
-		for (AccountBrief accountBrief : accountBriefs) {
-			RoleBrief[] accountRoleBriefs = accountBrief.getRoleBriefs();
-
-			if (accountRoleBriefs != null) {
-				Collections.addAll(roleBriefs, accountRoleBriefs);
-			}
+	public void syncUserAccountAccounts(UserAccount userAccount) {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing accounts for user account " +
+					userAccount.getExternalReferenceCode() + " to JSM");
 		}
 
-		return roleBriefs;
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_accountConverter,
+				ListUtil.fromArray(userAccount.getAccountBriefs()),
+				AccountBrief::getExternalReferenceCode));
+
+		_jiraSyncLock.withLock(
+			userAccount.getExternalReferenceCode(),
+			() -> _jiraAssetService.upsert(_contactConverter, jiraAssetObject));
+	}
+
+	public void syncUserAccountOrganizations(UserAccount userAccount) {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing organizations for user account " +
+					userAccount.getExternalReferenceCode() + " to JSM");
+		}
+
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_TEAMS,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_teamConverter,
+				ListUtil.fromArray(userAccount.getOrganizationBriefs()),
+				OrganizationBrief::getExternalReferenceCode));
+
+		_jiraSyncLock.withLock(
+			userAccount.getExternalReferenceCode(),
+			() -> _jiraAssetService.upsert(_contactConverter, jiraAssetObject));
+	}
+
+	public void syncUserAccountRoles(UserAccount userAccount) {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing roles for user account " +
+					userAccount.getExternalReferenceCode() + " to JSM");
+		}
+
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		jiraAssetObject.setAttributeValue(
+			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
+			_jiraAssetService.fetchReferenceObjectIds(
+				_contactRoleConverter, _getRoleBriefs(userAccount),
+				RoleBrief::getExternalReferenceCode));
+
+		_jiraSyncLock.withLock(
+			userAccount.getExternalReferenceCode(),
+			() -> _jiraAssetService.upsert(_contactConverter, jiraAssetObject));
 	}
 
 	private List<EntitlementDefinition> _getEntitlementDefinitions(
@@ -114,12 +163,22 @@ public class UserAccountSynchronizer {
 		return externalLinkProperties;
 	}
 
-	private List<RoleBrief> _getOrganizationRoleBriefs(
-		List<OrganizationBrief> organizationBriefs) {
-
+	private List<RoleBrief> _getRoleBriefs(UserAccount userAccount) {
 		List<RoleBrief> roleBriefs = new ArrayList<>();
 
-		for (OrganizationBrief organizationBrief : organizationBriefs) {
+		for (AccountBrief accountBrief :
+				ListUtil.fromArray(userAccount.getAccountBriefs())) {
+
+			RoleBrief[] accountRoleBriefs = accountBrief.getRoleBriefs();
+
+			if (accountRoleBriefs != null) {
+				Collections.addAll(roleBriefs, accountRoleBriefs);
+			}
+		}
+
+		for (OrganizationBrief organizationBrief :
+				ListUtil.fromArray(userAccount.getOrganizationBriefs())) {
+
 			RoleBrief[] organizationRoleBriefs =
 				organizationBrief.getRoleBriefs();
 
@@ -215,11 +274,6 @@ public class UserAccountSynchronizer {
 		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
 			userAccount);
 
-		List<RoleBrief> roleBriefs = new ArrayList<>(
-			_getAccountRoleBriefs(accountBriefs));
-
-		roleBriefs.addAll(_getOrganizationRoleBriefs(organizationBriefs));
-
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
 			_jiraAssetService.fetchReferenceObjectIds(
@@ -228,7 +282,7 @@ public class UserAccountSynchronizer {
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_contactRoleConverter, roleBriefs,
+				_contactRoleConverter, _getRoleBriefs(userAccount),
 				RoleBrief::getExternalReferenceCode));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ENTITLEMENTS,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/RoleService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/RoleService.java
@@ -30,7 +30,7 @@ public class RoleService extends OneBaseService {
 		RoleResource roleResource = _buildRoleResource();
 
 		roleResource.postOrganizationRoleUserAccountAssociation(
-			roleId, organizationId, userId);
+			roleId, userId, organizationId);
 	}
 
 	public List<Role> getAccountRoles() throws Exception {
@@ -54,7 +54,7 @@ public class RoleService extends OneBaseService {
 		RoleResource roleResource = _buildRoleResource();
 
 		roleResource.deleteOrganizationRoleUserAccountAssociation(
-			roleId, organizationId, userId);
+			roleId, userId, organizationId);
 	}
 
 	private RoleResource _buildRoleResource() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/FindUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/FindUtil.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * @author Drew Brokke
+ */
+public class FindUtil {
+
+	public static <T> T findFirst(List<T> list, Predicate<T> predicate) {
+		if (list == null) {
+			return null;
+		}
+
+		for (T t : list) {
+			if (predicate.test(t)) {
+				return t;
+			}
+		}
+
+		return null;
+	}
+
+	public static <T> T findFirst(T[] array, Predicate<T> predicate) {
+		if (array == null) {
+			return null;
+		}
+
+		return findFirst(Arrays.asList(array), predicate);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -10,6 +10,9 @@ import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.service.AccountAssetService;
+import com.liferay.one.jira.synchronizer.AccountSynchronizer;
+import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
@@ -122,6 +125,12 @@ public class AccountsRestControllerTest {
 			_createAccount()
 		);
 
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			_createUserAccount()
+		);
+
 		accountsRestController.deleteUserAccounts(
 			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
 
@@ -135,6 +144,61 @@ public class AccountsRestControllerTest {
 			_provisioningAssignmentService
 		).unassignAccountMembership(
 			_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testDeleteUserAccountsUnassignsContactRolesAndSyncsContacts()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		UserAccount userAccount = _createUserAccount(
+			_ACCOUNT_ID, "Account Member");
+
+		userAccount.setExternalReferenceCode("USER-ERC-1");
+
+		AccountBrief accountBrief = userAccount.getAccountBriefs()[0];
+
+		accountBrief.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+
+		RoleBrief roleBrief = accountBrief.getRoleBriefs()[0];
+
+		roleBrief.setExternalReferenceCode("ROLE-ERC-1");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		accountsRestController.deleteUserAccounts(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
+
+		Mockito.verify(
+			_accountUserAccountRoleSynchronizer
+		).syncUnassignRole(
+			"ROLE-ERC-1", "USER-ERC-1", _EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			userAccount
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountContacts(
+			account
 		);
 	}
 
@@ -171,6 +235,44 @@ public class AccountsRestControllerTest {
 			_provisioningAssignmentService
 		).assignAccountRole(
 			account, _USER_ID, "Support Administrator"
+		);
+	}
+
+	@Test
+	public void testPostUserAccountsAccountRoleSyncsContactsToJSM()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		UserAccount userAccount = _createUserAccount();
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		accountsRestController.postUserAccountsAccountRole(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID, _ACCOUNT_ROLE_ID);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			userAccount
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountContacts(
+			account
 		);
 	}
 
@@ -535,9 +637,46 @@ public class AccountsRestControllerTest {
 		Mockito.verifyNoInteractions(_provisioningEmailService);
 	}
 
+	@Test
+	public void testPostUserAccountsSyncsContactsToJSM() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			account
+		);
+
+		UserAccount userAccount = _createUserAccount();
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		accountsRestController.postUserAccounts(
+			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			userAccount
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountContacts(
+			account
+		);
+	}
+
 	private Account _createAccount() {
 		Account account = new Account();
 
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
 		account.setId(_ACCOUNT_ID);
 
 		return account;
@@ -578,6 +717,12 @@ public class AccountsRestControllerTest {
 		ReflectionTestUtils.setField(
 			accountsRestController, "_accountService", _accountService);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_accountSynchronizer",
+			_accountSynchronizer);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_accountUserAccountRoleSynchronizer",
+			_accountUserAccountRoleSynchronizer);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_emailAddressValidatorService",
 			_emailAddressValidatorService);
 		ReflectionTestUtils.setField(
@@ -592,6 +737,9 @@ public class AccountsRestControllerTest {
 			_provisioningEmailService);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_userAccountService", _userAccountService);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
 
 		return accountsRestController;
 	}
@@ -639,6 +787,11 @@ public class AccountsRestControllerTest {
 		AccountPermission.class);
 	private final AccountService _accountService = Mockito.mock(
 		AccountService.class);
+	private final AccountSynchronizer _accountSynchronizer = Mockito.mock(
+		AccountSynchronizer.class);
+	private final AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer = Mockito.mock(
+			AccountUserAccountRoleSynchronizer.class);
 	private final EmailAddressValidatorService _emailAddressValidatorService =
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
@@ -650,5 +803,7 @@ public class AccountsRestControllerTest {
 		Mockito.mock(ProvisioningEmailService.class);
 	private final UserAccountService _userAccountService = Mockito.mock(
 		UserAccountService.class);
+	private final UserAccountSynchronizer _userAccountSynchronizer =
+		Mockito.mock(UserAccountSynchronizer.class);
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -12,7 +12,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
-import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
+import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
@@ -148,7 +148,7 @@ public class AccountsRestControllerTest {
 	}
 
 	@Test
-	public void testDeleteUserAccountsUnassignsContactRolesAndSyncsContacts()
+	public void testDeleteUserAccountsUnassignsContactRolesAndSyncsMembership()
 		throws Exception {
 
 		AccountsRestController accountsRestController = _createController();
@@ -190,15 +190,9 @@ public class AccountsRestControllerTest {
 		);
 
 		Mockito.verify(
-			_userAccountSynchronizer
-		).syncUserAccount(
-			userAccount
-		);
-
-		Mockito.verify(
-			_accountSynchronizer
-		).syncAccountContacts(
-			account
+			_accountUserAccountSynchronizer
+		).syncAccountUserAccountMembership(
+			account, userAccount
 		);
 	}
 
@@ -239,7 +233,7 @@ public class AccountsRestControllerTest {
 	}
 
 	@Test
-	public void testPostUserAccountsAccountRoleSyncsContactsToJSM()
+	public void testPostUserAccountsAccountRoleSyncsMembershipToJSM()
 		throws Exception {
 
 		AccountsRestController accountsRestController = _createController();
@@ -264,15 +258,9 @@ public class AccountsRestControllerTest {
 			null, _EXTERNAL_REFERENCE_CODE, _USER_ID, _ACCOUNT_ROLE_ID);
 
 		Mockito.verify(
-			_userAccountSynchronizer
-		).syncUserAccount(
-			userAccount
-		);
-
-		Mockito.verify(
-			_accountSynchronizer
-		).syncAccountContacts(
-			account
+			_accountUserAccountSynchronizer
+		).syncAccountUserAccountMembership(
+			account, userAccount
 		);
 	}
 
@@ -638,7 +626,7 @@ public class AccountsRestControllerTest {
 	}
 
 	@Test
-	public void testPostUserAccountsSyncsContactsToJSM() throws Exception {
+	public void testPostUserAccountsSyncsMembershipToJSM() throws Exception {
 		AccountsRestController accountsRestController = _createController();
 
 		Account account = _createAccount();
@@ -661,15 +649,9 @@ public class AccountsRestControllerTest {
 			null, _EXTERNAL_REFERENCE_CODE, _USER_ID);
 
 		Mockito.verify(
-			_userAccountSynchronizer
-		).syncUserAccount(
-			userAccount
-		);
-
-		Mockito.verify(
-			_accountSynchronizer
-		).syncAccountContacts(
-			account
+			_accountUserAccountSynchronizer
+		).syncAccountUserAccountMembership(
+			account, userAccount
 		);
 	}
 
@@ -723,6 +705,9 @@ public class AccountsRestControllerTest {
 			accountsRestController, "_accountUserAccountRoleSynchronizer",
 			_accountUserAccountRoleSynchronizer);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_accountUserAccountSynchronizer",
+			_accountUserAccountSynchronizer);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_emailAddressValidatorService",
 			_emailAddressValidatorService);
 		ReflectionTestUtils.setField(
@@ -737,9 +722,6 @@ public class AccountsRestControllerTest {
 			_provisioningEmailService);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_userAccountService", _userAccountService);
-		ReflectionTestUtils.setField(
-			accountsRestController, "_userAccountSynchronizer",
-			_userAccountSynchronizer);
 
 		return accountsRestController;
 	}
@@ -792,6 +774,9 @@ public class AccountsRestControllerTest {
 	private final AccountUserAccountRoleSynchronizer
 		_accountUserAccountRoleSynchronizer = Mockito.mock(
 			AccountUserAccountRoleSynchronizer.class);
+	private final AccountUserAccountSynchronizer
+		_accountUserAccountSynchronizer = Mockito.mock(
+			AccountUserAccountSynchronizer.class);
 	private final EmailAddressValidatorService _emailAddressValidatorService =
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
@@ -803,7 +788,5 @@ public class AccountsRestControllerTest {
 		Mockito.mock(ProvisioningEmailService.class);
 	private final UserAccountService _userAccountService = Mockito.mock(
 		UserAccountService.class);
-	private final UserAccountSynchronizer _userAccountSynchronizer =
-		Mockito.mock(UserAccountSynchronizer.class);
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
@@ -6,11 +6,15 @@
 package com.liferay.one;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.Role;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.jira.synchronizer.OrganizationSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.OrganizationUserAccountSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AdminPermission;
@@ -128,6 +132,7 @@ public class OrganizationsRestControllerTest {
 			_createController();
 
 		_setUpOktaGroup("ana@example.com", "carla@example.com");
+		_setUpOrganization();
 		_setUpOrganizationUserAccounts("ana@example.com", "daniel@example.com");
 
 		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
@@ -142,6 +147,12 @@ public class OrganizationsRestControllerTest {
 			_organizationService
 		).removeOrganizationUserAccountByEmailAddress(
 			"daniel@example.com", _ORGANIZATION_ID
+		);
+
+		Mockito.verify(
+			_organizationService
+		).getOrganization(
+			_ORGANIZATION_ID
 		);
 
 		Mockito.verifyNoMoreInteractions(_organizationService);
@@ -179,6 +190,95 @@ public class OrganizationsRestControllerTest {
 		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
 
 		Mockito.verifyNoInteractions(_organizationService);
+	}
+
+	@Test
+	public void testPostSyncFromOktaSyncsContactsToJSM() throws Exception {
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		_setUpOktaGroup("carla@example.com");
+
+		Organization organization = _setUpOrganization();
+
+		UserAccount removedUserAccount = _createUserAccount(
+			"daniel@example.com");
+
+		removedUserAccount.setExternalReferenceCode("USER-ERC-1");
+
+		OrganizationBrief organizationBrief = new OrganizationBrief();
+
+		organizationBrief.setExternalReferenceCode(
+			_ORGANIZATION_EXTERNAL_REFERENCE_CODE);
+
+		RoleBrief roleBrief = new RoleBrief();
+
+		roleBrief.setExternalReferenceCode("ROLE-ERC-1");
+
+		organizationBrief.setRoleBriefs(new RoleBrief[] {roleBrief});
+
+		removedUserAccount.setOrganizationBriefs(
+			new OrganizationBrief[] {organizationBrief});
+
+		Mockito.when(
+			_userAccountService.getOrganizationUserAccounts(_ORGANIZATION_ID)
+		).thenReturn(
+			List.of(removedUserAccount)
+		);
+
+		UserAccount addedUserAccount = _createUserAccount("carla@example.com");
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(
+				"carla@example.com")
+		).thenReturn(
+			addedUserAccount
+		);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(
+				"daniel@example.com")
+		).thenReturn(
+			removedUserAccount
+		);
+
+		organizationsRestController.postSyncFromOkta(null, _ORGANIZATION_ID);
+
+		Mockito.verify(
+			_organizationUserAccountRoleSynchronizer
+		).syncUnassignRole(
+			"ROLE-ERC-1", "USER-ERC-1", _ORGANIZATION_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountOrganizations(
+			addedUserAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			addedUserAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountOrganizations(
+			removedUserAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			removedUserAccount
+		);
+
+		Mockito.verify(
+			_organizationSynchronizer
+		).syncOrganizationUserAccounts(
+			organization
+		);
 	}
 
 	@Test
@@ -244,6 +344,9 @@ public class OrganizationsRestControllerTest {
 			organizationsRestController, "_organizationService",
 			_organizationService);
 		ReflectionTestUtils.setField(
+			organizationsRestController, "_organizationSynchronizer",
+			_organizationSynchronizer);
+		ReflectionTestUtils.setField(
 			organizationsRestController,
 			"_organizationUserAccountRoleSynchronizer",
 			_organizationUserAccountRoleSynchronizer);
@@ -257,6 +360,9 @@ public class OrganizationsRestControllerTest {
 		ReflectionTestUtils.setField(
 			organizationsRestController, "_userAccountService",
 			_userAccountService);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
 
 		return organizationsRestController;
 	}
@@ -350,6 +456,8 @@ public class OrganizationsRestControllerTest {
 	private final OktaService _oktaService = Mockito.mock(OktaService.class);
 	private final OrganizationService _organizationService = Mockito.mock(
 		OrganizationService.class);
+	private final OrganizationSynchronizer _organizationSynchronizer =
+		Mockito.mock(OrganizationSynchronizer.class);
 	private final OrganizationUserAccountRoleSynchronizer
 		_organizationUserAccountRoleSynchronizer = Mockito.mock(
 			OrganizationUserAccountRoleSynchronizer.class);
@@ -361,5 +469,7 @@ public class OrganizationsRestControllerTest {
 	private final RoleService _roleService = Mockito.mock(RoleService.class);
 	private final UserAccountService _userAccountService = Mockito.mock(
 		UserAccountService.class);
+	private final UserAccountSynchronizer _userAccountSynchronizer =
+		Mockito.mock(UserAccountSynchronizer.class);
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/OrganizationsRestControllerTest.java
@@ -5,15 +5,19 @@
 
 package com.liferay.one;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.Role;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.jira.synchronizer.OrganizationUserAccountRoleSynchronizer;
+import com.liferay.one.jira.synchronizer.OrganizationUserAccountSynchronizer;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.service.OrganizationService;
 import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.RoleService;
 import com.liferay.one.service.UserAccountService;
-import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 
 import java.util.Arrays;
@@ -32,6 +36,57 @@ import org.springframework.web.server.ResponseStatusException;
  * @author Ricardo Mariz
  */
 public class OrganizationsRestControllerTest {
+
+	@Test
+	public void testDeleteUserAccountsOrganizationRoleSyncsMembershipToJSM()
+		throws Exception {
+
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		Organization organization = _setUpOrganization();
+
+		Role role = new Role();
+
+		role.setExternalReferenceCode("ROLE-ERC-1");
+
+		Mockito.when(
+			_roleService.getRole(_ROLE_ID)
+		).thenReturn(
+			role
+		);
+
+		UserAccount userAccount = _createUserAccount("ana@example.com");
+
+		userAccount.setExternalReferenceCode("USER-ERC-1");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		organizationsRestController.deleteUserAccountsOrganizationRole(
+			null, _ORGANIZATION_ID, _USER_ID, _ROLE_ID);
+
+		Mockito.verify(
+			_roleService
+		).removeOrganizationUserAccountRole(
+			_ORGANIZATION_ID, _ROLE_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_organizationUserAccountRoleSynchronizer
+		).syncUnassignRole(
+			"ROLE-ERC-1", "USER-ERC-1", _ORGANIZATION_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_organizationUserAccountSynchronizer
+		).syncOrganizationUserAccountMembership(
+			organization, userAccount
+		);
+	}
 
 	@Test
 	public void testPostSyncFromOktaChecksAdminPermission() throws Exception {
@@ -126,6 +181,57 @@ public class OrganizationsRestControllerTest {
 		Mockito.verifyNoInteractions(_organizationService);
 	}
 
+	@Test
+	public void testPostUserAccountsOrganizationRoleSyncsMembershipToJSM()
+		throws Exception {
+
+		OrganizationsRestController organizationsRestController =
+			_createController();
+
+		Organization organization = _setUpOrganization();
+
+		Role role = new Role();
+
+		role.setExternalReferenceCode("ROLE-ERC-1");
+
+		Mockito.when(
+			_roleService.getRole(_ROLE_ID)
+		).thenReturn(
+			role
+		);
+
+		UserAccount userAccount = _createUserAccount("ana@example.com");
+
+		userAccount.setExternalReferenceCode("USER-ERC-1");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		organizationsRestController.postUserAccountsOrganizationRole(
+			null, _ORGANIZATION_ID, _USER_ID, _ROLE_ID);
+
+		Mockito.verify(
+			_roleService
+		).addOrganizationUserAccountRole(
+			_ORGANIZATION_ID, _ROLE_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_organizationUserAccountRoleSynchronizer
+		).syncAssignRole(
+			"ROLE-ERC-1", "USER-ERC-1", _ORGANIZATION_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_organizationUserAccountSynchronizer
+		).syncOrganizationUserAccountMembership(
+			organization, userAccount
+		);
+	}
+
 	private OrganizationsRestController _createController() {
 		OrganizationsRestController organizationsRestController =
 			new OrganizationsRestController();
@@ -138,7 +244,16 @@ public class OrganizationsRestControllerTest {
 			organizationsRestController, "_organizationService",
 			_organizationService);
 		ReflectionTestUtils.setField(
+			organizationsRestController,
+			"_organizationUserAccountRoleSynchronizer",
+			_organizationUserAccountRoleSynchronizer);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_organizationUserAccountSynchronizer",
+			_organizationUserAccountSynchronizer);
+		ReflectionTestUtils.setField(
 			organizationsRestController, "_propertyService", _propertyService);
+		ReflectionTestUtils.setField(
+			organizationsRestController, "_roleService", _roleService);
 		ReflectionTestUtils.setField(
 			organizationsRestController, "_userAccountService",
 			_userAccountService);
@@ -169,8 +284,8 @@ public class OrganizationsRestControllerTest {
 	private void _setUpOktaGroup(String... emailAddresses) throws Exception {
 		Mockito.when(
 			_propertyService.getPropertyValue(
-				Organization.class.getName(), _ORGANIZATION_ID,
-				PropertyConstants.NAME_OKTA_GROUP)
+				com.liferay.portal.kernel.model.Organization.class.getName(),
+				_ORGANIZATION_ID, PropertyConstants.NAME_OKTA_GROUP)
 		).thenReturn(
 			_OKTA_GROUP_ID
 		);
@@ -186,6 +301,22 @@ public class OrganizationsRestControllerTest {
 		).thenReturn(
 			oktaUsers
 		);
+	}
+
+	private Organization _setUpOrganization() throws Exception {
+		Organization organization = new Organization();
+
+		organization.setExternalReferenceCode(
+			_ORGANIZATION_EXTERNAL_REFERENCE_CODE);
+		organization.setId(String.valueOf(_ORGANIZATION_ID));
+
+		Mockito.when(
+			_organizationService.getOrganization(_ORGANIZATION_ID)
+		).thenReturn(
+			organization
+		);
+
+		return organization;
 	}
 
 	private void _setUpOrganizationUserAccounts(String... emailAddresses)
@@ -206,15 +337,28 @@ public class OrganizationsRestControllerTest {
 
 	private static final String _OKTA_GROUP_ID = "00g1abcd2efGHIJK3l4m";
 
+	private static final String _ORGANIZATION_EXTERNAL_REFERENCE_CODE = "ORG-1";
+
 	private static final long _ORGANIZATION_ID = 44444;
+
+	private static final long _ROLE_ID = 55555;
+
+	private static final long _USER_ID = 22222;
 
 	private final AdminPermission _adminPermission = Mockito.mock(
 		AdminPermission.class);
 	private final OktaService _oktaService = Mockito.mock(OktaService.class);
 	private final OrganizationService _organizationService = Mockito.mock(
 		OrganizationService.class);
+	private final OrganizationUserAccountRoleSynchronizer
+		_organizationUserAccountRoleSynchronizer = Mockito.mock(
+			OrganizationUserAccountRoleSynchronizer.class);
+	private final OrganizationUserAccountSynchronizer
+		_organizationUserAccountSynchronizer = Mockito.mock(
+			OrganizationUserAccountSynchronizer.class);
 	private final PropertyService _propertyService = Mockito.mock(
 		PropertyService.class);
+	private final RoleService _roleService = Mockito.mock(RoleService.class);
 	private final UserAccountService _userAccountService = Mockito.mock(
 		UserAccountService.class);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
@@ -1,0 +1,198 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.synchronizer.LockSerializationTestHelper;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_jiraAssetService = new JiraAssetService();
+
+		_converter = Mockito.mock(BaseJiraAssetObjectConverter.class);
+
+		Mockito.when(
+			_converter.getAQLWithBuilder(Mockito.any())
+		).thenReturn(
+			"aql"
+		);
+
+		Mockito.when(
+			_converter.getExternalKeyAttributeName()
+		).thenReturn(
+			"External Key"
+		);
+
+		Mockito.when(
+			_converter.getObjectTypeId()
+		).thenReturn(
+			"objectTypeId"
+		);
+
+		Mockito.when(
+			_converter.getObjectTypeName()
+		).thenReturn(
+			"Test Object"
+		);
+
+		_existingJiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			_existingJiraAssetObject.getAttributeValue("External Key")
+		).thenReturn(
+			_EXTERNAL_KEY
+		);
+
+		Mockito.when(
+			_existingJiraAssetObject.getObjectId()
+		).thenReturn(
+			_OBJECT_ID
+		);
+
+		_jiraAssetPersistence = Mockito.mock(JiraAssetPersistence.class);
+
+		ReflectionTestUtils.setField(
+			_jiraAssetService, "_jiraAssetPersistence", _jiraAssetPersistence);
+	}
+
+	@Test
+	public void testDeleteWaitsForUpsert() throws Exception {
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.updateObject(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			lockSerializationTestHelper.block("update")
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.deleteObject(Mockito.any())
+		).thenAnswer(
+			lockSerializationTestHelper.record("delete")
+		);
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue("External Key")
+		).thenReturn(
+			_EXTERNAL_KEY
+		);
+
+		lockSerializationTestHelper.assertSerialized(
+			() -> _jiraAssetService.upsert(_converter, jiraAssetObject),
+			() -> _jiraAssetService.delete(_converter, _EXTERNAL_KEY), "update",
+			"delete");
+	}
+
+	@Test
+	public void testGetOrCreateReferenceObjectIdsWaitsForUpsert()
+		throws Exception {
+
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
+
+		AtomicBoolean created = new AtomicBoolean();
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				if (created.get()) {
+					return Collections.singletonList(_existingJiraAssetObject);
+				}
+
+				return Collections.emptyList();
+			}
+		);
+
+		Answer<Object> blockAnswer = lockSerializationTestHelper.block(
+			"create");
+
+		Mockito.when(
+			_jiraAssetPersistence.createObject(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				blockAnswer.answer(invocation);
+
+				created.set(true);
+
+				return new JSONObject();
+			}
+		);
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue("External Key")
+		).thenReturn(
+			_EXTERNAL_KEY
+		);
+
+		AtomicReference<List<String>> objectIdsAtomicReference =
+			new AtomicReference<>();
+
+		lockSerializationTestHelper.assertSerialized(
+			() -> _jiraAssetService.upsert(_converter, jiraAssetObject),
+			() -> objectIdsAtomicReference.set(
+				_jiraAssetService.getOrCreateReferenceObjectIds(
+					_converter, Collections.singletonList(_EXTERNAL_KEY),
+					externalKey -> externalKey,
+					externalKey -> Mockito.mock(JiraAssetObject.class))),
+			"create");
+
+		Assertions.assertEquals(
+			Collections.singletonList(_OBJECT_ID),
+			objectIdsAtomicReference.get());
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.times(1)
+		).createObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	private static final String _EXTERNAL_KEY = "test-external-key";
+
+	private static final String _OBJECT_ID = "test-object-id";
+
+	private BaseJiraAssetObjectConverter _converter;
+	private JiraAssetObject _existingJiraAssetObject;
+	private JiraAssetPersistence _jiraAssetPersistence;
+	private JiraAssetService _jiraAssetService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.one.jira.synchronizer;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.jira.constants.AccountConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
 import com.liferay.one.jira.converter.EntitlementConverter;
@@ -44,6 +45,8 @@ public class AccountSynchronizerTest {
 
 		_jiraAssetService = Mockito.mock(JiraAssetService.class);
 
+		_jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
 		AccountConverter accountConverter = Mockito.mock(
 			AccountConverter.class);
 
@@ -51,7 +54,7 @@ public class AccountSynchronizerTest {
 			accountConverter.toAssetObject(
 				Mockito.any(Account.class), Mockito.any(), Mockito.any())
 		).thenReturn(
-			Mockito.mock(JiraAssetObject.class)
+			_jiraAssetObject
 		);
 
 		CommerceOrderService commerceOrderService = Mockito.mock(
@@ -186,10 +189,44 @@ public class AccountSynchronizerTest {
 			"upsert", "delete");
 	}
 
+	@Test
+	public void testSyncAccountUserAccountsUpsertsUserAccountReferences()
+		throws Exception {
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		account.setId(1L);
+		account.setName("Test Account");
+
+		_accountSynchronizer.syncAccountUserAccounts(account);
+
+		Mockito.verify(
+			_jiraAssetObject
+		).setAttributeValue(
+			Mockito.eq(AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetObject
+		).setAttributeValue(
+			Mockito.eq(AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.eq(_jiraAssetObject)
+		);
+	}
+
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
 	private AccountSynchronizer _accountSynchronizer;
+	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountSynchronizerTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountUserAccountSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_accountUserAccountSynchronizer = new AccountUserAccountSynchronizer();
+
+		_accountSynchronizer = Mockito.mock(AccountSynchronizer.class);
+		_userAccountSynchronizer = Mockito.mock(UserAccountSynchronizer.class);
+
+		ReflectionTestUtils.setField(
+			_accountUserAccountSynchronizer, "_accountSynchronizer",
+			_accountSynchronizer);
+		ReflectionTestUtils.setField(
+			_accountUserAccountSynchronizer, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
+	}
+
+	@Test
+	public void testSyncAccountUserAccountMembershipSyncsBothSides()
+		throws Exception {
+
+		Account account = new Account();
+		UserAccount userAccount = new UserAccount();
+
+		_accountUserAccountSynchronizer.syncAccountUserAccountMembership(
+			account, userAccount);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountUserAccounts(
+			account
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountAccounts(
+			userAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			userAccount
+		);
+	}
+
+	@Test
+	public void testSyncAccountUserAccountMembershipSyncsPastFailures()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("expected")
+		).when(
+			_accountSynchronizer
+		).syncAccountUserAccounts(
+			Mockito.any()
+		);
+
+		UserAccount userAccount = new UserAccount();
+
+		_accountUserAccountSynchronizer.syncAccountUserAccountMembership(
+			new Account(), userAccount);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountAccounts(
+			userAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			userAccount
+		);
+	}
+
+	private AccountSynchronizer _accountSynchronizer;
+	private AccountUserAccountSynchronizer _accountUserAccountSynchronizer;
+	private UserAccountSynchronizer _userAccountSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.one.jira.synchronizer;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.one.jira.constants.TeamConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
 import com.liferay.one.jira.converter.ExternalLinkConverter;
@@ -44,12 +45,14 @@ public class OrganizationSynchronizerTest {
 			Collections.emptyList()
 		);
 
+		_jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
 		TeamConverter teamConverter = Mockito.mock(TeamConverter.class);
 
 		Mockito.when(
 			teamConverter.toAssetObject(Mockito.any(Organization.class))
 		).thenReturn(
-			Mockito.mock(JiraAssetObject.class)
+			_jiraAssetObject
 		);
 
 		UserAccountService userAccountService = Mockito.mock(
@@ -123,9 +126,34 @@ public class OrganizationSynchronizerTest {
 			"upsert", "delete");
 	}
 
+	@Test
+	public void testSyncOrganizationUserAccountsUpsertsUserAccountReferences()
+		throws Exception {
+
+		Organization organization = new Organization();
+
+		organization.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		organization.setId("1");
+
+		_organizationSynchronizer.syncOrganizationUserAccounts(organization);
+
+		Mockito.verify(
+			_jiraAssetObject
+		).setAttributeValue(
+			Mockito.eq(TeamConstants.ATTRIBUTE_NAME_CONTACTS), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.eq(_jiraAssetObject)
+		);
+	}
+
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
+	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
 	private OrganizationSynchronizer _organizationSynchronizer;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountSynchronizerTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class OrganizationUserAccountSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_organizationUserAccountSynchronizer =
+			new OrganizationUserAccountSynchronizer();
+
+		_organizationSynchronizer = Mockito.mock(
+			OrganizationSynchronizer.class);
+		_userAccountSynchronizer = Mockito.mock(UserAccountSynchronizer.class);
+
+		ReflectionTestUtils.setField(
+			_organizationUserAccountSynchronizer, "_organizationSynchronizer",
+			_organizationSynchronizer);
+		ReflectionTestUtils.setField(
+			_organizationUserAccountSynchronizer, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
+	}
+
+	@Test
+	public void testSyncOrganizationUserAccountMembershipSyncsBothSides()
+		throws Exception {
+
+		Organization organization = new Organization();
+		UserAccount userAccount = new UserAccount();
+
+		_organizationUserAccountSynchronizer.
+			syncOrganizationUserAccountMembership(organization, userAccount);
+
+		Mockito.verify(
+			_organizationSynchronizer
+		).syncOrganizationUserAccounts(
+			organization
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountOrganizations(
+			userAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			userAccount
+		);
+	}
+
+	@Test
+	public void testSyncOrganizationUserAccountMembershipSyncsPastFailures()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("expected")
+		).when(
+			_organizationSynchronizer
+		).syncOrganizationUserAccounts(
+			Mockito.any()
+		);
+
+		UserAccount userAccount = new UserAccount();
+
+		_organizationUserAccountSynchronizer.
+			syncOrganizationUserAccountMembership(
+				new Organization(), userAccount);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountOrganizations(
+			userAccount
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountRoles(
+			userAccount
+		);
+	}
+
+	private OrganizationSynchronizer _organizationSynchronizer;
+	private OrganizationUserAccountSynchronizer
+		_organizationUserAccountSynchronizer;
+	private UserAccountSynchronizer _userAccountSynchronizer;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -6,6 +6,7 @@
 package com.liferay.one.jira.synchronizer;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.constants.ContactConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
 import com.liferay.one.jira.converter.ContactRoleConverter;
@@ -48,10 +49,12 @@ public class UserAccountSynchronizerTest {
 			Collections.emptyList()
 		);
 
+		_jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
 		Mockito.when(
 			_contactConverter.toAssetObject(Mockito.any(UserAccount.class))
 		).thenReturn(
-			Mockito.mock(JiraAssetObject.class)
+			_jiraAssetObject
 		);
 
 		ReflectionTestUtils.setField(
@@ -115,10 +118,7 @@ public class UserAccountSynchronizerTest {
 			Mockito.any(), Mockito.any()
 		);
 
-		UserAccount userAccount = new UserAccount();
-
-		userAccount.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
-		userAccount.setId(1L);
+		UserAccount userAccount = _createUserAccount();
 
 		lockSerializationTestHelper.assertSerialized(
 			() -> _userAccountSynchronizer.syncUserAccount(userAccount),
@@ -127,10 +127,62 @@ public class UserAccountSynchronizerTest {
 			"upsert", "delete");
 	}
 
+	@Test
+	public void testSyncUserAccountAccountsUpsertsAccountReferences() {
+		_assertUpsertsAttribute(
+			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
+			() -> _userAccountSynchronizer.syncUserAccountAccounts(
+				_createUserAccount()));
+	}
+
+	@Test
+	public void testSyncUserAccountOrganizationsUpsertsOrganizationReferences() {
+		_assertUpsertsAttribute(
+			ContactConstants.ATTRIBUTE_NAME_TEAMS,
+			() -> _userAccountSynchronizer.syncUserAccountOrganizations(
+				_createUserAccount()));
+	}
+
+	@Test
+	public void testSyncUserAccountRolesUpsertsRoleReferences() {
+		_assertUpsertsAttribute(
+			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
+			() -> _userAccountSynchronizer.syncUserAccountRoles(
+				_createUserAccount()));
+	}
+
+	private void _assertUpsertsAttribute(
+		String attributeName, Runnable runnable) {
+
+		runnable.run();
+
+		Mockito.verify(
+			_jiraAssetObject
+		).setAttributeValue(
+			Mockito.eq(attributeName), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.eq(_jiraAssetObject)
+		);
+	}
+
+	private UserAccount _createUserAccount() {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		userAccount.setId(1L);
+
+		return userAccount;
+	}
+
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
 	private ContactConverter _contactConverter;
+	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
 	private UserAccountSynchronizer _userAccountSynchronizer;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/FindUtilTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/FindUtilTest.java
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.util;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class FindUtilTest {
+
+	@Test
+	public void testFindFirst() {
+		Assertions.assertEquals(
+			"banana",
+			FindUtil.findFirst(
+				List.of("apple", "banana", "cherry"),
+				value -> value.startsWith("b")));
+		Assertions.assertEquals(
+			"banana",
+			FindUtil.findFirst(
+				new String[] {"apple", "banana", "cherry"},
+				value -> value.startsWith("b")));
+
+		Assertions.assertNull(
+			FindUtil.findFirst(
+				List.of("apple", "banana", "cherry"),
+				value -> value.startsWith("z")));
+		Assertions.assertNull(
+			FindUtil.findFirst(
+				new String[] {"apple", "banana", "cherry"},
+				value -> value.startsWith("z")));
+
+		Assertions.assertNull(
+			FindUtil.findFirst((List<String>)null, value -> true));
+		Assertions.assertNull(
+			FindUtil.findFirst((String[])null, value -> true));
+	}
+
+}


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-100140](https://liferay.atlassian.net/browse/LPD-100140)

## What is being fixed

Membership changes were not reaching JSM. The sync-from-okta endpoint reconciled organization membership in Liferay without pushing any of those changes to JSM, and account membership changes likewise left Account, Contact, and Team asset references stale — removed users kept their contact role assignments and changed users' organization and role references were never refreshed. Additionally, JSM sync locking wrapped whole orchestrations rather than the individual check-then-write operations, and RoleService made incorrect service calls.

## How it is being fixed

Membership sync is now handled by dedicated composite synchronizers, AccountUserAccountSynchronizer and OrganizationUserAccountSynchronizer, which maintain the two-way links between related entities, backed by new reference sync methods on OrganizationSynchronizer and UserAccountSynchronizer. The REST controllers apply these synchronizers on membership changes, and the Okta reconciliation now tracks which user accounts were added or removed, unassigns removed users' organization contact roles in JSM, resyncs each changed user's organizations and roles, and refreshes the organization's user account list. Lock acquisition in JiraAssetService now wraps only single check-then-write JSM operations with a lock key scoped to type and external reference code, a shared findFirst helper is extracted into FindUtil, and the bad RoleService calls are corrected. Test coverage is added across the new and changed classes.


[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-100140]: https://liferay.atlassian.net/browse/LPD-100140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ