### PR TITLE
LPD-101368 Resolve the DXP endpoint port and log forbidden scopes

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/build.gradle
@@ -128,6 +128,8 @@ buildDockerImage {
 		}
 
 		localEnvironmentFile.text =
-		names.collect { "${it}=unused" }.join("\n") + "\n"
+		names.collect { "${it}=unused" }.join("\n") + "\n" +
+		"LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB_REACTIVE_FUNCTION_CLIENT=DEBUG\n" +
+		"LOGGING_LEVEL_SUN_NET_WWW_PROTOCOL_HTTP=TRACE\n"
 	}
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -142,7 +142,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -154,7 +154,7 @@ public class AccountService extends OneBaseService {
 	public Account fetchAccount(long accountId) throws Exception {
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -179,7 +179,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -217,7 +217,7 @@ public class AccountService extends OneBaseService {
 	public Account getAccount(long accountEntryId, Jwt jwt) throws Exception {
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
 		).build();
@@ -228,7 +228,7 @@ public class AccountService extends OneBaseService {
 	public Account getAccount(String externalReferenceCode) throws Exception {
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -242,7 +242,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
 		).build();
@@ -381,7 +381,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -413,7 +413,7 @@ public class AccountService extends OneBaseService {
 	private AccountRoleResource _buildAccountRoleResource() {
 		return AccountRoleResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -540,7 +540,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -691,7 +691,7 @@ public class AccountService extends OneBaseService {
 
 		AccountResource accountResource = AccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceCatalogService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceCatalogService.java
@@ -21,7 +21,7 @@ public class CommerceCatalogService extends OneBaseService {
 	public Catalog fetchCatalog(String externalReferenceCode) throws Exception {
 		CatalogResource catalogResource = CatalogResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderItemService.java
@@ -162,7 +162,7 @@ public class CommerceOrderItemService extends OneBaseService {
 	private OrderItemResource _buildOrderItemResource() {
 		return OrderItemResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).parameters(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceOrderService.java
@@ -356,7 +356,7 @@ public class CommerceOrderService extends OneBaseService {
 	private CurrencyResource _buildCurrencyResource() {
 		return CurrencyResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -365,7 +365,7 @@ public class CommerceOrderService extends OneBaseService {
 	private OrderResource _buildOrderResource() {
 		return OrderResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).parameters(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommercePriceEntryService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommercePriceEntryService.java
@@ -74,7 +74,7 @@ public class CommercePriceEntryService extends OneBaseService {
 	private PriceEntryResource _buildPriceEntryResource() {
 		return PriceEntryResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommercePriceListService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommercePriceListService.java
@@ -56,7 +56,7 @@ public class CommercePriceListService extends OneBaseService {
 	private PriceListResource _buildPriceListResource() {
 		return PriceListResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceProductService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceProductService.java
@@ -96,7 +96,7 @@ public class CommerceProductService extends OneBaseService {
 	private ProductResource _buildProductResource() {
 		return ProductResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceSkuService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CommerceSkuService.java
@@ -21,7 +21,7 @@ public class CommerceSkuService extends OneBaseService {
 	public Sku fetchSku(String externalReferenceCode) throws Exception {
 		SkuResource skuResource = SkuResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();
@@ -44,7 +44,7 @@ public class CommerceSkuService extends OneBaseService {
 	public Sku getSku(long skuId) throws Exception {
 		SkuResource skuResource = SkuResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CountryService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/CountryService.java
@@ -20,7 +20,7 @@ public class CountryService extends OneBaseService {
 	public Country getCountryByA2(String a2) throws Exception {
 		CountryResource countryResource = CountryResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/NotificationQueueEntryService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/NotificationQueueEntryService.java
@@ -28,7 +28,7 @@ public class NotificationQueueEntryService extends OneBaseService {
 		NotificationQueueEntryResource notificationQueueEntryResource =
 			NotificationQueueEntryResource.builder(
 			).endpoint(
-				lxcDXPMainDomain, lxcDXPServerProtocol
+				getDXPEndpointAddress(), lxcDXPServerProtocol
 			).header(
 				HttpHeaders.AUTHORIZATION, getAuthorization()
 			).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/NotificationTemplateService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/NotificationTemplateService.java
@@ -30,7 +30,7 @@ public class NotificationTemplateService extends OneBaseService {
 		NotificationTemplateResource notificationTemplateResource =
 			NotificationTemplateResource.builder(
 			).endpoint(
-				lxcDXPMainDomain, lxcDXPServerProtocol
+				getDXPEndpointAddress(), lxcDXPServerProtocol
 			).header(
 				HttpHeaders.AUTHORIZATION, getAuthorization()
 			).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OneBaseService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OneBaseService.java
@@ -7,6 +7,7 @@ package com.liferay.one.service;
 
 import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -93,6 +94,20 @@ public abstract class OneBaseService extends BaseService {
 		}
 
 		return "Bearer " + jwt.getTokenValue();
+	}
+
+	protected String getDXPEndpointAddress() {
+		if (lxcDXPMainDomain.contains(":")) {
+			return lxcDXPMainDomain;
+		}
+
+		int port = 80;
+
+		if (StringUtil.equals(lxcDXPServerProtocol, "https")) {
+			port = 443;
+		}
+
+		return lxcDXPMainDomain + ":" + port;
 	}
 
 	protected boolean isNotFound(String status) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OneBaseService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OneBaseService.java
@@ -7,20 +7,32 @@ package com.liferay.one.service;
 
 import com.liferay.client.extension.util.spring.boot3.client.LiferayOAuth2AccessTokenManager;
 import com.liferay.client.extension.util.spring.boot3.service.BaseService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.net.URI;
+
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -110,11 +122,126 @@ public abstract class OneBaseService extends BaseService {
 		return lxcDXPMainDomain + ":" + port;
 	}
 
+	@Override
+	protected ExchangeFilterFunction getWebClientExchangeFilterFunction() {
+		return super.getWebClientExchangeFilterFunction(
+		).andThen(
+			(clientRequest, exchangeFunction) -> exchangeFunction.exchange(
+				clientRequest
+			).doOnNext(
+				clientResponse -> {
+					int statusCode = clientResponse.statusCode(
+					).value();
+
+					if (statusCode == 403) {
+						_logForbidden(clientRequest);
+					}
+				}
+			)
+		);
+	}
+
 	protected boolean isNotFound(String status) {
 		return Objects.equals(HttpStatus.NOT_FOUND.name(), status);
 	}
 
+	private String _getObjectScope(URI uri) {
+		String path = uri.getPath();
+
+		int index = path.indexOf("/o/c/");
+
+		if (index < 0) {
+			return null;
+		}
+
+		String objectName = path.substring(index + 5);
+
+		int slashIndex = objectName.indexOf('/');
+
+		if (slashIndex >= 0) {
+			objectName = objectName.substring(0, slashIndex);
+		}
+
+		if (objectName.isEmpty()) {
+			return null;
+		}
+
+		if (objectName.endsWith("s")) {
+			objectName = objectName.substring(0, objectName.length() - 1);
+		}
+
+		return "c_" + objectName;
+	}
+
+	private String _getTokenScope(String authorization) {
+		if ((authorization == null) || !authorization.startsWith("Bearer ")) {
+			return "";
+		}
+
+		try {
+			String token = authorization.substring(7);
+
+			int firstIndex = token.indexOf('.');
+
+			int secondIndex = token.indexOf('.', firstIndex + 1);
+
+			if ((firstIndex < 0) || (secondIndex < 0)) {
+				return "";
+			}
+
+			String payload = new String(
+				Base64.getUrlDecoder(
+				).decode(
+					token.substring(firstIndex + 1, secondIndex)
+				),
+				StandardCharsets.UTF_8);
+
+			JSONObject jsonObject = new JSONObject(payload);
+
+			return jsonObject.optString("scope");
+		}
+		catch (RuntimeException runtimeException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to read the token scope", runtimeException);
+			}
+
+			return "";
+		}
+	}
+
+	private void _logForbidden(ClientRequest clientRequest) {
+		if (!_log.isWarnEnabled()) {
+			return;
+		}
+
+		URI uri = clientRequest.url();
+
+		String tokenScope = _getTokenScope(
+			clientRequest.headers(
+			).getFirst(
+				HttpHeaders.AUTHORIZATION
+			));
+
+		String objectScope = _getObjectScope(uri);
+
+		if ((objectScope != null) && !tokenScope.contains(objectScope)) {
+			_log.warn(
+				StringBundler.concat(
+					"Received a 403 from ", uri,
+					". The service account token is missing the ", objectScope,
+					" scope. The token scopes are ", tokenScope));
+		}
+		else {
+			_log.warn(
+				StringBundler.concat(
+					"Received a 403 from ", uri, ". The token scopes are ",
+					tokenScope));
+		}
+	}
+
 	private static final int _PAGE_SIZE = 500;
+
+	private static final Log _log = LogFactory.getLog(OneBaseService.class);
 
 	@Autowired
 	private LiferayOAuth2AccessTokenManager _liferayOAuth2AccessTokenManager;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/OrganizationService.java
@@ -83,7 +83,7 @@ public class OrganizationService extends OneBaseService {
 	private OrganizationResource _buildOrganizationResource() {
 		return OrganizationResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PostalAddressService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/PostalAddressService.java
@@ -23,7 +23,7 @@ public class PostalAddressService extends OneBaseService {
 		PostalAddressResource postalAddressResource =
 			PostalAddressResource.builder(
 			).endpoint(
-				lxcDXPMainDomain, lxcDXPServerProtocol
+				getDXPEndpointAddress(), lxcDXPServerProtocol
 			).header(
 				HttpHeaders.AUTHORIZATION, getAuthorization()
 			).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/RoleService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/RoleService.java
@@ -60,7 +60,7 @@ public class RoleService extends OneBaseService {
 	private RoleResource _buildRoleResource() {
 		return RoleResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).build();

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -220,7 +220,7 @@ public class UserAccountService extends OneBaseService {
 
 		return UserAccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization(jwt)
 		).parameters(
@@ -233,7 +233,7 @@ public class UserAccountService extends OneBaseService {
 
 		return UserAccountResource.builder(
 		).endpoint(
-			lxcDXPMainDomain, lxcDXPServerProtocol
+			getDXPEndpointAddress(), lxcDXPServerProtocol
 		).header(
 			HttpHeaders.AUTHORIZATION, getAuthorization()
 		).parameters(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101368

## What is being fixed

The generated Liferay REST clients default the port to 443 when the endpoint address carries no port, so against a local environment served over HTTP on port 80  every downstream call failed to connect. When a call did reach the server and came back 403, nothing in the logs explained which OAuth2 scope the service account token was missing, and there was no request-level tracing available for local debugging.

## How it is being fixed

A shared getDXPEndpointAddress resolves the DXP endpoint to an explicit host and port, honoring a port already embedded in the LXC main domain and otherwise defaulting to 80 for HTTP and 443 for HTTPS, and every service now builds its client against it. A WebClient exchange filter logs a 403 with the requested URI, the object scope it needed, and the scopes the token actually carried, so a missing-scope failure is self-explanatory. The local Docker image build enables debug and trace logging for the reactive client so requests can be inspected locally; this is written only to the local environment file and never ships.
