### PR TITLE
LPD-99654 Soft delete stale account assignments during JSM sync

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverter.java
@@ -26,6 +26,15 @@ public class AccountContactRoleAssignmentConverter
 		return AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME;
 	}
 
+	public String getName(
+		String contactRoleExternalKey, String contactExternalKey,
+		String accountExternalKey) {
+
+		return StringBundler.concat(
+			contactRoleExternalKey, ";", contactExternalKey, ";",
+			accountExternalKey);
+	}
+
 	@Override
 	public String getObjectTypeName() {
 		return AccountContactRoleAssignmentConstants.OBJECT_TYPE_NAME;
@@ -39,7 +48,7 @@ public class AccountContactRoleAssignmentConverter
 
 		jiraAssetObject.setAttributeValue(
 			AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME,
-			_getName(
+			getName(
 				contactRoleExternalKey, contactExternalKey,
 				accountExternalKey));
 		jiraAssetObject.setAttributeValue(
@@ -68,15 +77,6 @@ public class AccountContactRoleAssignmentConverter
 	@Override
 	protected String getObjectSchemaName() {
 		return _schemaName;
-	}
-
-	private String _getName(
-		String contactRoleExternalKey, String contactExternalKey,
-		String accountExternalKey) {
-
-		return StringBundler.concat(
-			contactRoleExternalKey, ";", contactExternalKey, ";",
-			accountExternalKey);
 	}
 
 	@Value("${liferay.one.jira.asset.schema.name}")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
@@ -31,6 +31,19 @@ public abstract class BaseJiraAssetObjectConverter {
 		return new JiraAssetObject(_getAttributeIds(), _getAttributeOptions());
 	}
 
+	public String formatDate(Date date) {
+		if (date == null) {
+			return null;
+		}
+
+		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+		return simpleDateFormat.format(date);
+	}
+
 	public String getAQLWithBuilder(Consumer<AQLUtil.Builder> consumer) {
 		AQLUtil.Builder builder = AQLUtil.builder(getBaseAQL());
 
@@ -59,19 +72,6 @@ public abstract class BaseJiraAssetObjectConverter {
 	public JiraAssetObject toJiraAssetObject(JSONObject jsonObject) {
 		return new JiraAssetObject(
 			jsonObject, _getAttributeIds(), _getAttributeOptions());
-	}
-
-	protected String formatDate(Date date) {
-		if (date == null) {
-			return null;
-		}
-
-		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
-			"yyyy-MM-dd'T'HH:mm:ssXX");
-
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-
-		return simpleDateFormat.format(date);
 	}
 
 	protected String getBaseAQL() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/AccountAssetService.java
@@ -24,12 +24,10 @@ public class AccountAssetService {
 	public JiraAssetObject fetchAccountJiraAssetObjectByExternalKey(
 		String externalKey) {
 
-		List<JiraAssetObject> objects = _jiraAssetPersistence.searchObjects(
-			_accountConverter.getAQLWithBuilder(
-				aqlBuilder -> aqlBuilder.andEquals(
-					externalKey,
-					_accountConverter.getExternalKeyAttributeName())),
-			_accountConverter::toJiraAssetObject);
+		List<JiraAssetObject> objects = _jiraAssetService.getJiraAssetObjects(
+			_accountConverter,
+			aqlBuilder -> aqlBuilder.andEquals(
+				externalKey, _accountConverter.getExternalKeyAttributeName()));
 
 		if (objects.isEmpty()) {
 			return null;
@@ -53,6 +51,6 @@ public class AccountAssetService {
 	private AccountConverter _accountConverter;
 
 	@Autowired
-	private JiraAssetPersistence _jiraAssetPersistence;
+	private JiraAssetService _jiraAssetService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -330,15 +330,10 @@ public class JiraAssetService {
 	private void _delete(
 		BaseJiraAssetObjectConverter converter, String externalKey) {
 
-		String externalKeyAttributeName =
-			converter.getExternalKeyAttributeName();
-
-		List<JiraAssetObject> jiraAssetObjects =
-			_jiraAssetPersistence.searchObjects(
-				converter.getAQLWithBuilder(
-					aqlBuilder -> aqlBuilder.andEquals(
-						externalKey, externalKeyAttributeName)),
-				converter::toJiraAssetObject);
+		List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+			converter,
+			aqlBuilder -> aqlBuilder.andEquals(
+				externalKey, converter.getExternalKeyAttributeName()));
 
 		if (jiraAssetObjects.isEmpty()) {
 			if (_log.isInfoEnabled()) {
@@ -377,12 +372,10 @@ public class JiraAssetService {
 		String externalKeyAttributeName =
 			converter.getExternalKeyAttributeName();
 
-		List<JiraAssetObject> jiraAssetObjects =
-			_jiraAssetPersistence.searchObjects(
-				converter.getAQLWithBuilder(
-					aqlBuilder -> aqlBuilder.andIn(
-						externalKeys, externalKeyAttributeName)),
-				converter::toJiraAssetObject);
+		List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+			converter,
+			aqlBuilder -> aqlBuilder.andIn(
+				externalKeys, externalKeyAttributeName));
 
 		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
 			String externalKey = jiraAssetObject.getAttributeValue(
@@ -478,15 +471,10 @@ public class JiraAssetService {
 		BiPredicate<JiraAssetObject, JiraAssetObject>
 			shouldSkipUpdateBiPredicate) {
 
-		String externalKeyAttributeName =
-			converter.getExternalKeyAttributeName();
-
-		List<JiraAssetObject> jiraAssetObjects =
-			_jiraAssetPersistence.searchObjects(
-				converter.getAQLWithBuilder(
-					aqlBuilder -> aqlBuilder.andEquals(
-						externalKey, externalKeyAttributeName)),
-				converter::toJiraAssetObject);
+		List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+			converter,
+			aqlBuilder -> aqlBuilder.andEquals(
+				externalKey, converter.getExternalKeyAttributeName()));
 
 		if (jiraAssetObjects.isEmpty()) {
 			if (_log.isInfoEnabled()) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -8,6 +8,7 @@ package com.liferay.one.jira.service;
 import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
 import com.liferay.one.jira.exception.JiraAssetObjectException;
 import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
@@ -115,6 +117,25 @@ public class JiraAssetService {
 		}
 
 		return _resolveToObjectIds(converter, externalKeys, null);
+	}
+
+	/**
+	 * Returns the asset objects of the converter's type that match the AQL
+	 * criteria appended by the consumer.
+	 *
+	 * @param  converter the converter describing the asset object type
+	 * @param  consumer the consumer that appends criteria to the type's base
+	 *         AQL
+	 *
+	 * @return the matching asset objects
+	 */
+	public List<JiraAssetObject> getJiraAssetObjects(
+		BaseJiraAssetObjectConverter converter,
+		Consumer<AQLUtil.Builder> consumer) {
+
+		return _jiraAssetPersistence.searchObjects(
+			converter.getAQLWithBuilder(consumer),
+			converter::toJiraAssetObject);
 	}
 
 	/**

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -232,6 +233,38 @@ public class JiraAssetService {
 			externalUpdatedAt,
 			existingJiraAssetObject.getAttributeValue(
 				externalUpdatedAtAttributeName));
+	}
+
+	/**
+	 * Returns <code>true</code> if the asset object's external updated at
+	 * attribute value is on or after the given date, meaning another sync has
+	 * written the asset object since the date was captured.
+	 *
+	 * @param  converter the converter describing the asset object type
+	 * @param  date the date to compare against
+	 * @param  jiraAssetObject the asset object to check
+	 *
+	 * @return <code>true</code> if the asset object was updated on or after
+	 *         the given date
+	 */
+	public boolean isUpdatedSince(
+		BaseJiraAssetObjectConverter converter, Date date,
+		JiraAssetObject jiraAssetObject) {
+
+		String externalUpdatedAt = jiraAssetObject.getAttributeValue(
+			converter.getExternalUpdatedAtAttributeName());
+
+		if (Validator.isNull(externalUpdatedAt)) {
+			return false;
+		}
+
+		String formattedDate = converter.formatDate(date);
+
+		if (externalUpdatedAt.compareTo(formattedDate) >= 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	public void upsert(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -16,6 +16,8 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -47,6 +49,51 @@ public class AccountOrganizationSynchronizer {
 			accountExternalKey,
 			() -> _syncAssignment(
 				organizationExternalKey, accountExternalKey, true));
+	}
+
+	public void syncUnassignStaleOrganizations(
+		String accountExternalKey, Set<String> organizationExternalKeys) {
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetService.getJiraAssetObjects(
+				_accountTeamRoleAssignmentConverter,
+				aqlBuilder -> {
+					aqlBuilder.andEquals(
+						accountExternalKey,
+						AccountTeamRoleAssignmentConstants.
+							ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
+					).andEquals(
+						false,
+						AccountTeamRoleAssignmentConstants.
+							ATTRIBUTE_NAME_DELETED
+					);
+
+					if (!organizationExternalKeys.isEmpty()) {
+						aqlBuilder.andNotIn(
+							organizationExternalKeys,
+							AccountTeamRoleAssignmentConstants.
+								ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY);
+					}
+				});
+
+		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			String organizationExternalKey = jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY);
+
+			try {
+				syncUnassignOrganization(
+					organizationExternalKey, accountExternalKey);
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to unassign stale organization ",
+						organizationExternalKey, " from account ",
+						accountExternalKey),
+					exception);
+			}
+		}
 	}
 
 	private void _syncAssignment(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -18,6 +18,7 @@ import com.liferay.petra.string.StringBundler;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,7 +39,7 @@ public class AccountOrganizationSynchronizer {
 		_jiraSyncLock.withLock(
 			accountExternalKey,
 			() -> _syncAssignment(
-				organizationExternalKey, accountExternalKey, false));
+				organizationExternalKey, accountExternalKey, false, null));
 	}
 
 	public void syncUnassignOrganization(
@@ -48,11 +49,12 @@ public class AccountOrganizationSynchronizer {
 		_jiraSyncLock.withLock(
 			accountExternalKey,
 			() -> _syncAssignment(
-				organizationExternalKey, accountExternalKey, true));
+				organizationExternalKey, accountExternalKey, true, null));
 	}
 
 	public void syncUnassignStaleOrganizations(
-		String accountExternalKey, Set<String> organizationExternalKeys) {
+		String accountExternalKey, Set<String> organizationExternalKeys,
+		Date startDate) {
 
 		List<JiraAssetObject> jiraAssetObjects =
 			_jiraAssetService.getJiraAssetObjects(
@@ -82,8 +84,14 @@ public class AccountOrganizationSynchronizer {
 					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY);
 
 			try {
-				syncUnassignOrganization(
-					organizationExternalKey, accountExternalKey);
+				_jiraSyncLock.withLock(
+					accountExternalKey,
+					() -> _syncAssignment(
+						organizationExternalKey, accountExternalKey, true,
+						(existingJiraAssetObject, newJiraAssetObject) ->
+							_jiraAssetService.isUpdatedSince(
+								_accountTeamRoleAssignmentConverter, startDate,
+								existingJiraAssetObject)));
 			}
 			catch (Exception exception) {
 				_log.error(
@@ -98,7 +106,9 @@ public class AccountOrganizationSynchronizer {
 
 	private void _syncAssignment(
 		String organizationExternalKey, String accountExternalKey,
-		boolean deleted) {
+		boolean deleted,
+		BiPredicate<JiraAssetObject, JiraAssetObject>
+			shouldSkipUpdateBiPredicate) {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -128,7 +138,8 @@ public class AccountOrganizationSynchronizer {
 				_accountConverter, accountExternalKey));
 
 		_jiraAssetService.upsert(
-			_accountTeamRoleAssignmentConverter, jiraAssetObject);
+			_accountTeamRoleAssignmentConverter, jiraAssetObject,
+			shouldSkipUpdateBiPredicate);
 	}
 
 	private static final Log _log = LogFactory.getLog(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -50,9 +50,11 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -411,7 +413,12 @@ public class AccountSynchronizer {
 	private void _syncAccountOrganizationAssignments(
 		Account account, List<Organization> organizations) {
 
+		Set<String> organizationExternalKeys = new LinkedHashSet<>();
+
 		for (Organization organization : organizations) {
+			organizationExternalKeys.add(
+				organization.getExternalReferenceCode());
+
 			try {
 				_accountOrganizationSynchronizer.syncAssignOrganization(
 					organization.getExternalReferenceCode(),
@@ -426,10 +433,24 @@ public class AccountSynchronizer {
 					exception);
 			}
 		}
+
+		try {
+			_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+				account.getExternalReferenceCode(), organizationExternalKeys);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to unassign stale organizations from account " +
+					account.getExternalReferenceCode(),
+				exception);
+		}
 	}
 
 	private void _syncContactRoleAssignments(
 		Account account, List<UserAccount> accountUserAccounts) {
+
+		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey =
+			new LinkedHashMap<>();
 
 		for (UserAccount accountUserAccount : accountUserAccounts) {
 			AccountBrief accountBrief = FindUtil.findFirst(
@@ -448,7 +469,15 @@ public class AccountSynchronizer {
 				continue;
 			}
 
+			Set<String> roleExternalKeys = new LinkedHashSet<>();
+
+			roleExternalKeysByUserAccountExternalKey.put(
+				accountUserAccount.getExternalReferenceCode(),
+				roleExternalKeys);
+
 			for (RoleBrief roleBrief : roleBriefs) {
+				roleExternalKeys.add(roleBrief.getExternalReferenceCode());
+
 				try {
 					_accountUserAccountRoleSynchronizer.syncAssignRole(
 						roleBrief.getExternalReferenceCode(),
@@ -463,6 +492,18 @@ public class AccountSynchronizer {
 						exception);
 				}
 			}
+		}
+
+		try {
+			_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+				account.getExternalReferenceCode(),
+				roleExternalKeysByUserAccountExternalKey);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to unassign stale contact roles for account " +
+					account.getExternalReferenceCode(),
+				exception);
 		}
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -49,6 +49,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -90,6 +91,8 @@ public class AccountSynchronizer {
 					" to JSM");
 		}
 
+		Date startDate = new Date();
+
 		List<UserAccount> accountUserAccounts =
 			_userAccountService.getAccountUserAccounts(account.getId());
 		List<Organization> accountOrganizations =
@@ -102,8 +105,9 @@ public class AccountSynchronizer {
 			account, accountAttributeValues, account.getExternalReferenceCode(),
 			account.getName());
 
-		_syncContactRoleAssignments(account, accountUserAccounts);
-		_syncAccountOrganizationAssignments(account, accountOrganizations);
+		_syncContactRoleAssignments(account, accountUserAccounts, startDate);
+		_syncAccountOrganizationAssignments(
+			account, accountOrganizations, startDate);
 
 		List<Project> projects = _projectService.getProjects(account.getId());
 
@@ -411,7 +415,7 @@ public class AccountSynchronizer {
 	}
 
 	private void _syncAccountOrganizationAssignments(
-		Account account, List<Organization> organizations) {
+		Account account, List<Organization> organizations, Date startDate) {
 
 		Set<String> organizationExternalKeys = new LinkedHashSet<>();
 
@@ -436,7 +440,8 @@ public class AccountSynchronizer {
 
 		try {
 			_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
-				account.getExternalReferenceCode(), organizationExternalKeys);
+				account.getExternalReferenceCode(), organizationExternalKeys,
+				startDate);
 		}
 		catch (Exception exception) {
 			_log.error(
@@ -447,7 +452,8 @@ public class AccountSynchronizer {
 	}
 
 	private void _syncContactRoleAssignments(
-		Account account, List<UserAccount> accountUserAccounts) {
+		Account account, List<UserAccount> accountUserAccounts,
+		Date startDate) {
 
 		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey =
 			new LinkedHashMap<>();
@@ -497,7 +503,7 @@ public class AccountSynchronizer {
 		try {
 			_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
 				account.getExternalReferenceCode(),
-				roleExternalKeysByUserAccountExternalKey);
+				roleExternalKeysByUserAccountExternalKey, startDate);
 		}
 		catch (Exception exception) {
 			_log.error(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -39,7 +40,8 @@ public class AccountUserAccountRoleSynchronizer {
 		throws Exception {
 
 		_syncAssignment(
-			roleExternalKey, userAccountExternalKey, accountExternalKey, false);
+			roleExternalKey, userAccountExternalKey, accountExternalKey, false,
+			null);
 	}
 
 	public void syncUnassignRole(
@@ -48,12 +50,14 @@ public class AccountUserAccountRoleSynchronizer {
 		throws Exception {
 
 		_syncAssignment(
-			roleExternalKey, userAccountExternalKey, accountExternalKey, true);
+			roleExternalKey, userAccountExternalKey, accountExternalKey, true,
+			null);
 	}
 
 	public void syncUnassignStaleRoles(
 		String accountExternalKey,
-		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey) {
+		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey,
+		Date startDate) {
 
 		Set<String> names = new LinkedHashSet<>();
 
@@ -98,9 +102,13 @@ public class AccountUserAccountRoleSynchronizer {
 					ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY);
 
 			try {
-				syncUnassignRole(
-					roleExternalKey, userAccountExternalKey,
-					accountExternalKey);
+				_syncAssignment(
+					roleExternalKey, userAccountExternalKey, accountExternalKey,
+					true,
+					(existingJiraAssetObject, newJiraAssetObject) ->
+						_jiraAssetService.isUpdatedSince(
+							_accountContactRoleAssignmentConverter, startDate,
+							existingJiraAssetObject));
 			}
 			catch (Exception exception) {
 				_log.error(
@@ -115,19 +123,23 @@ public class AccountUserAccountRoleSynchronizer {
 
 	private void _syncAssignment(
 			String roleExternalKey, String userAccountExternalKey,
-			String accountExternalKey, boolean deleted)
+			String accountExternalKey, boolean deleted,
+			BiPredicate<JiraAssetObject, JiraAssetObject>
+				shouldSkipUpdateBiPredicate)
 		throws Exception {
 
 		_jiraSyncLock.withLock(
 			userAccountExternalKey,
 			() -> _syncAssignmentWithinLock(
 				roleExternalKey, userAccountExternalKey, accountExternalKey,
-				deleted));
+				deleted, shouldSkipUpdateBiPredicate));
 	}
 
 	private void _syncAssignmentWithinLock(
 		String roleExternalKey, String userAccountExternalKey,
-		String accountExternalKey, boolean deleted) {
+		String accountExternalKey, boolean deleted,
+		BiPredicate<JiraAssetObject, JiraAssetObject>
+			shouldSkipUpdateBiPredicate) {
 
 		if (_log.isInfoEnabled()) {
 			_log.info(
@@ -157,7 +169,8 @@ public class AccountUserAccountRoleSynchronizer {
 				_accountConverter, accountExternalKey));
 
 		_jiraAssetService.upsert(
-			_accountContactRoleAssignmentConverter, jiraAssetObject);
+			_accountContactRoleAssignmentConverter, jiraAssetObject,
+			shouldSkipUpdateBiPredicate);
 	}
 
 	private static final Log _log = LogFactory.getLog(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
@@ -16,6 +16,10 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,6 +49,68 @@ public class AccountUserAccountRoleSynchronizer {
 
 		_syncAssignment(
 			roleExternalKey, userAccountExternalKey, accountExternalKey, true);
+	}
+
+	public void syncUnassignStaleRoles(
+		String accountExternalKey,
+		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey) {
+
+		Set<String> names = new LinkedHashSet<>();
+
+		for (Map.Entry<String, Set<String>> entry :
+				roleExternalKeysByUserAccountExternalKey.entrySet()) {
+
+			for (String roleExternalKey : entry.getValue()) {
+				names.add(
+					_accountContactRoleAssignmentConverter.getName(
+						roleExternalKey, entry.getKey(), accountExternalKey));
+			}
+		}
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetService.getJiraAssetObjects(
+				_accountContactRoleAssignmentConverter,
+				aqlBuilder -> {
+					aqlBuilder.andEquals(
+						accountExternalKey,
+						AccountContactRoleAssignmentConstants.
+							ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
+					).andEquals(
+						false,
+						AccountContactRoleAssignmentConstants.
+							ATTRIBUTE_NAME_DELETED
+					);
+
+					if (!names.isEmpty()) {
+						aqlBuilder.andNotIn(
+							names,
+							AccountContactRoleAssignmentConstants.
+								ATTRIBUTE_NAME_NAME);
+					}
+				});
+
+		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			String roleExternalKey = jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY);
+			String userAccountExternalKey = jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY);
+
+			try {
+				syncUnassignRole(
+					roleExternalKey, userAccountExternalKey,
+					accountExternalKey);
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to unassign stale role ", roleExternalKey,
+						" for user account ", userAccountExternalKey,
+						" on account ", accountExternalKey),
+					exception);
+			}
+		}
 	}
 
 	private void _syncAssignment(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
@@ -29,6 +29,15 @@ public class AQLUtil {
 
 	public static class Builder {
 
+		public Builder andEquals(boolean value, String... fieldNames) {
+			_sb.append(" AND ");
+			_sb.append(_field(fieldNames));
+			_sb.append(" = ");
+			_sb.append(value);
+
+			return this;
+		}
+
 		public Builder andEquals(String value, String... fieldNames) {
 			_sb.append(" AND ");
 			_sb.append(_field(fieldNames));
@@ -56,6 +65,26 @@ public class AQLUtil {
 			_sb.append(" AND ");
 			_sb.append(_field(fieldNames));
 			_sb.append(" IN (");
+			_sb.append(
+				StringUtil.merge(
+					TransformUtil.transform(values, AQLUtil::_quote),
+					StringPool.COMMA_AND_SPACE));
+			_sb.append(")");
+
+			return this;
+		}
+
+		public Builder andNotIn(
+			Collection<String> values, String... fieldNames) {
+
+			if (values.isEmpty()) {
+				throw new IllegalArgumentException(
+					"A NOT IN clause requires at least one value");
+			}
+
+			_sb.append(" AND ");
+			_sb.append(_field(fieldNames));
+			_sb.append(" NOT IN (");
 			_sb.append(
 				StringUtil.merge(
 					TransformUtil.transform(values, AQLUtil::_quote),

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
@@ -10,6 +10,7 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.synchronizer.LockSerializationTestHelper;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -200,6 +201,125 @@ public class JiraAssetServiceTest {
 		).createObject(
 			Mockito.any(), Mockito.any()
 		);
+	}
+
+	@Test
+	public void testIsUpdatedSinceReturnsFalseForMissingExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Assertions.assertFalse(
+			_jiraAssetService.isUpdatedSince(
+				_converter, new Date(), Mockito.mock(JiraAssetObject.class)));
+	}
+
+	@Test
+	public void testIsUpdatedSinceReturnsFalseForOlderExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Date date = new Date();
+
+		Assertions.assertFalse(
+			_jiraAssetService.isUpdatedSince(
+				_converter, date,
+				_mockJiraAssetObjectUpdatedAt(
+					new Date(date.getTime() - 60000))));
+	}
+
+	@Test
+	public void testIsUpdatedSinceReturnsTrueForSameOrNewerExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Date date = new Date();
+
+		Assertions.assertTrue(
+			_jiraAssetService.isUpdatedSince(
+				_converter, date, _mockJiraAssetObjectUpdatedAt(date)));
+		Assertions.assertTrue(
+			_jiraAssetService.isUpdatedSince(
+				_converter, date,
+				_mockJiraAssetObjectUpdatedAt(
+					new Date(date.getTime() + 60000))));
+	}
+
+	@Test
+	public void testUpsertSkipsUpdateForMatchingBiPredicate() throws Exception {
+		JiraAssetObject jiraAssetObject = _mockUpsertJiraAssetObject();
+
+		_jiraAssetService.upsert(
+			_converter, jiraAssetObject,
+			(existingJiraAssetObject, newJiraAssetObject) -> true);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).updateObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testUpsertUpdatesForNonmatchingBiPredicate() throws Exception {
+		JiraAssetObject jiraAssetObject = _mockUpsertJiraAssetObject();
+
+		_jiraAssetService.upsert(
+			_converter, jiraAssetObject,
+			(existingJiraAssetObject, newJiraAssetObject) -> false);
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).updateObject(
+			_OBJECT_ID, jiraAssetObject
+		);
+	}
+
+	private void _mockExternalUpdatedAt() {
+		Mockito.when(
+			_converter.formatDate(Mockito.any())
+		).thenCallRealMethod();
+
+		Mockito.when(
+			_converter.getExternalUpdatedAtAttributeName()
+		).thenReturn(
+			"External Updated At"
+		);
+	}
+
+	private JiraAssetObject _mockJiraAssetObjectUpdatedAt(Date date) {
+		String externalUpdatedAt = _converter.formatDate(date);
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue("External Updated At")
+		).thenReturn(
+			externalUpdatedAt
+		);
+
+		return jiraAssetObject;
+	}
+
+	private JiraAssetObject _mockUpsertJiraAssetObject() {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue("External Key")
+		).thenReturn(
+			_EXTERNAL_KEY
+		);
+
+		return jiraAssetObject;
 	}
 
 	private static final String _EXTERNAL_KEY = "test-external-key";

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
@@ -119,6 +119,22 @@ public class JiraAssetServiceTest {
 	}
 
 	@Test
+	public void testGetJiraAssetObjectsSearchesWithConverterAQL()
+		throws Exception {
+
+		Mockito.when(
+			_jiraAssetPersistence.<JiraAssetObject>searchObjects(
+				Mockito.eq("aql"), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		Assertions.assertEquals(
+			Collections.singletonList(_existingJiraAssetObject),
+			_jiraAssetService.getJiraAssetObjects(_converter, null));
+	}
+
+	@Test
 	public void testGetOrCreateReferenceObjectIdsWaitsForUpsert()
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -16,13 +16,16 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -83,7 +86,7 @@ public class AccountOrganizationSynchronizerTest {
 		).when(
 			_jiraAssetService
 		).upsert(
-			Mockito.any(), Mockito.any()
+			Mockito.any(), Mockito.any(), Mockito.any()
 		);
 
 		lockSerializationTestHelper.assertSerialized(
@@ -102,7 +105,7 @@ public class AccountOrganizationSynchronizerTest {
 
 		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
 			_ACCOUNT_EXTERNAL_KEY,
-			Collections.singleton(_ORGANIZATION_EXTERNAL_KEY));
+			Collections.singleton(_ORGANIZATION_EXTERNAL_KEY), new Date());
 
 		Assertions.assertEquals(
 			StringBundler.concat(
@@ -119,12 +122,59 @@ public class AccountOrganizationSynchronizerTest {
 		AtomicReference<String> aqlAtomicReference = _captureAQL();
 
 		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
-			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet());
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet(), new Date());
 
 		Assertions.assertEquals(
 			"base AND \"Account External Key\" = \"account-erc\" AND " +
 				"\"Deleted\" = false",
 			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleOrganizationsSkipsFreshAssignments()
+		throws Exception {
+
+		JiraAssetObject jiraAssetObject = _mockAssignment();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		Date startDate = new Date();
+
+		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet(), startDate);
+
+		ArgumentCaptor<BiPredicate<JiraAssetObject, JiraAssetObject>>
+			biPredicateArgumentCaptor = ArgumentCaptor.forClass(
+				BiPredicate.class);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
+			biPredicateArgumentCaptor.capture()
+		);
+
+		JiraAssetObject existingJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			_jiraAssetService.isUpdatedSince(
+				_accountTeamRoleAssignmentConverter, startDate,
+				existingJiraAssetObject)
+		).thenReturn(
+			true
+		);
+
+		BiPredicate<JiraAssetObject, JiraAssetObject> biPredicate =
+			biPredicateArgumentCaptor.getValue();
+
+		Assertions.assertTrue(
+			biPredicate.test(
+				existingJiraAssetObject, Mockito.mock(JiraAssetObject.class)));
 	}
 
 	@Test
@@ -140,7 +190,7 @@ public class AccountOrganizationSynchronizerTest {
 		);
 
 		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
-			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet());
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet(), new Date());
 
 		Mockito.verify(
 			_accountTeamRoleAssignmentConverter
@@ -152,7 +202,8 @@ public class AccountOrganizationSynchronizerTest {
 		Mockito.verify(
 			_jiraAssetService
 		).upsert(
-			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any()
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
+			Mockito.any()
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -5,13 +5,21 @@
 
 package com.liferay.one.jira.synchronizer;
 
+import com.liferay.one.jira.constants.AccountTeamRoleAssignmentConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.petra.string.StringBundler;
 
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,11 +39,11 @@ public class AccountOrganizationSynchronizerTest {
 
 		_jiraAssetService = Mockito.mock(JiraAssetService.class);
 
-		AccountTeamRoleAssignmentConverter accountTeamRoleAssignmentConverter =
-			Mockito.mock(AccountTeamRoleAssignmentConverter.class);
+		_accountTeamRoleAssignmentConverter = Mockito.mock(
+			AccountTeamRoleAssignmentConverter.class);
 
 		Mockito.when(
-			accountTeamRoleAssignmentConverter.toAssetObject(
+			_accountTeamRoleAssignmentConverter.toAssetObject(
 				Mockito.any(), Mockito.any(), Mockito.any(),
 				Mockito.anyBoolean(), Mockito.any())
 		).thenReturn(
@@ -48,7 +56,7 @@ public class AccountOrganizationSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_accountOrganizationSynchronizer,
 			"_accountTeamRoleAssignmentConverter",
-			accountTeamRoleAssignmentConverter);
+			_accountTeamRoleAssignmentConverter);
 		ReflectionTestUtils.setField(
 			_accountOrganizationSynchronizer, "_jiraAssetService",
 			_jiraAssetService);
@@ -86,7 +94,111 @@ public class AccountOrganizationSynchronizerTest {
 			"upsert", "upsert");
 	}
 
+	@Test
+	public void testSyncUnassignStaleOrganizationsExcludesCurrentAssignments()
+		throws Exception {
+
+		AtomicReference<String> aqlAtomicReference = _captureAQL();
+
+		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+			_ACCOUNT_EXTERNAL_KEY,
+			Collections.singleton(_ORGANIZATION_EXTERNAL_KEY));
+
+		Assertions.assertEquals(
+			StringBundler.concat(
+				"base AND \"Account External Key\" = \"account-erc\" AND ",
+				"\"Deleted\" = false AND \"Team External Key\" NOT IN ",
+				"(\"organization-erc\")"),
+			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleOrganizationsExcludesDeletedAssignments()
+		throws Exception {
+
+		AtomicReference<String> aqlAtomicReference = _captureAQL();
+
+		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet());
+
+		Assertions.assertEquals(
+			"base AND \"Account External Key\" = \"account-erc\" AND " +
+				"\"Deleted\" = false",
+			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleOrganizationsSoftDeletesStaleAssignments()
+		throws Exception {
+
+		JiraAssetObject jiraAssetObject = _mockAssignment();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptySet());
+
+		Mockito.verify(
+			_accountTeamRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.any(), Mockito.eq(_ORGANIZATION_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(true), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any()
+		);
+	}
+
+	private AtomicReference<String> _captureAQL() {
+		AtomicReference<String> aqlAtomicReference = new AtomicReference<>();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				Consumer<AQLUtil.Builder> consumer = invocation.getArgument(1);
+
+				AQLUtil.Builder aqlBuilder = AQLUtil.builder("base");
+
+				consumer.accept(aqlBuilder);
+
+				aqlAtomicReference.set(aqlBuilder.build());
+
+				return Collections.emptyList();
+			}
+		);
+
+		return aqlAtomicReference;
+	}
+
+	private JiraAssetObject _mockAssignment() {
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY)
+		).thenReturn(
+			_ORGANIZATION_EXTERNAL_KEY
+		);
+
+		return jiraAssetObject;
+	}
+
+	private static final String _ACCOUNT_EXTERNAL_KEY = "account-erc";
+
+	private static final String _ORGANIZATION_EXTERNAL_KEY = "organization-erc";
+
 	private AccountOrganizationSynchronizer _accountOrganizationSynchronizer;
+	private AccountTeamRoleAssignmentConverter
+		_accountTeamRoleAssignmentConverter;
 	private JiraAssetService _jiraAssetService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -30,6 +30,7 @@ import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
 
 import java.util.Collections;
+import java.util.Date;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -239,15 +240,19 @@ public class AccountSynchronizerTest {
 		Mockito.verify(
 			_accountOrganizationSynchronizer
 		).syncUnassignStaleOrganizations(
-			_EXTERNAL_REFERENCE_CODE, Collections.singleton("organization-erc")
+			Mockito.eq(_EXTERNAL_REFERENCE_CODE),
+			Mockito.eq(Collections.singleton("organization-erc")),
+			Mockito.any(Date.class)
 		);
 
 		Mockito.verify(
 			_accountUserAccountRoleSynchronizer
 		).syncUnassignStaleRoles(
-			_EXTERNAL_REFERENCE_CODE,
-			Collections.singletonMap(
-				"user-account-erc", Collections.singleton("role-erc"))
+			Mockito.eq(_EXTERNAL_REFERENCE_CODE),
+			Mockito.eq(
+				Collections.singletonMap(
+					"user-account-erc", Collections.singleton("role-erc"))),
+			Mockito.any(Date.class)
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -6,6 +6,10 @@
 package com.liferay.one.jira.synchronizer;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.constants.AccountConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
@@ -76,11 +80,10 @@ public class AccountSynchronizerTest {
 			Collections.emptyList()
 		);
 
-		OrganizationService organizationService = Mockito.mock(
-			OrganizationService.class);
+		_organizationService = Mockito.mock(OrganizationService.class);
 
 		Mockito.when(
-			organizationService.getAccountOrganizations(Mockito.anyLong())
+			_organizationService.getAccountOrganizations(Mockito.anyLong())
 		).thenReturn(
 			Collections.emptyList()
 		);
@@ -101,23 +104,27 @@ public class AccountSynchronizerTest {
 			Collections.emptyList()
 		);
 
-		UserAccountService userAccountService = Mockito.mock(
-			UserAccountService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
 
 		Mockito.when(
-			userAccountService.getAccountUserAccounts(Mockito.anyLong())
+			_userAccountService.getAccountUserAccounts(Mockito.anyLong())
 		).thenReturn(
 			Collections.emptyList()
 		);
+
+		_accountOrganizationSynchronizer = Mockito.mock(
+			AccountOrganizationSynchronizer.class);
+		_accountUserAccountRoleSynchronizer = Mockito.mock(
+			AccountUserAccountRoleSynchronizer.class);
 
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_accountConverter", accountConverter);
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_accountOrganizationSynchronizer",
-			Mockito.mock(AccountOrganizationSynchronizer.class));
+			_accountOrganizationSynchronizer);
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_accountUserAccountRoleSynchronizer",
-			Mockito.mock(AccountUserAccountRoleSynchronizer.class));
+			_accountUserAccountRoleSynchronizer);
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_commerceOrderService",
 			commerceOrderService);
@@ -141,7 +148,7 @@ public class AccountSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_jiraSyncLock", new JiraSyncLock());
 		ReflectionTestUtils.setField(
-			_accountSynchronizer, "_organizationService", organizationService);
+			_accountSynchronizer, "_organizationService", _organizationService);
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_postalAddressConverter",
 			Mockito.mock(PostalAddressConverter.class));
@@ -153,7 +160,7 @@ public class AccountSynchronizerTest {
 			_accountSynchronizer, "_teamConverter",
 			Mockito.mock(TeamConverter.class));
 		ReflectionTestUtils.setField(
-			_accountSynchronizer, "_userAccountService", userAccountService);
+			_accountSynchronizer, "_userAccountService", _userAccountService);
 	}
 
 	@Test
@@ -187,6 +194,61 @@ public class AccountSynchronizerTest {
 			() -> _accountSynchronizer.syncAccount(account),
 			() -> _accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE),
 			"upsert", "delete");
+	}
+
+	@Test
+	public void testSyncAccountUnassignsStaleAssignments() throws Exception {
+		RoleBrief roleBrief = new RoleBrief();
+
+		roleBrief.setExternalReferenceCode("role-erc");
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		accountBrief.setRoleBriefs(new RoleBrief[] {roleBrief});
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
+		userAccount.setExternalReferenceCode("user-account-erc");
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(Mockito.anyLong())
+		).thenReturn(
+			Collections.singletonList(userAccount)
+		);
+
+		Organization organization = new Organization();
+
+		organization.setExternalReferenceCode("organization-erc");
+
+		Mockito.when(
+			_organizationService.getAccountOrganizations(Mockito.anyLong())
+		).thenReturn(
+			Collections.singletonList(organization)
+		);
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		account.setId(1L);
+		account.setName("Test Account");
+
+		_accountSynchronizer.syncAccount(account);
+
+		Mockito.verify(
+			_accountOrganizationSynchronizer
+		).syncUnassignStaleOrganizations(
+			_EXTERNAL_REFERENCE_CODE, Collections.singleton("organization-erc")
+		);
+
+		Mockito.verify(
+			_accountUserAccountRoleSynchronizer
+		).syncUnassignStaleRoles(
+			_EXTERNAL_REFERENCE_CODE,
+			Collections.singletonMap(
+				"user-account-erc", Collections.singleton("role-erc"))
+		);
 	}
 
 	@Test
@@ -225,8 +287,13 @@ public class AccountSynchronizerTest {
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
+	private AccountOrganizationSynchronizer _accountOrganizationSynchronizer;
 	private AccountSynchronizer _accountSynchronizer;
+	private AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer;
 	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
+	private OrganizationService _organizationService;
+	private UserAccountService _userAccountService;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
@@ -17,13 +17,16 @@ import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -92,7 +95,8 @@ public class AccountUserAccountRoleSynchronizerTest {
 			_ACCOUNT_EXTERNAL_KEY,
 			Collections.singletonMap(
 				_USER_ACCOUNT_EXTERNAL_KEY,
-				Collections.singleton(_ROLE_EXTERNAL_KEY)));
+				Collections.singleton(_ROLE_EXTERNAL_KEY)),
+			new Date());
 
 		Assertions.assertEquals(
 			StringBundler.concat(
@@ -109,12 +113,59 @@ public class AccountUserAccountRoleSynchronizerTest {
 		AtomicReference<String> aqlAtomicReference = _captureAQL();
 
 		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
-			_ACCOUNT_EXTERNAL_KEY, Collections.emptyMap());
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptyMap(), new Date());
 
 		Assertions.assertEquals(
 			"base AND \"Account External Key\" = \"account-erc\" AND " +
 				"\"Deleted\" = false",
 			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesSkipsFreshAssignments()
+		throws Exception {
+
+		JiraAssetObject jiraAssetObject = _mockAssignment(_ROLE_EXTERNAL_KEY);
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		Date startDate = new Date();
+
+		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptyMap(), startDate);
+
+		ArgumentCaptor<BiPredicate<JiraAssetObject, JiraAssetObject>>
+			biPredicateArgumentCaptor = ArgumentCaptor.forClass(
+				BiPredicate.class);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any(),
+			biPredicateArgumentCaptor.capture()
+		);
+
+		JiraAssetObject existingJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			_jiraAssetService.isUpdatedSince(
+				_accountContactRoleAssignmentConverter, startDate,
+				existingJiraAssetObject)
+		).thenReturn(
+			true
+		);
+
+		BiPredicate<JiraAssetObject, JiraAssetObject> biPredicate =
+			biPredicateArgumentCaptor.getValue();
+
+		Assertions.assertTrue(
+			biPredicate.test(
+				existingJiraAssetObject, Mockito.mock(JiraAssetObject.class)));
 	}
 
 	@Test
@@ -133,7 +184,8 @@ public class AccountUserAccountRoleSynchronizerTest {
 			_ACCOUNT_EXTERNAL_KEY,
 			Collections.singletonMap(
 				_USER_ACCOUNT_EXTERNAL_KEY,
-				Collections.singleton("other-role-erc")));
+				Collections.singleton("other-role-erc")),
+			new Date());
 
 		Mockito.verify(
 			_accountContactRoleAssignmentConverter
@@ -146,7 +198,8 @@ public class AccountUserAccountRoleSynchronizerTest {
 		Mockito.verify(
 			_jiraAssetService
 		).upsert(
-			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any()
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any(),
+			Mockito.any()
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.AccountContactRoleAssignmentConstants;
+import com.liferay.one.jira.converter.AccountContactRoleAssignmentConverter;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.ContactRoleConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.AQLUtil;
+import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountUserAccountRoleSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_accountUserAccountRoleSynchronizer =
+			new AccountUserAccountRoleSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
+		_accountContactRoleAssignmentConverter = Mockito.mock(
+			AccountContactRoleAssignmentConverter.class);
+
+		Mockito.when(
+			_accountContactRoleAssignmentConverter.getName(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenAnswer(
+			invocation -> StringBundler.concat(
+				invocation.getArgument(0), ";", invocation.getArgument(1), ";",
+				invocation.getArgument(2))
+		);
+
+		Mockito.when(
+			_accountContactRoleAssignmentConverter.toAssetObject(
+				Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.anyBoolean(), Mockito.any())
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer,
+			"_accountContactRoleAssignmentConverter",
+			_accountContactRoleAssignmentConverter);
+
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer, "_accountConverter",
+			Mockito.mock(AccountConverter.class));
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer, "_contactConverter",
+			Mockito.mock(ContactConverter.class));
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer, "_contactRoleConverter",
+			Mockito.mock(ContactRoleConverter.class));
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer, "_jiraAssetService",
+			_jiraAssetService);
+		ReflectionTestUtils.setField(
+			_accountUserAccountRoleSynchronizer, "_jiraSyncLock",
+			new JiraSyncLock());
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesExcludesCurrentAssignments()
+		throws Exception {
+
+		AtomicReference<String> aqlAtomicReference = _captureAQL();
+
+		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+			_ACCOUNT_EXTERNAL_KEY,
+			Collections.singletonMap(
+				_USER_ACCOUNT_EXTERNAL_KEY,
+				Collections.singleton(_ROLE_EXTERNAL_KEY)));
+
+		Assertions.assertEquals(
+			StringBundler.concat(
+				"base AND \"Account External Key\" = \"account-erc\" AND ",
+				"\"Deleted\" = false AND \"Name\" NOT IN ",
+				"(\"role-erc;user-account-erc;account-erc\")"),
+			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesExcludesDeletedAssignments()
+		throws Exception {
+
+		AtomicReference<String> aqlAtomicReference = _captureAQL();
+
+		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+			_ACCOUNT_EXTERNAL_KEY, Collections.emptyMap());
+
+		Assertions.assertEquals(
+			"base AND \"Account External Key\" = \"account-erc\" AND " +
+				"\"Deleted\" = false",
+			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesSoftDeletesStaleAssignments()
+		throws Exception {
+
+		JiraAssetObject jiraAssetObject = _mockAssignment(_ROLE_EXTERNAL_KEY);
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+			_ACCOUNT_EXTERNAL_KEY,
+			Collections.singletonMap(
+				_USER_ACCOUNT_EXTERNAL_KEY,
+				Collections.singleton("other-role-erc")));
+
+		Mockito.verify(
+			_accountContactRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.eq(_ROLE_EXTERNAL_KEY),
+			Mockito.eq(_USER_ACCOUNT_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(true), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any()
+		);
+	}
+
+	private AtomicReference<String> _captureAQL() {
+		AtomicReference<String> aqlAtomicReference = new AtomicReference<>();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				Consumer<AQLUtil.Builder> consumer = invocation.getArgument(1);
+
+				AQLUtil.Builder aqlBuilder = AQLUtil.builder("base");
+
+				consumer.accept(aqlBuilder);
+
+				aqlAtomicReference.set(aqlBuilder.build());
+
+				return Collections.emptyList();
+			}
+		);
+
+		return aqlAtomicReference;
+	}
+
+	private JiraAssetObject _mockAssignment(String roleExternalKey) {
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY)
+		).thenReturn(
+			_USER_ACCOUNT_EXTERNAL_KEY
+		);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY)
+		).thenReturn(
+			roleExternalKey
+		);
+
+		return jiraAssetObject;
+	}
+
+	private static final String _ACCOUNT_EXTERNAL_KEY = "account-erc";
+
+	private static final String _ROLE_EXTERNAL_KEY = "role-erc";
+
+	private static final String _USER_ACCOUNT_EXTERNAL_KEY = "user-account-erc";
+
+	private AccountContactRoleAssignmentConverter
+		_accountContactRoleAssignmentConverter;
+	private AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer;
+	private JiraAssetService _jiraAssetService;
+
+}


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-99654](https://liferay.atlassian.net/browse/LPD-99654)

## What is being fixed

When an account's memberships change in Liferay, the JSM account sync only ever added or updated assignments. A contact role or organization assignment removed on the Liferay side stayed live in JSM indefinitely, so Assets automation keyed on those assignments (first-line support routing) kept acting on memberships that no longer exist.

## How it is being fixed

A full account sync now finishes with a stale-assignment sweep. After upserting the current memberships, it queries JSM for live Account Contact Role Assignment and Account Team Role Assignment objects on the account that are not in the current membership set and soft-deletes each one through the existing unassign path. JiraAssetService#getJiraAssetObjects centralizes converter-scoped AQL searches, and AQLUtil.Builder gains boolean equals and NOT IN clauses to express the queries.

Because the sweep decides staleness from a membership snapshot, a concurrent webhook assign landing mid-sync could otherwise be tombstoned by mistake. Each tombstone upsert therefore carries a skip predicate evaluated under the asset-level lock: when the existing assignment's External Updated At is on or after the sync's start date, the tombstone is skipped, so the newer write wins in either ordering.

Verified by unit tests and the end-to-end stale-assignment suite against JSM (18/18: baseline sync, idempotent re-run, tombstone on user and organization removal, un-tombstone on re-add).

[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-99654]: https://liferay.atlassian.net/browse/LPD-99654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ