### PR TITLE
LPD-101369 Fix Enterprise Search upload type and row actions menu

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -1368,6 +1368,7 @@ export default {
 		'Unable to download your license file.  Please try again and/or contact support via the manage menu on the dashboard.',
 	'unable-to-invite-member': 'Unable to invite member.',
 	'unable-to-invite-project-member': 'Unable to invite project member.',
+	'unable-to-load-the-license-keys': 'Unable to load the license keys.',
 	'unable-to-remove-member': 'Unable to remove member.',
 	'unable-to-remove-roles': 'Unable to remove roles',
 	'unable-to-update-account-details': 'Unable to update account details',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/es_ES.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/es_ES.ts
@@ -122,6 +122,8 @@ export default {
 	'unable-to-connect-to-file-server':
 		'No es posible conectarse al servidor de archivos',
 	'unable-to-delete-attachment': 'No se pudo eliminar el adjunto.',
+	'unable-to-load-the-license-keys':
+		'No se pudieron cargar las claves de licencia.',
 	'upgrade': 'Actualización',
 	'upload': 'Subir',
 	'user': 'Usuario',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/ja_JP.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/ja_JP.ts
@@ -119,6 +119,7 @@ export default {
 	'try-again-later': '後でもう一度試してください。',
 	'unable-to-connect-to-file-server': 'ファイルサーバーに接続できない',
 	'unable-to-delete-attachment': '添付ファイルを削除できませんでした。',
+	'unable-to-load-the-license-keys': 'ライセンスキーを読み込めませんでした。',
 	'upgrade': 'アップグレード',
 	'upload': 'アップロード',
 	'user': 'ユーザー',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/pt_BR.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/pt_BR.ts
@@ -123,6 +123,8 @@ export default {
 	'unable-to-connect-to-file-server':
 		'Não foi possível conectar ao servidor de arquivos.',
 	'unable-to-delete-attachment': 'Não foi possível excluir o anexo.',
+	'unable-to-load-the-license-keys':
+		'Não foi possível carregar as chaves de licença.',
 	'upgrade': 'Atualização',
 	'upload': 'Enviar',
 	'user': 'Usuário',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
@@ -27,6 +27,11 @@ import useCommonLicenseKeys, {PAGE_SIZE} from './hooks/useCommonLicenseKeys';
 
 type Tab = 'commerce' | 'elasticsearch';
 
+const ACCEPT_BY_PRODUCT_GROUP: Record<ProductGroup, string> = {
+	COMMERCE: '.xml',
+	ENTERPRISE_SEARCH: '.json',
+};
+
 const PRODUCT_GROUP_BY_TAB: Record<Tab, ProductGroup> = {
 	commerce: 'COMMERCE',
 	elasticsearch: 'ENTERPRISE_SEARCH',
@@ -193,7 +198,7 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 			<form className="mb-4" onSubmit={handleUpload}>
 				<div className="align-items-center d-flex">
 					<input
-						accept=".xml"
+						accept={ACCEPT_BY_PRODUCT_GROUP[productGroup]}
 						className="form-control mr-3"
 						multiple
 						onChange={handleFileChange}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
@@ -6,7 +6,7 @@
 import ClayButton from '@clayui/button';
 import {useModal} from '@clayui/modal';
 import ClayTabs from '@clayui/tabs';
-import {ChangeEvent, FormEvent, useRef, useState} from 'react';
+import {ChangeEvent, FormEvent, useEffect, useRef, useState} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import Loading from '~/components/Loading/Loading';
 import Modal from '~/components/Modal/Modal';
@@ -69,7 +69,19 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const deleteModal = useModal();
 
-	const {data, isLoading, mutate} = useCommonLicenseKeys(productGroup, page);
+	const {data, error, isLoading, mutate} = useCommonLicenseKeys(
+		productGroup,
+		page
+	);
+
+	useEffect(() => {
+		if (error) {
+			Liferay.Util.openToast({
+				message: i18n.translate('unable-to-load-the-license-keys'),
+				type: 'danger',
+			});
+		}
+	}, [error]);
 
 	function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
 		setSelectedFiles(Array.from(event.target.files ?? []));

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
@@ -4,15 +4,14 @@
  */
 
 import ClayButton from '@clayui/button';
-import ClayDropDown, {Align} from '@clayui/drop-down';
 import {useModal} from '@clayui/modal';
 import ClayTabs from '@clayui/tabs';
 import {ChangeEvent, FormEvent, useRef, useState} from 'react';
 import {useSearchParams} from 'react-router-dom';
-import ButtonWithIcon from '~/components/ButtonWithIcon/ButtonWithIcon';
 import Loading from '~/components/Loading/Loading';
 import Modal from '~/components/Modal/Modal';
 import Page from '~/components/Page/Page';
+import RowActionsMenu from '~/components/RowActionsMenu/RowActionsMenu';
 import Table from '~/components/Table/Table';
 import i18n from '~/i18n';
 import FetcherError from '~/services/fetcher/FetcherError';
@@ -152,12 +151,10 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 	const totalCount = data?.totalCount ?? 0;
 
 	const RowActions = ({row}: {row: CommonLicenseKey}) => (
-		<ClayDropDown
-			alignmentPosition={Align.BottomCenter}
-			closeOnClick
-			items={[
+		<RowActionsMenu
+			actions={[
 				{
-					label: i18n.translate('download'),
+					label: 'download',
 					onClick: () =>
 						CommonLicenseKeys.downloadCommonLicenseKey(
 							row.id,
@@ -165,7 +162,7 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 						),
 				},
 				{
-					label: i18n.translate('delete'),
+					label: 'delete',
 					onClick: () => {
 						setSelectedKey(row);
 
@@ -173,24 +170,7 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 					},
 				},
 			]}
-			trigger={
-				<ButtonWithIcon
-					aria-label={i18n.translate('actions')}
-					className="btn-monospaced"
-					displayType="unstyled"
-					symbol="ellipsis-v"
-				/>
-			}
-		>
-			{(item, index) => (
-				<ClayDropDown.Item
-					onClick={() => item.onClick()}
-					{...{['keyValue']: index}}
-				>
-					{item.label}
-				</ClayDropDown.Item>
-			)}
-		</ClayDropDown>
+		/>
 	);
 
 	return (


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101369

## What is being fixed

The license key uploads admin page hardcoded a `.xml` file filter, so Enterprise Search license files, which are JSON, could not be selected for upload. The row actions used a bespoke ClayDropDown that differed from the shared menu used by the other tables, and a failed license key list request showed nothing to the user.

## How it is being fixed

The upload input now chooses its accepted file types by product group, `.xml` for Commerce and `.json` for Enterprise Search. The row actions use the shared RowActionsMenu component to match the rest of the UI. When the list request fails, the page shows a danger toast backed by a new unable-to-load-the-license-keys language key added to all supported locales.
