### PR TITLE
LPD-100046 LPD-100047 Soft delete and reconcile JSM assignments

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverter.java
@@ -22,6 +22,11 @@ public class AccountContactRoleAssignmentConverter
 	extends BaseJiraAssetObjectConverter {
 
 	@Override
+	public String getDeletedAttributeName() {
+		return AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED;
+	}
+
+	@Override
 	public String getExternalKeyAttributeName() {
 		return AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME;
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountTeamRoleAssignmentConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/AccountTeamRoleAssignmentConverter.java
@@ -22,6 +22,11 @@ public class AccountTeamRoleAssignmentConverter
 	extends BaseJiraAssetObjectConverter {
 
 	@Override
+	public String getDeletedAttributeName() {
+		return AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED;
+	}
+
+	@Override
 	public String getExternalKeyAttributeName() {
 		return AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_NAME;
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/BaseJiraAssetObjectConverter.java
@@ -54,6 +54,18 @@ public abstract class BaseJiraAssetObjectConverter {
 		return builder.build();
 	}
 
+	/**
+	 * @return the name of the boolean attribute that marks an asset object as
+	 *         soft deleted
+	 * @throws UnsupportedOperationException if the asset object type does not
+	 *         support soft deletion
+	 */
+	public String getDeletedAttributeName() {
+		throw new UnsupportedOperationException(
+			"The object type " + getObjectTypeName() +
+				" does not support soft deletion");
+	}
+
 	public String getExternalKeyAttributeName() {
 		return _ATTRIBUTE_NAME_EXTERNAL_KEY;
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/TeamContactRoleAssignmentConverter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/converter/TeamContactRoleAssignmentConverter.java
@@ -22,6 +22,11 @@ public class TeamContactRoleAssignmentConverter
 	extends BaseJiraAssetObjectConverter {
 
 	@Override
+	public String getDeletedAttributeName() {
+		return TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED;
+	}
+
+	@Override
 	public String getExternalKeyAttributeName() {
 		return TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME;
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetPersistence.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetPersistence.java
@@ -14,6 +14,8 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
 
+import java.time.Duration;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,10 +30,17 @@ import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import reactor.util.retry.Retry;
 
 /**
  * @author Drew Brokke
@@ -68,10 +77,54 @@ public class JiraAssetPersistence extends BaseJiraService {
 	}
 
 	public JSONObject deleteObject(String objectId) {
-		String response = delete(
-			getAuthorization(), StringPool.BLANK, _objectURI(objectId));
+		try {
+			String response = Mono.fromCallable(
+				() -> delete(
+					getAuthorization(), StringPool.BLANK, _objectURI(objectId))
+			).retryWhen(
+				Retry.backoff(
+					_MAX_RETRIES, _RETRY_MIN_BACKOFF
+				).maxBackoff(
+					_RETRY_MAX_BACKOFF
+				).scheduler(
+					Schedulers.boundedElastic()
+				).filter(
+					this::_isRetryable
+				).onRetryExhaustedThrow(
+					(retryBackoffSpec, retrySignal) -> retrySignal.failure()
+				)
+			).block();
 
-		return _toJSONObject(response);
+			return _toJSONObject(response);
+		}
+		catch (WebClientResponseException webClientResponseException) {
+			HttpStatusCode httpStatusCode =
+				webClientResponseException.getStatusCode();
+
+			if (httpStatusCode.isSameCodeAs(HttpStatus.NOT_FOUND)) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Skipping delete of asset object ", objectId,
+							" because it does not exist"));
+				}
+
+				return new JSONObject();
+			}
+
+			_log.error(
+				StringBundler.concat(
+					"Unable to delete asset object ", objectId, ": ",
+					webClientResponseException.getResponseBodyAsString()));
+
+			throw webClientResponseException;
+		}
+		catch (RuntimeException runtimeException) {
+			_log.error(
+				"Unable to delete asset object " + objectId, runtimeException);
+
+			throw runtimeException;
+		}
 	}
 
 	public JSONObject getObject(String objectId) {
@@ -214,6 +267,25 @@ public class JiraAssetPersistence extends BaseJiraService {
 		).build();
 	}
 
+	private boolean _isRetryable(Throwable throwable) {
+		if (throwable instanceof
+				WebClientResponseException webClientResponseException) {
+
+			HttpStatusCode httpStatusCode =
+				webClientResponseException.getStatusCode();
+
+			if (httpStatusCode.is5xxServerError() ||
+				httpStatusCode.isSameCodeAs(HttpStatus.TOO_MANY_REQUESTS)) {
+
+				return true;
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
 	private URI _objectURI(String suffix) {
 		return _v1URI("object/" + suffix);
 	}
@@ -281,6 +353,16 @@ public class JiraAssetPersistence extends BaseJiraService {
 		"https://api.atlassian.com";
 
 	private static final int _MAX_RESULTS = 100;
+
+	private static final int _MAX_RETRIES = 3;
+
+	// Callers hold a JiraSyncLock stripe across the retried call, so the
+	// worst case backoff must stay within a few seconds to keep unrelated
+	// syncs that hash to the same stripe from stalling
+
+	private static final Duration _RETRY_MAX_BACKOFF = Duration.ofSeconds(2);
+
+	private static final Duration _RETRY_MIN_BACKOFF = Duration.ofMillis(500);
 
 	private static final Log _log = LogFactory.getLog(
 		JiraAssetPersistence.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/service/JiraAssetService.java
@@ -11,6 +11,7 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -27,6 +29,7 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,11 +75,9 @@ public class JiraAssetService {
 			return null;
 		}
 
-		Map<String, String> externalKeyToObjectIdMap = new HashMap<>();
-
-		_putObjectIds(
-			converter, Collections.singletonList(externalKey),
-			externalKeyToObjectIdMap);
+		Map<String, String> externalKeyToObjectIdMap =
+			_getExternalKeyToObjectIdMap(
+				converter, Collections.singletonList(externalKey));
 
 		return externalKeyToObjectIdMap.get(externalKey);
 	}
@@ -118,6 +119,25 @@ public class JiraAssetService {
 		}
 
 		return _resolveToObjectIds(converter, externalKeys, null);
+	}
+
+	/**
+	 * Resolves a collection of external keys to the IDs of their existing
+	 * asset objects. External keys that do not resolve to an existing asset
+	 * object are absent from the returned map.
+	 *
+	 * @param  converter the converter describing the asset object type and its
+	 *         external key attribute
+	 * @param  externalKeys the external keys of the reference asset objects
+	 *
+	 * @return the map from external key to existing asset object ID
+	 */
+	public Map<String, String> getExternalKeyToObjectIdMap(
+		BaseJiraAssetObjectConverter converter,
+		Collection<String> externalKeys) {
+
+		return _getExternalKeyToObjectIdMap(
+			converter, new ArrayList<>(externalKeys));
 	}
 
 	/**
@@ -267,6 +287,82 @@ public class JiraAssetService {
 		return false;
 	}
 
+	/**
+	 * Soft deletes an existing asset object by setting its deleted attribute
+	 * to <code>true</code> instead of removing it. Unlike an upsert, no
+	 * reference attribute is resolved, so the asset object can be soft deleted
+	 * after the asset objects it references are gone.
+	 *
+	 * @param converter the converter describing the asset object type; it must
+	 *        support soft deletion
+	 * @param jiraAssetObject the existing asset object to soft delete
+	 */
+	public void softDelete(
+		BaseJiraAssetObjectConverter converter,
+		JiraAssetObject jiraAssetObject) {
+
+		softDelete(converter, jiraAssetObject, null);
+	}
+
+	/**
+	 * Soft deletes an existing asset object. A non-null predicate receives
+	 * the asset object's freshly fetched state inside the asset-level lock
+	 * and returns <code>true</code> to skip, so a decision made from an
+	 * earlier snapshot cannot undo a concurrent write.
+	 */
+	public void softDelete(
+		BaseJiraAssetObjectConverter converter, JiraAssetObject jiraAssetObject,
+		Predicate<JiraAssetObject> shouldSkipUpdatePredicate) {
+
+		String externalKey = jiraAssetObject.getAttributeValue(
+			converter.getExternalKeyAttributeName());
+
+		_jiraSyncLock.withLock(
+			_getLockKey(converter, externalKey),
+			() -> _softDelete(
+				converter, converter.getDeletedAttributeName(), externalKey,
+				jiraAssetObject, shouldSkipUpdatePredicate));
+	}
+
+	/**
+	 * Soft deletes every live asset object whose named attribute matches the
+	 * given value, unconditionally and continuing past per-object failures.
+	 * Only for delete cascades, where the matches reference a doomed entity
+	 * and no concurrent write can make them worth keeping.
+	 */
+	public void softDeleteByAttribute(
+		BaseJiraAssetObjectConverter converter, String attributeName,
+		String attributeValue) {
+
+		if (Validator.isNull(attributeValue)) {
+			return;
+		}
+
+		List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+			converter,
+			aqlBuilder -> aqlBuilder.andEquals(
+				attributeValue, attributeName
+			).andEquals(
+				false, converter.getDeletedAttributeName()
+			));
+
+		// JSM has no batch update endpoint, so each matching asset object is
+		// patched individually
+
+		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			try {
+				softDelete(converter, jiraAssetObject);
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to soft delete ", converter.getObjectTypeName(),
+						" asset object ", jiraAssetObject.getObjectId()),
+					exception);
+			}
+		}
+	}
+
 	public void upsert(
 		BaseJiraAssetObjectConverter converter,
 		JiraAssetObject jiraAssetObject) {
@@ -392,52 +488,69 @@ public class JiraAssetService {
 		_jiraAssetPersistence.deleteObject(jiraAssetObject.getObjectId());
 	}
 
+	private Map<String, String> _getExternalKeyToObjectIdMap(
+		BaseJiraAssetObjectConverter converter, List<String> externalKeys) {
+
+		Map<String, String> externalKeyToObjectIdMap = new HashMap<>();
+
+		if (ListUtil.isEmpty(externalKeys)) {
+			return externalKeyToObjectIdMap;
+		}
+
+		Set<String> externalKeySet = new HashSet<>(externalKeys);
+
+		externalKeys = new ArrayList<>(externalKeySet);
+
+		for (int i = 0; i < externalKeys.size(); i += _CHUNK_SIZE) {
+			List<String> externalKeys1 = externalKeys.subList(
+				i, Math.min(i + _CHUNK_SIZE, externalKeys.size()));
+
+			String externalKeyAttributeName =
+				converter.getExternalKeyAttributeName();
+
+			List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+				converter,
+				aqlBuilder -> aqlBuilder.andIn(
+					externalKeys1, externalKeyAttributeName));
+
+			for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+				String externalKey = jiraAssetObject.getAttributeValue(
+					externalKeyAttributeName);
+				String objectId = jiraAssetObject.getObjectId();
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Resolved external key ", externalKey,
+							" to existing ", converter.getObjectTypeName(),
+							" asset object ", objectId));
+				}
+
+				String previousObjectId = externalKeyToObjectIdMap.putIfAbsent(
+					externalKey, objectId);
+
+				if ((previousObjectId != null) &&
+					!Objects.equals(previousObjectId, objectId) &&
+					_log.isWarnEnabled()) {
+
+					_log.warn(
+						StringBundler.concat(
+							"Multiple asset objects share external key ",
+							externalKey, ": ", previousObjectId, " and ",
+							objectId,
+							"; the reference will resolve to the first match ",
+							previousObjectId));
+				}
+			}
+		}
+
+		return externalKeyToObjectIdMap;
+	}
+
 	private String _getLockKey(
 		BaseJiraAssetObjectConverter converter, String externalKey) {
 
 		return converter.getObjectTypeName() + "#" + externalKey;
-	}
-
-	private void _putObjectIds(
-		BaseJiraAssetObjectConverter converter, List<String> externalKeys,
-		Map<String, String> externalKeyToObjectIdMap) {
-
-		String externalKeyAttributeName =
-			converter.getExternalKeyAttributeName();
-
-		List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
-			converter,
-			aqlBuilder -> aqlBuilder.andIn(
-				externalKeys, externalKeyAttributeName));
-
-		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
-			String externalKey = jiraAssetObject.getAttributeValue(
-				externalKeyAttributeName);
-			String objectId = jiraAssetObject.getObjectId();
-
-			if (_log.isInfoEnabled()) {
-				_log.info(
-					StringBundler.concat(
-						"Resolved external key ", externalKey, " to existing ",
-						converter.getObjectTypeName(), " asset object ",
-						objectId));
-			}
-
-			String previousObjectId = externalKeyToObjectIdMap.putIfAbsent(
-				externalKey, objectId);
-
-			if ((previousObjectId != null) &&
-				!Objects.equals(previousObjectId, objectId) &&
-				_log.isWarnEnabled()) {
-
-				_log.warn(
-					StringBundler.concat(
-						"Multiple asset objects share external key ",
-						externalKey, ": ", previousObjectId, " and ", objectId,
-						"; the reference will resolve to the first match ",
-						previousObjectId));
-			}
-		}
 	}
 
 	private List<String> _resolveToObjectIds(
@@ -458,19 +571,11 @@ public class JiraAssetService {
 			return resolvedObjectIds;
 		}
 
-		Map<String, String> externalKeyToObjectIdMap = new HashMap<>();
-
 		List<String> uniqueExternalKeysList = new ArrayList<>(
 			uniqueExternalKeys);
 
-		for (int i = 0; i < uniqueExternalKeysList.size(); i += _CHUNK_SIZE) {
-			_putObjectIds(
-				converter,
-				uniqueExternalKeysList.subList(
-					i,
-					Math.min(i + _CHUNK_SIZE, uniqueExternalKeysList.size())),
-				externalKeyToObjectIdMap);
-		}
+		Map<String, String> externalKeyToObjectIdMap =
+			_getExternalKeyToObjectIdMap(converter, uniqueExternalKeysList);
 
 		for (String externalKey : uniqueExternalKeysList) {
 			String objectId = externalKeyToObjectIdMap.get(externalKey);
@@ -496,6 +601,66 @@ public class JiraAssetService {
 		}
 
 		return resolvedObjectIds;
+	}
+
+	private void _softDelete(
+		BaseJiraAssetObjectConverter converter, String deletedAttributeName,
+		String externalKey, JiraAssetObject jiraAssetObject,
+		Predicate<JiraAssetObject> shouldSkipUpdatePredicate) {
+
+		JiraAssetObject existingJiraAssetObject = jiraAssetObject;
+
+		if (shouldSkipUpdatePredicate != null) {
+			List<JiraAssetObject> jiraAssetObjects = getJiraAssetObjects(
+				converter,
+				aqlBuilder -> aqlBuilder.andEquals(
+					externalKey, converter.getExternalKeyAttributeName()));
+
+			if (jiraAssetObjects.isEmpty()) {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Skipping soft delete of ",
+							converter.getObjectTypeName(),
+							" asset object for external key ", externalKey,
+							" because it does not exist"));
+				}
+
+				return;
+			}
+
+			existingJiraAssetObject = jiraAssetObjects.get(0);
+
+			if (shouldSkipUpdatePredicate.test(existingJiraAssetObject)) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Skipping soft delete of recently updated ",
+							converter.getObjectTypeName(),
+							" asset object for external key ", externalKey));
+				}
+
+				return;
+			}
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Soft deleting ", converter.getObjectTypeName(),
+					" asset object ", existingJiraAssetObject.getObjectId()));
+		}
+
+		JiraAssetObject patchJiraAssetObject =
+			converter.createJiraAssetObject();
+
+		patchJiraAssetObject.setAttributeValue(deletedAttributeName, true);
+		patchJiraAssetObject.setAttributeValue(
+			converter.getExternalUpdatedAtAttributeName(),
+			converter.formatDate(new Date()));
+
+		_jiraAssetPersistence.updateObject(
+			existingJiraAssetObject.getObjectId(), patchJiraAssetObject);
 	}
 
 	private void _upsert(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -32,6 +32,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class AccountOrganizationSynchronizer {
 
+	public void softDeleteByAccount(String accountExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_accountTeamRoleAssignmentConverter,
+			AccountTeamRoleAssignmentConstants.
+				ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+			accountExternalKey);
+	}
+
+	public void softDeleteByOrganization(String organizationExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_accountTeamRoleAssignmentConverter,
+			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+			organizationExternalKey);
+	}
+
 	public void syncAssignOrganization(
 			String organizationExternalKey, String accountExternalKey)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -79,6 +79,30 @@ public class AccountSynchronizer {
 							" from JSM");
 				}
 
+				try {
+					_accountOrganizationSynchronizer.softDeleteByAccount(
+						externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete account team role ",
+							"assignments for account ", externalReferenceCode),
+						exception);
+				}
+
+				try {
+					_accountUserAccountRoleSynchronizer.softDeleteByAccount(
+						externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete account contact role ",
+							"assignments for account ", externalReferenceCode),
+						exception);
+				}
+
 				_jiraAssetService.delete(
 					_accountConverter, externalReferenceCode);
 			});

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
@@ -34,6 +34,22 @@ import org.springframework.stereotype.Component;
 @Component
 public class AccountUserAccountRoleSynchronizer {
 
+	public void softDeleteByAccount(String accountExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_accountContactRoleAssignmentConverter,
+			AccountContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+			accountExternalKey);
+	}
+
+	public void softDeleteByUserAccount(String userAccountExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_accountContactRoleAssignmentConverter,
+			AccountContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+			userAccountExternalKey);
+	}
+
 	public void syncAssignRole(
 			String roleExternalKey, String userAccountExternalKey,
 			String accountExternalKey)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizer.java
@@ -47,8 +47,35 @@ public class OrganizationSynchronizer {
 
 		_jiraSyncLock.withLock(
 			externalReferenceCode,
-			() -> _jiraAssetService.delete(
-				_teamConverter, externalReferenceCode));
+			() -> {
+				try {
+					_accountOrganizationSynchronizer.softDeleteByOrganization(
+						externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete account team role ",
+							"assignments for organization ",
+							externalReferenceCode),
+						exception);
+				}
+
+				try {
+					_organizationUserAccountRoleSynchronizer.
+						softDeleteByOrganization(externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete team contact role ",
+							"assignments for organization ",
+							externalReferenceCode),
+						exception);
+				}
+
+				_jiraAssetService.delete(_teamConverter, externalReferenceCode);
+			});
 	}
 
 	public void syncOrganization(Organization organization) throws Exception {
@@ -186,6 +213,10 @@ public class OrganizationSynchronizer {
 
 	@Autowired
 	private JiraSyncLock _jiraSyncLock;
+
+	@Autowired
+	private OrganizationUserAccountRoleSynchronizer
+		_organizationUserAccountRoleSynchronizer;
 
 	@Autowired
 	private PropertyService _propertyService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizer.java
@@ -29,6 +29,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrganizationUserAccountRoleSynchronizer {
 
+	public void softDeleteByOrganization(String organizationExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_teamContactRoleAssignmentConverter,
+			TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+			organizationExternalKey);
+	}
+
+	public void softDeleteByUserAccount(String userAccountExternalKey) {
+		_jiraAssetService.softDeleteByAttribute(
+			_teamContactRoleAssignmentConverter,
+			TeamContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+			userAccountExternalKey);
+	}
+
 	public void syncAssignRole(
 			String roleExternalKey, String userAccountExternalKey,
 			String organizationExternalKey)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrphanedAssignmentReconciler.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/OrphanedAssignmentReconciler.java
@@ -1,0 +1,328 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.AccountContactRoleAssignmentConstants;
+import com.liferay.one.jira.constants.AccountTeamRoleAssignmentConstants;
+import com.liferay.one.jira.constants.TeamContactRoleAssignmentConstants;
+import com.liferay.one.jira.converter.AccountContactRoleAssignmentConverter;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
+import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.ContactRoleConverter;
+import com.liferay.one.jira.converter.TeamContactRoleAssignmentConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.converter.TeamRoleConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Drew Brokke
+ */
+@Component
+public class OrphanedAssignmentReconciler {
+
+	@Async
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationReady() {
+		try {
+			reconcileOrphanedAssignments();
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to reconcile orphaned assignments on application " +
+					"startup",
+				exception);
+		}
+	}
+
+	@Scheduled(cron = "${liferay.one.jira.orphaned.assignment.reconcile.cron}")
+	public void reconcileOrphanedAssignments() {
+		if (!_reconciling.compareAndSet(false, true)) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Skipping orphaned assignment reconciliation because " +
+						"another reconciliation is in progress");
+			}
+
+			return;
+		}
+
+		try {
+			_reconcileOrphanedAssignments();
+		}
+		finally {
+			_reconciling.set(false);
+		}
+	}
+
+	private boolean _isOrphaned(
+		JiraAssetObject jiraAssetObject,
+		Map<AssignmentReference, Set<String>> liveExternalKeysMap) {
+
+		for (Map.Entry<AssignmentReference, Set<String>> entry :
+				liveExternalKeysMap.entrySet()) {
+
+			AssignmentReference assignmentReference = entry.getKey();
+
+			String externalKey = jiraAssetObject.getAttributeValue(
+				assignmentReference.getExternalKeyAttributeName());
+
+			Set<String> liveExternalKeys = entry.getValue();
+
+			if (Validator.isNull(externalKey) ||
+				!liveExternalKeys.contains(externalKey)) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private void _reconcile(
+		BaseJiraAssetObjectConverter converter,
+		List<AssignmentReference> assignmentReferences) {
+
+		try {
+			_reconcile(converter, assignmentReferences, new Date());
+		}
+		catch (Exception exception) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to reconcile orphaned ",
+					converter.getObjectTypeName(), " asset objects"),
+				exception);
+		}
+	}
+
+	private void _reconcile(
+		BaseJiraAssetObjectConverter converter,
+		List<AssignmentReference> assignmentReferences, Date startDate) {
+
+		List<String> referenceAttributeNames = TransformUtil.transform(
+			assignmentReferences,
+			AssignmentReference::getReferenceAttributeName);
+
+		// JSM clears inbound references when an asset object is deleted, so
+		// an empty reference attribute marks a candidate whose referenced
+		// entity may be gone
+
+		List<JiraAssetObject> jiraAssetObjects =
+			_jiraAssetService.getJiraAssetObjects(
+				converter,
+				aqlBuilder -> aqlBuilder.andEquals(
+					false, converter.getDeletedAttributeName()
+				).andAnyEmpty(
+					referenceAttributeNames.toArray(new String[0])
+				));
+
+		if (jiraAssetObjects.isEmpty()) {
+			return;
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Found ", jiraAssetObjects.size(), " orphaned ",
+					converter.getObjectTypeName(), " asset object candidates"));
+		}
+
+		Map<AssignmentReference, Set<String>> liveExternalKeysMap =
+			new LinkedHashMap<>();
+
+		for (AssignmentReference assignmentReference : assignmentReferences) {
+			Set<String> externalKeys = new LinkedHashSet<>();
+
+			for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+				String externalKey = jiraAssetObject.getAttributeValue(
+					assignmentReference.getExternalKeyAttributeName());
+
+				if (Validator.isNotNull(externalKey)) {
+					externalKeys.add(externalKey);
+				}
+			}
+
+			Map<String, String> externalKeyToObjectIdMap =
+				_jiraAssetService.getExternalKeyToObjectIdMap(
+					assignmentReference.getConverter(), externalKeys);
+
+			liveExternalKeysMap.put(
+				assignmentReference, externalKeyToObjectIdMap.keySet());
+		}
+
+		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			if (!_isOrphaned(jiraAssetObject, liveExternalKeysMap)) {
+				continue;
+			}
+
+			try {
+				_jiraAssetService.softDelete(
+					converter, jiraAssetObject,
+					existingJiraAssetObject -> _jiraAssetService.isUpdatedSince(
+						converter, startDate, existingJiraAssetObject));
+			}
+			catch (Exception exception) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to soft delete orphaned ",
+						converter.getObjectTypeName(), " asset object ",
+						jiraAssetObject.getObjectId()),
+					exception);
+			}
+		}
+	}
+
+	private void _reconcileOrphanedAssignments() {
+		_reconcile(
+			_accountContactRoleAssignmentConverter,
+			Arrays.asList(
+				new AssignmentReference(
+					_accountConverter,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_ACCOUNT),
+				new AssignmentReference(
+					_contactConverter,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT),
+				new AssignmentReference(
+					_contactRoleConverter,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_ROLE)));
+		_reconcile(
+			_accountTeamRoleAssignmentConverter,
+			Arrays.asList(
+				new AssignmentReference(
+					_accountConverter,
+					AccountTeamRoleAssignmentConstants.
+						ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+					AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_ACCOUNT),
+				new AssignmentReference(
+					_teamConverter,
+					AccountTeamRoleAssignmentConstants.
+						ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+					AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM),
+				new AssignmentReference(
+					_teamRoleConverter,
+					AccountTeamRoleAssignmentConstants.
+						ATTRIBUTE_NAME_TEAM_ROLE_EXTERNAL_KEY,
+					AccountTeamRoleAssignmentConstants.
+						ATTRIBUTE_NAME_TEAM_ROLE)));
+		_reconcile(
+			_teamContactRoleAssignmentConverter,
+			Arrays.asList(
+				new AssignmentReference(
+					_contactConverter,
+					TeamContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+					TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_CONTACT),
+				new AssignmentReference(
+					_contactRoleConverter,
+					TeamContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY,
+					TeamContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_CONTACT_ROLE),
+				new AssignmentReference(
+					_teamConverter,
+					TeamContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+					TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM)));
+	}
+
+	private static final Log _log = LogFactory.getLog(
+		OrphanedAssignmentReconciler.class);
+
+	@Autowired
+	private AccountContactRoleAssignmentConverter
+		_accountContactRoleAssignmentConverter;
+
+	@Autowired
+	private AccountConverter _accountConverter;
+
+	@Autowired
+	private AccountTeamRoleAssignmentConverter
+		_accountTeamRoleAssignmentConverter;
+
+	@Autowired
+	private ContactConverter _contactConverter;
+
+	@Autowired
+	private ContactRoleConverter _contactRoleConverter;
+
+	@Autowired
+	private JiraAssetService _jiraAssetService;
+
+	private final AtomicBoolean _reconciling = new AtomicBoolean();
+
+	@Autowired
+	private TeamContactRoleAssignmentConverter
+		_teamContactRoleAssignmentConverter;
+
+	@Autowired
+	private TeamConverter _teamConverter;
+
+	@Autowired
+	private TeamRoleConverter _teamRoleConverter;
+
+	private static class AssignmentReference {
+
+		public BaseJiraAssetObjectConverter getConverter() {
+			return _converter;
+		}
+
+		public String getExternalKeyAttributeName() {
+			return _externalKeyAttributeName;
+		}
+
+		public String getReferenceAttributeName() {
+			return _referenceAttributeName;
+		}
+
+		private AssignmentReference(
+			BaseJiraAssetObjectConverter converter,
+			String externalKeyAttributeName, String referenceAttributeName) {
+
+			_converter = converter;
+			_externalKeyAttributeName = externalKeyAttributeName;
+			_referenceAttributeName = referenceAttributeName;
+		}
+
+		private final BaseJiraAssetObjectConverter _converter;
+		private final String _externalKeyAttributeName;
+		private final String _referenceAttributeName;
+
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
@@ -55,6 +55,32 @@ public class UserAccountSynchronizer {
 							" from JSM");
 				}
 
+				try {
+					_accountUserAccountRoleSynchronizer.softDeleteByUserAccount(
+						externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete account contact role ",
+							"assignments for user account ",
+							externalReferenceCode),
+						exception);
+				}
+
+				try {
+					_organizationUserAccountRoleSynchronizer.
+						softDeleteByUserAccount(externalReferenceCode);
+				}
+				catch (Exception exception) {
+					_log.error(
+						StringBundler.concat(
+							"Unable to soft delete team contact role ",
+							"assignments for user account ",
+							externalReferenceCode),
+						exception);
+				}
+
 				_jiraAssetService.delete(
 					_contactConverter, externalReferenceCode);
 			});

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
@@ -29,6 +29,28 @@ public class AQLUtil {
 
 	public static class Builder {
 
+		public Builder andAnyEmpty(String... fieldNames) {
+			if (fieldNames.length == 0) {
+				throw new IllegalArgumentException(
+					"An IS EMPTY clause requires at least one field name");
+			}
+
+			_sb.append(" AND (");
+
+			for (int i = 0; i < fieldNames.length; i++) {
+				if (i > 0) {
+					_sb.append(" OR ");
+				}
+
+				_sb.append(_field(fieldNames[i]));
+				_sb.append(" IS EMPTY");
+			}
+
+			_sb.append(")");
+
+			return this;
+		}
+
 		public Builder andEquals(boolean value, String... fieldNames) {
 			_sb.append(" AND ");
 			_sb.append(_field(fieldNames));

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/resources/application-default.properties
@@ -35,6 +35,7 @@ liferay.one.jira.issue.support.hc.field.organization=${LIFERAY_ONE_JIRA_ISSUE_SU
 liferay.one.jira.issue.support.hc.field.request.type=${LIFERAY_ONE_JIRA_ISSUE_SUPPORT_HC_FIELD_REQUEST_TYPE}
 liferay.one.jira.organization.provisioning.id=${LIFERAY_ONE_JIRA_ORGANIZATION_PROVISIONING_ID}
 liferay.one.jira.organization.role.sync.cron=0 0 0 * * SUN
+liferay.one.jira.orphaned.assignment.reconcile.cron=0 0 2 * * *
 liferay.one.jira.project.support.fls=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_FLS}
 liferay.one.jira.project.support.fls.url=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_FLS_URL}
 liferay.one.jira.project.support.hc=${LIFERAY_ONE_JIRA_PROJECT_SUPPORT_HC}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetPersistenceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetPersistenceTest.java
@@ -1,0 +1,136 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.service;
+
+import java.net.URI;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetPersistenceTest {
+
+	@Test
+	public void testDeleteObjectDoesNotRetryClientErrors() {
+		TestJiraAssetPersistence testJiraAssetPersistence =
+			new TestJiraAssetPersistence(
+				1, _createWebClientResponseException(400));
+
+		Assertions.assertThrows(
+			WebClientResponseException.class,
+			() -> testJiraAssetPersistence.deleteObject("test-object-id"));
+
+		Assertions.assertEquals(1, testJiraAssetPersistence.getDeleteCount());
+	}
+
+	@Test
+	public void testDeleteObjectRethrowsAfterExhaustingRetries() {
+		WebClientResponseException webClientResponseException1 =
+			_createWebClientResponseException(500);
+
+		TestJiraAssetPersistence testJiraAssetPersistence =
+			new TestJiraAssetPersistence(
+				Integer.MAX_VALUE, webClientResponseException1);
+
+		WebClientResponseException webClientResponseException2 =
+			Assertions.assertThrows(
+				WebClientResponseException.class,
+				() -> testJiraAssetPersistence.deleteObject("test-object-id"));
+
+		Assertions.assertSame(
+			webClientResponseException1, webClientResponseException2);
+
+		Assertions.assertEquals(4, testJiraAssetPersistence.getDeleteCount());
+	}
+
+	@Test
+	public void testDeleteObjectRetriesServerErrors() {
+		TestJiraAssetPersistence testJiraAssetPersistence =
+			new TestJiraAssetPersistence(
+				1, _createWebClientResponseException(500));
+
+		JSONObject jsonObject = testJiraAssetPersistence.deleteObject(
+			"test-object-id");
+
+		Assertions.assertTrue(jsonObject.isEmpty());
+
+		Assertions.assertEquals(2, testJiraAssetPersistence.getDeleteCount());
+	}
+
+	@Test
+	public void testDeleteObjectRetriesTooManyRequests() {
+		TestJiraAssetPersistence testJiraAssetPersistence =
+			new TestJiraAssetPersistence(
+				1, _createWebClientResponseException(429));
+
+		JSONObject jsonObject = testJiraAssetPersistence.deleteObject(
+			"test-object-id");
+
+		Assertions.assertTrue(jsonObject.isEmpty());
+
+		Assertions.assertEquals(2, testJiraAssetPersistence.getDeleteCount());
+	}
+
+	@Test
+	public void testDeleteObjectTreatsMissingObjectAsSuccess() {
+		TestJiraAssetPersistence testJiraAssetPersistence =
+			new TestJiraAssetPersistence(
+				2, _createWebClientResponseException(404));
+
+		JSONObject jsonObject = testJiraAssetPersistence.deleteObject(
+			"test-object-id");
+
+		Assertions.assertTrue(jsonObject.isEmpty());
+
+		Assertions.assertEquals(1, testJiraAssetPersistence.getDeleteCount());
+	}
+
+	private WebClientResponseException _createWebClientResponseException(
+		int statusCode) {
+
+		return WebClientResponseException.create(
+			statusCode, "Test Reason", HttpHeaders.EMPTY, new byte[0], null);
+	}
+
+	private static class TestJiraAssetPersistence extends JiraAssetPersistence {
+
+		public TestJiraAssetPersistence(
+			int failureCount,
+			WebClientResponseException webClientResponseException) {
+
+			_failureCount = failureCount;
+			_webClientResponseException = webClientResponseException;
+		}
+
+		public int getDeleteCount() {
+			return _deleteCount.get();
+		}
+
+		@Override
+		protected String delete(String authorization, String body, URI uri) {
+			if (_deleteCount.getAndIncrement() < _failureCount) {
+				throw _webClientResponseException;
+			}
+
+			return "{}";
+		}
+
+		private final AtomicInteger _deleteCount = new AtomicInteger();
+		private final int _failureCount;
+		private final WebClientResponseException _webClientResponseException;
+
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
@@ -8,12 +8,17 @@ package com.liferay.one.jira.service;
 import com.liferay.one.jira.converter.BaseJiraAssetObjectConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.synchronizer.LockSerializationTestHelper;
+import com.liferay.one.jira.util.AQLUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import org.json.JSONObject;
 
@@ -21,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -117,6 +123,63 @@ public class JiraAssetServiceTest {
 			() -> _jiraAssetService.upsert(_converter, jiraAssetObject),
 			() -> _jiraAssetService.delete(_converter, _EXTERNAL_KEY), "update",
 			"delete");
+	}
+
+	@Test
+	public void testFetchReferenceObjectIdsChunksExternalKeys() {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		List<String> externalKeys = new ArrayList<>();
+
+		for (int i = 0; i < 51; i++) {
+			externalKeys.add("external-key-" + i);
+		}
+
+		_jiraAssetService.getExternalKeyToObjectIdMap(_converter, externalKeys);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.times(2)
+		).searchObjects(
+			Mockito.anyString(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testFetchReferenceObjectIdsMapsResolvedExternalKeys() {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		Map<String, String> externalKeyToObjectIdMap =
+			_jiraAssetService.getExternalKeyToObjectIdMap(
+				_converter, Arrays.asList(_EXTERNAL_KEY, "unresolved-key"));
+
+		Assertions.assertEquals(
+			Collections.singletonMap(_EXTERNAL_KEY, _OBJECT_ID),
+			externalKeyToObjectIdMap);
+	}
+
+	@Test
+	public void testFetchReferenceObjectIdsSkipsSearchWithoutExternalKeys() {
+		Map<String, String> externalKeyToObjectIdMap =
+			_jiraAssetService.getExternalKeyToObjectIdMap(
+				_converter, Collections.emptyList());
+
+		Assertions.assertTrue(externalKeyToObjectIdMap.isEmpty());
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).searchObjects(
+			Mockito.anyString(), Mockito.any()
+		);
 	}
 
 	@Test
@@ -248,6 +311,334 @@ public class JiraAssetServiceTest {
 	}
 
 	@Test
+	public void testSoftDeleteByAttributeContinuesWhenSoftDeleteFails() {
+		_mockSoftDeleteAttributes();
+
+		Mockito.when(
+			_converter.createJiraAssetObject()
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		JiraAssetObject secondJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			secondJiraAssetObject.getObjectId()
+		).thenReturn(
+			"second-object-id"
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Arrays.asList(_existingJiraAssetObject, secondJiraAssetObject)
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.updateObject(
+				Mockito.eq(_OBJECT_ID), Mockito.any())
+		).thenThrow(
+			new RuntimeException()
+		);
+
+		_jiraAssetService.softDeleteByAttribute(
+			_converter, "Team External Key", "team-key");
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).updateObject(
+			Mockito.eq("second-object-id"), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteByAttributeFiltersDeletedAndPatchesEveryMatch() {
+		_mockSoftDeleteAttributes();
+
+		List<JiraAssetObject> patchJiraAssetObjects = new ArrayList<>();
+
+		Mockito.when(
+			_converter.createJiraAssetObject()
+		).thenAnswer(
+			invocation -> {
+				JiraAssetObject patchJiraAssetObject = Mockito.mock(
+					JiraAssetObject.class);
+
+				patchJiraAssetObjects.add(patchJiraAssetObject);
+
+				return patchJiraAssetObject;
+			}
+		);
+
+		JiraAssetObject secondJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			secondJiraAssetObject.getObjectId()
+		).thenReturn(
+			"second-object-id"
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Arrays.asList(_existingJiraAssetObject, secondJiraAssetObject)
+		);
+
+		_jiraAssetService.softDeleteByAttribute(
+			_converter, "Team External Key", "team-key");
+
+		ArgumentCaptor<Consumer<AQLUtil.Builder>> consumerArgumentCaptor =
+			ArgumentCaptor.forClass(Consumer.class);
+
+		Mockito.verify(
+			_converter
+		).getAQLWithBuilder(
+			consumerArgumentCaptor.capture()
+		);
+
+		AQLUtil.Builder aqlBuilder = AQLUtil.builder("base");
+
+		Consumer<AQLUtil.Builder> consumer = consumerArgumentCaptor.getValue();
+
+		consumer.accept(aqlBuilder);
+
+		Assertions.assertEquals(
+			"base AND \"Team External Key\" = \"team-key\" AND \"Deleted\" = " +
+				"false",
+			aqlBuilder.build());
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).updateObject(
+			Mockito.eq(_OBJECT_ID), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).updateObject(
+			Mockito.eq("second-object-id"), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).deleteObject(
+			Mockito.any()
+		);
+
+		Assertions.assertEquals(2, patchJiraAssetObjects.size());
+
+		for (JiraAssetObject patchJiraAssetObject : patchJiraAssetObjects) {
+			Mockito.verify(
+				patchJiraAssetObject
+			).setAttributeValue(
+				"Deleted", true
+			);
+
+			Mockito.verify(
+				patchJiraAssetObject
+			).setAttributeValue(
+				"External Updated At", "formatted-date"
+			);
+		}
+	}
+
+	@Test
+	public void testSoftDeleteByAttributeRejectsUnsupportedConverter() {
+		Mockito.when(
+			_converter.getAQLWithBuilder(Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				Consumer<AQLUtil.Builder> consumer = invocation.getArgument(0);
+
+				AQLUtil.Builder aqlBuilder = AQLUtil.builder("base");
+
+				consumer.accept(aqlBuilder);
+
+				return aqlBuilder.build();
+			}
+		);
+
+		Mockito.when(
+			_converter.getDeletedAttributeName()
+		).thenThrow(
+			new UnsupportedOperationException()
+		);
+
+		Assertions.assertThrows(
+			UnsupportedOperationException.class,
+			() -> _jiraAssetService.softDeleteByAttribute(
+				_converter, "Team External Key", "team-key"));
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).searchObjects(
+			Mockito.anyString(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteByAttributeSkipsNullValue() {
+		_jiraAssetService.softDeleteByAttribute(
+			_converter, "Team External Key", null);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).searchObjects(
+			Mockito.anyString(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteRejectsUnsupportedConverter() {
+		Mockito.when(
+			_converter.getDeletedAttributeName()
+		).thenThrow(
+			new UnsupportedOperationException()
+		);
+
+		Assertions.assertThrows(
+			UnsupportedOperationException.class,
+			() -> _jiraAssetService.softDelete(
+				_converter, _existingJiraAssetObject));
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).updateObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteSkipsMissingObject() {
+		_mockSoftDeleteAttributes();
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_jiraAssetService.softDelete(
+			_converter, _existingJiraAssetObject,
+			existingJiraAssetObject -> false);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).updateObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteSkipsUpdateForMatchingPredicate() {
+		_mockSoftDeleteAttributes();
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		_jiraAssetService.softDelete(
+			_converter, _existingJiraAssetObject,
+			existingJiraAssetObject -> true);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).updateObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSoftDeleteUpdatesForNonmatchingPredicate() {
+		_mockSoftDeleteAttributes();
+
+		JiraAssetObject patchJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			_converter.createJiraAssetObject()
+		).thenReturn(
+			patchJiraAssetObject
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		_jiraAssetService.softDelete(
+			_converter, _existingJiraAssetObject,
+			existingJiraAssetObject -> false);
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).updateObject(
+			Mockito.eq(_OBJECT_ID), Mockito.any()
+		);
+
+		Mockito.verify(
+			patchJiraAssetObject
+		).setAttributeValue(
+			"Deleted", true
+		);
+
+		Mockito.verify(
+			patchJiraAssetObject
+		).setAttributeValue(
+			"External Updated At", "formatted-date"
+		);
+	}
+
+	@Test
+	public void testSoftDeleteWaitsForDelete() throws Exception {
+		LockSerializationTestHelper lockSerializationTestHelper =
+			new LockSerializationTestHelper();
+
+		_mockSoftDeleteAttributes();
+
+		Mockito.when(
+			_converter.createJiraAssetObject()
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.deleteObject(Mockito.any())
+		).thenAnswer(
+			lockSerializationTestHelper.block("delete")
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.updateObject(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			lockSerializationTestHelper.record("update")
+		);
+
+		lockSerializationTestHelper.assertSerialized(
+			() -> _jiraAssetService.delete(_converter, _EXTERNAL_KEY),
+			() -> _jiraAssetService.softDelete(
+				_converter, _existingJiraAssetObject),
+			"delete", "update");
+	}
+
+	@Test
 	public void testUpsertSkipsUpdateForMatchingBiPredicate() throws Exception {
 		JiraAssetObject jiraAssetObject = _mockUpsertJiraAssetObject();
 
@@ -301,6 +692,26 @@ public class JiraAssetServiceTest {
 		);
 
 		return jiraAssetObject;
+	}
+
+	private void _mockSoftDeleteAttributes() {
+		Mockito.when(
+			_converter.formatDate(Mockito.any())
+		).thenReturn(
+			"formatted-date"
+		);
+
+		Mockito.when(
+			_converter.getDeletedAttributeName()
+		).thenReturn(
+			"Deleted"
+		);
+
+		Mockito.when(
+			_converter.getExternalUpdatedAtAttributeName()
+		).thenReturn(
+			"External Updated At"
+		);
 	}
 
 	private JiraAssetObject _mockUpsertJiraAssetObject() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -75,6 +75,34 @@ public class AccountOrganizationSynchronizerTest {
 	}
 
 	@Test
+	public void testSoftDeleteByAccount() {
+		_accountOrganizationSynchronizer.softDeleteByAccount("account-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_accountTeamRoleAssignmentConverter,
+			AccountTeamRoleAssignmentConstants.
+				ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+			"account-erc"
+		);
+	}
+
+	@Test
+	public void testSoftDeleteByOrganization() {
+		_accountOrganizationSynchronizer.softDeleteByOrganization(
+			"organization-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_accountTeamRoleAssignmentConverter,
+			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+			"organization-erc"
+		);
+	}
+
+	@Test
 	public void testSyncAssignOrganizationWaitsForSyncAssignOrganization()
 		throws Exception {
 
@@ -95,6 +123,28 @@ public class AccountOrganizationSynchronizerTest {
 			() -> _accountOrganizationSynchronizer.syncAssignOrganization(
 				"organization-erc", "account-erc"),
 			"upsert", "upsert");
+	}
+
+	@Test
+	public void testSyncUnassignOrganizationMarksAssignmentDeleted()
+		throws Exception {
+
+		_accountOrganizationSynchronizer.syncUnassignOrganization(
+			_ORGANIZATION_EXTERNAL_KEY, _ACCOUNT_EXTERNAL_KEY);
+
+		Mockito.verify(
+			_accountTeamRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.any(), Mockito.eq(_ORGANIZATION_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(true), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
+			Mockito.isNull()
+		);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -162,6 +163,66 @@ public class AccountSynchronizerTest {
 			Mockito.mock(TeamConverter.class));
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_userAccountService", _userAccountService);
+	}
+
+	@Test
+	public void testDeleteAccountContinuesWhenSoftDeleteFails() {
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_accountOrganizationSynchronizer
+		).softDeleteByAccount(
+			Mockito.any()
+		);
+
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_accountUserAccountRoleSynchronizer
+		).softDeleteByAccount(
+			Mockito.any()
+		);
+
+		_accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE);
+
+		Mockito.verify(
+			_accountUserAccountRoleSynchronizer
+		).softDeleteByAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
+	}
+
+	@Test
+	public void testDeleteAccountSoftDeletesAssignmentsFirst() {
+		_accountSynchronizer.deleteAccount(_EXTERNAL_REFERENCE_CODE);
+
+		InOrder inOrder = Mockito.inOrder(
+			_accountOrganizationSynchronizer,
+			_accountUserAccountRoleSynchronizer, _jiraAssetService);
+
+		inOrder.verify(
+			_accountOrganizationSynchronizer
+		).softDeleteByAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_accountUserAccountRoleSynchronizer
+		).softDeleteByAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
@@ -86,6 +86,35 @@ public class AccountUserAccountRoleSynchronizerTest {
 	}
 
 	@Test
+	public void testSoftDeleteByAccount() {
+		_accountUserAccountRoleSynchronizer.softDeleteByAccount("account-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_accountContactRoleAssignmentConverter,
+			AccountContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY,
+			"account-erc"
+		);
+	}
+
+	@Test
+	public void testSoftDeleteByUserAccount() {
+		_accountUserAccountRoleSynchronizer.softDeleteByUserAccount(
+			"user-account-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_accountContactRoleAssignmentConverter,
+			AccountContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+			"user-account-erc"
+		);
+	}
+
+	@Test
 	public void testSyncUnassignStaleRolesExcludesCurrentAssignments()
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationSynchronizerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -64,12 +65,17 @@ public class OrganizationSynchronizerTest {
 			Collections.emptyList()
 		);
 
+		_accountOrganizationSynchronizer = Mockito.mock(
+			AccountOrganizationSynchronizer.class);
+		_organizationUserAccountRoleSynchronizer = Mockito.mock(
+			OrganizationUserAccountRoleSynchronizer.class);
+
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_accountConverter",
 			Mockito.mock(AccountConverter.class));
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_accountOrganizationSynchronizer",
-			Mockito.mock(AccountOrganizationSynchronizer.class));
+			_accountOrganizationSynchronizer);
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_contactConverter",
 			Mockito.mock(ContactConverter.class));
@@ -81,6 +87,10 @@ public class OrganizationSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_jiraSyncLock", new JiraSyncLock());
 		ReflectionTestUtils.setField(
+			_organizationSynchronizer,
+			"_organizationUserAccountRoleSynchronizer",
+			_organizationUserAccountRoleSynchronizer);
+		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_propertyService", propertyService);
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_teamConverter", teamConverter);
@@ -90,6 +100,66 @@ public class OrganizationSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_organizationSynchronizer, "_userAccountService",
 			userAccountService);
+	}
+
+	@Test
+	public void testDeleteOrganizationContinuesWhenSoftDeleteFails() {
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_accountOrganizationSynchronizer
+		).softDeleteByOrganization(
+			Mockito.any()
+		);
+
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByOrganization(
+			Mockito.any()
+		);
+
+		_organizationSynchronizer.deleteOrganization(_EXTERNAL_REFERENCE_CODE);
+
+		Mockito.verify(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByOrganization(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
+	}
+
+	@Test
+	public void testDeleteOrganizationSoftDeletesAssignmentsFirst() {
+		_organizationSynchronizer.deleteOrganization(_EXTERNAL_REFERENCE_CODE);
+
+		InOrder inOrder = Mockito.inOrder(
+			_accountOrganizationSynchronizer, _jiraAssetService,
+			_organizationUserAccountRoleSynchronizer);
+
+		inOrder.verify(
+			_accountOrganizationSynchronizer
+		).softDeleteByOrganization(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByOrganization(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
 	}
 
 	@Test
@@ -153,8 +223,11 @@ public class OrganizationSynchronizerTest {
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
+	private AccountOrganizationSynchronizer _accountOrganizationSynchronizer;
 	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
 	private OrganizationSynchronizer _organizationSynchronizer;
+	private OrganizationUserAccountRoleSynchronizer
+		_organizationUserAccountRoleSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizerTest.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.TeamContactRoleAssignmentConstants;
+import com.liferay.one.jira.converter.TeamContactRoleAssignmentConverter;
+import com.liferay.one.jira.service.JiraAssetService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class OrganizationUserAccountRoleSynchronizerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_organizationUserAccountRoleSynchronizer =
+			new OrganizationUserAccountRoleSynchronizer();
+
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+		_teamContactRoleAssignmentConverter = Mockito.mock(
+			TeamContactRoleAssignmentConverter.class);
+
+		ReflectionTestUtils.setField(
+			_organizationUserAccountRoleSynchronizer, "_jiraAssetService",
+			_jiraAssetService);
+		ReflectionTestUtils.setField(
+			_organizationUserAccountRoleSynchronizer,
+			"_teamContactRoleAssignmentConverter",
+			_teamContactRoleAssignmentConverter);
+	}
+
+	@Test
+	public void testSoftDeleteByOrganization() {
+		_organizationUserAccountRoleSynchronizer.softDeleteByOrganization(
+			"organization-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_teamContactRoleAssignmentConverter,
+			TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY,
+			"organization-erc"
+		);
+	}
+
+	@Test
+	public void testSoftDeleteByUserAccount() {
+		_organizationUserAccountRoleSynchronizer.softDeleteByUserAccount(
+			"user-account-erc");
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDeleteByAttribute(
+			_teamContactRoleAssignmentConverter,
+			TeamContactRoleAssignmentConstants.
+				ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
+			"user-account-erc"
+		);
+	}
+
+	private JiraAssetService _jiraAssetService;
+	private OrganizationUserAccountRoleSynchronizer
+		_organizationUserAccountRoleSynchronizer;
+	private TeamContactRoleAssignmentConverter
+		_teamContactRoleAssignmentConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrphanedAssignmentReconcilerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrphanedAssignmentReconcilerTest.java
@@ -1,0 +1,395 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.one.jira.constants.AccountContactRoleAssignmentConstants;
+import com.liferay.one.jira.constants.AccountTeamRoleAssignmentConstants;
+import com.liferay.one.jira.constants.TeamContactRoleAssignmentConstants;
+import com.liferay.one.jira.converter.AccountContactRoleAssignmentConverter;
+import com.liferay.one.jira.converter.AccountConverter;
+import com.liferay.one.jira.converter.AccountTeamRoleAssignmentConverter;
+import com.liferay.one.jira.converter.ContactConverter;
+import com.liferay.one.jira.converter.ContactRoleConverter;
+import com.liferay.one.jira.converter.TeamContactRoleAssignmentConverter;
+import com.liferay.one.jira.converter.TeamConverter;
+import com.liferay.one.jira.converter.TeamRoleConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.jira.util.AQLUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class OrphanedAssignmentReconcilerTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_orphanedAssignmentReconciler = new OrphanedAssignmentReconciler();
+
+		_accountContactRoleAssignmentConverter = Mockito.mock(
+			AccountContactRoleAssignmentConverter.class);
+		_accountConverter = Mockito.mock(AccountConverter.class);
+		_accountTeamRoleAssignmentConverter = Mockito.mock(
+			AccountTeamRoleAssignmentConverter.class);
+		_contactConverter = Mockito.mock(ContactConverter.class);
+		_contactRoleConverter = Mockito.mock(ContactRoleConverter.class);
+		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+		_teamContactRoleAssignmentConverter = Mockito.mock(
+			TeamContactRoleAssignmentConverter.class);
+		_teamConverter = Mockito.mock(TeamConverter.class);
+		_teamRoleConverter = Mockito.mock(TeamRoleConverter.class);
+
+		Mockito.when(
+			_accountContactRoleAssignmentConverter.getDeletedAttributeName()
+		).thenReturn(
+			AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED
+		);
+
+		Mockito.when(
+			_accountTeamRoleAssignmentConverter.getDeletedAttributeName()
+		).thenReturn(
+			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED
+		);
+
+		Mockito.when(
+			_teamContactRoleAssignmentConverter.getDeletedAttributeName()
+		).thenReturn(
+			TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED
+		);
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler,
+			"_accountContactRoleAssignmentConverter",
+			_accountContactRoleAssignmentConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_accountConverter",
+			_accountConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler,
+			"_accountTeamRoleAssignmentConverter",
+			_accountTeamRoleAssignmentConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_contactConverter",
+			_contactConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_contactRoleConverter",
+			_contactRoleConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_jiraAssetService",
+			_jiraAssetService);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler,
+			"_teamContactRoleAssignmentConverter",
+			_teamContactRoleAssignmentConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_teamConverter", _teamConverter);
+		ReflectionTestUtils.setField(
+			_orphanedAssignmentReconciler, "_teamRoleConverter",
+			_teamRoleConverter);
+	}
+
+	@Test
+	public void testOnApplicationReadyReconcilesOrphanedAssignments() {
+		_orphanedAssignmentReconciler.onApplicationReady();
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.times(3)
+		).getJiraAssetObjects(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsContinuesAfterTypeFailure() {
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(
+				Mockito.eq(_accountContactRoleAssignmentConverter),
+				Mockito.any())
+		).thenThrow(
+			new RuntimeException()
+		);
+
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		Mockito.verify(
+			_jiraAssetService
+		).getJiraAssetObjects(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).getJiraAssetObjects(
+			Mockito.eq(_teamContactRoleAssignmentConverter), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsQueriesLiveCandidatesWithEmptyReferences() {
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		ArgumentCaptor<Consumer<AQLUtil.Builder>> consumerArgumentCaptor =
+			ArgumentCaptor.forClass(Consumer.class);
+
+		Mockito.verify(
+			_jiraAssetService
+		).getJiraAssetObjects(
+			Mockito.eq(_accountTeamRoleAssignmentConverter),
+			consumerArgumentCaptor.capture()
+		);
+
+		AQLUtil.Builder aqlBuilder = AQLUtil.builder("base");
+
+		Consumer<AQLUtil.Builder> consumer = consumerArgumentCaptor.getValue();
+
+		consumer.accept(aqlBuilder);
+
+		Assertions.assertEquals(
+			"base AND \"Deleted\" = false AND (\"Account\" IS EMPTY OR " +
+				"\"Team\" IS EMPTY OR \"Team Role\" IS EMPTY)",
+			aqlBuilder.build());
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsSkipsFreshAssignments() {
+		JiraAssetObject orphanedJiraAssetObject = _createJiraAssetObject(
+			null, "team-1", "role-1");
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(
+				Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(orphanedJiraAssetObject)
+		);
+
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		ArgumentCaptor<Predicate<JiraAssetObject>> predicateArgumentCaptor =
+			ArgumentCaptor.forClass(Predicate.class);
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDelete(
+			Mockito.eq(_accountTeamRoleAssignmentConverter),
+			Mockito.eq(orphanedJiraAssetObject),
+			predicateArgumentCaptor.capture()
+		);
+
+		JiraAssetObject existingJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		Mockito.when(
+			_jiraAssetService.isUpdatedSince(
+				Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
+				Mockito.eq(existingJiraAssetObject))
+		).thenReturn(
+			true
+		);
+
+		Predicate<JiraAssetObject> predicate =
+			predicateArgumentCaptor.getValue();
+
+		Assertions.assertTrue(predicate.test(existingJiraAssetObject));
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsSkipsOverlappingRun() {
+		AtomicInteger searchCount = new AtomicInteger();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				if (searchCount.incrementAndGet() == 1) {
+					_orphanedAssignmentReconciler.
+						reconcileOrphanedAssignments();
+				}
+
+				return Collections.emptyList();
+			}
+		);
+
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		Assertions.assertEquals(3, searchCount.get());
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsSkipsUnsupportedConverter() {
+		Mockito.when(
+			_accountContactRoleAssignmentConverter.getDeletedAttributeName()
+		).thenThrow(
+			new UnsupportedOperationException()
+		);
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(
+				Mockito.eq(_accountContactRoleAssignmentConverter),
+				Mockito.any())
+		).thenAnswer(
+			invocation -> {
+				Consumer<AQLUtil.Builder> consumer = invocation.getArgument(1);
+
+				consumer.accept(AQLUtil.builder("base"));
+
+				return Collections.emptyList();
+			}
+		);
+
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).softDelete(
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any(),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).getJiraAssetObjects(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).getJiraAssetObjects(
+			Mockito.eq(_teamContactRoleAssignmentConverter), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReconcileOrphanedAssignmentsSoftDeletesUnresolvableCandidates() {
+		JiraAssetObject healthyJiraAssetObject = _createJiraAssetObject(
+			"account-1", "team-1", "role-1");
+		JiraAssetObject missingKeyJiraAssetObject = _createJiraAssetObject(
+			"account-1", null, "role-1");
+		JiraAssetObject orphanedJiraAssetObject = _createJiraAssetObject(
+			"account-1", "team-gone", "role-1");
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(
+				Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any())
+		).thenReturn(
+			Arrays.asList(
+				healthyJiraAssetObject, missingKeyJiraAssetObject,
+				orphanedJiraAssetObject)
+		);
+
+		Mockito.when(
+			_jiraAssetService.getExternalKeyToObjectIdMap(
+				Mockito.eq(_accountConverter), Mockito.anyCollection())
+		).thenReturn(
+			Collections.singletonMap("account-1", "account-object-id")
+		);
+
+		Mockito.when(
+			_jiraAssetService.getExternalKeyToObjectIdMap(
+				Mockito.eq(_teamConverter), Mockito.anyCollection())
+		).thenReturn(
+			Collections.singletonMap("team-1", "team-object-id")
+		);
+
+		Mockito.when(
+			_jiraAssetService.getExternalKeyToObjectIdMap(
+				Mockito.eq(_teamRoleConverter), Mockito.anyCollection())
+		).thenReturn(
+			Collections.singletonMap("role-1", "team-role-object-id")
+		);
+
+		_orphanedAssignmentReconciler.reconcileOrphanedAssignments();
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDelete(
+			Mockito.eq(_accountTeamRoleAssignmentConverter),
+			Mockito.eq(missingKeyJiraAssetObject), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).softDelete(
+			Mockito.eq(_accountTeamRoleAssignmentConverter),
+			Mockito.eq(orphanedJiraAssetObject), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).softDelete(
+			Mockito.eq(_accountTeamRoleAssignmentConverter),
+			Mockito.eq(healthyJiraAssetObject), Mockito.any()
+		);
+	}
+
+	private JiraAssetObject _createJiraAssetObject(
+		String accountExternalKey, String teamExternalKey,
+		String teamRoleExternalKey) {
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY)
+		).thenReturn(
+			accountExternalKey
+		);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY)
+		).thenReturn(
+			teamExternalKey
+		);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_ROLE_EXTERNAL_KEY)
+		).thenReturn(
+			teamRoleExternalKey
+		);
+
+		return jiraAssetObject;
+	}
+
+	private AccountContactRoleAssignmentConverter
+		_accountContactRoleAssignmentConverter;
+	private AccountConverter _accountConverter;
+	private AccountTeamRoleAssignmentConverter
+		_accountTeamRoleAssignmentConverter;
+	private ContactConverter _contactConverter;
+	private ContactRoleConverter _contactRoleConverter;
+	private JiraAssetService _jiraAssetService;
+	private OrphanedAssignmentReconciler _orphanedAssignmentReconciler;
+	private TeamContactRoleAssignmentConverter
+		_teamContactRoleAssignmentConverter;
+	private TeamConverter _teamConverter;
+	private TeamRoleConverter _teamRoleConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -38,8 +39,12 @@ public class UserAccountSynchronizerTest {
 	public void setUp() throws Exception {
 		_userAccountSynchronizer = new UserAccountSynchronizer();
 
+		_accountUserAccountRoleSynchronizer = Mockito.mock(
+			AccountUserAccountRoleSynchronizer.class);
 		_contactConverter = Mockito.mock(ContactConverter.class);
 		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+		_organizationUserAccountRoleSynchronizer = Mockito.mock(
+			OrganizationUserAccountRoleSynchronizer.class);
 
 		PropertyService propertyService = Mockito.mock(PropertyService.class);
 
@@ -62,7 +67,7 @@ public class UserAccountSynchronizerTest {
 			Mockito.mock(AccountConverter.class));
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_accountUserAccountRoleSynchronizer",
-			Mockito.mock(AccountUserAccountRoleSynchronizer.class));
+			_accountUserAccountRoleSynchronizer);
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_contactConverter", _contactConverter);
 		ReflectionTestUtils.setField(
@@ -84,7 +89,7 @@ public class UserAccountSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer,
 			"_organizationUserAccountRoleSynchronizer",
-			Mockito.mock(OrganizationUserAccountRoleSynchronizer.class));
+			_organizationUserAccountRoleSynchronizer);
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_phoneConverter",
 			Mockito.mock(PhoneConverter.class));
@@ -93,6 +98,66 @@ public class UserAccountSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_teamConverter",
 			Mockito.mock(TeamConverter.class));
+	}
+
+	@Test
+	public void testDeleteUserAccountContinuesWhenSoftDeleteFails() {
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_accountUserAccountRoleSynchronizer
+		).softDeleteByUserAccount(
+			Mockito.any()
+		);
+
+		Mockito.doThrow(
+			new RuntimeException()
+		).when(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByUserAccount(
+			Mockito.any()
+		);
+
+		_userAccountSynchronizer.deleteUserAccount(_EXTERNAL_REFERENCE_CODE);
+
+		Mockito.verify(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByUserAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
+	}
+
+	@Test
+	public void testDeleteUserAccountSoftDeletesAssignmentsFirst() {
+		_userAccountSynchronizer.deleteUserAccount(_EXTERNAL_REFERENCE_CODE);
+
+		InOrder inOrder = Mockito.inOrder(
+			_accountUserAccountRoleSynchronizer, _jiraAssetService,
+			_organizationUserAccountRoleSynchronizer);
+
+		inOrder.verify(
+			_accountUserAccountRoleSynchronizer
+		).softDeleteByUserAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_organizationUserAccountRoleSynchronizer
+		).softDeleteByUserAccount(
+			_EXTERNAL_REFERENCE_CODE
+		);
+
+		inOrder.verify(
+			_jiraAssetService
+		).delete(
+			Mockito.any(), Mockito.eq(_EXTERNAL_REFERENCE_CODE)
+		);
 	}
 
 	@Test
@@ -181,9 +246,13 @@ public class UserAccountSynchronizerTest {
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
+	private AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer;
 	private ContactConverter _contactConverter;
 	private JiraAssetObject _jiraAssetObject;
 	private JiraAssetService _jiraAssetService;
+	private OrganizationUserAccountRoleSynchronizer
+		_organizationUserAccountRoleSynchronizer;
 	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/util/AQLUtilTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/util/AQLUtilTest.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class AQLUtilTest {
+
+	@Test
+	public void testAndAnyEmpty() {
+		AQLUtil.Builder builder = AQLUtil.builder("base");
+
+		builder.andAnyEmpty("Account", "Team", "Team Role");
+
+		Assertions.assertEquals(
+			"base AND (\"Account\" IS EMPTY OR \"Team\" IS EMPTY OR \"Team " +
+				"Role\" IS EMPTY)",
+			builder.build());
+	}
+
+	@Test
+	public void testAndAnyEmptyRequiresFieldNames() {
+		AQLUtil.Builder builder = AQLUtil.builder("base");
+
+		Assertions.assertThrows(
+			IllegalArgumentException.class, builder::andAnyEmpty);
+	}
+
+	@Test
+	public void testAndAnyEmptySingleFieldName() {
+		AQLUtil.Builder builder = AQLUtil.builder("base");
+
+		builder.andAnyEmpty("Account");
+
+		Assertions.assertEquals(
+			"base AND (\"Account\" IS EMPTY)", builder.build());
+	}
+
+	@Test
+	public void testAndEqualsBoolean() {
+		AQLUtil.Builder builder = AQLUtil.builder("base");
+
+		builder.andEquals(false, "Deleted");
+
+		Assertions.assertEquals(
+			"base AND \"Deleted\" = false", builder.build());
+	}
+
+	@Test
+	public void testAndEqualsString() {
+		AQLUtil.Builder builder = AQLUtil.builder("base");
+
+		builder.andEquals("team-key", "Team External Key");
+
+		Assertions.assertEquals(
+			"base AND \"Team External Key\" = \"team-key\"", builder.build());
+	}
+
+}


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-100046](https://liferay.atlassian.net/browse/LPD-100046)
Technical Task: [LPD-100047](https://liferay.atlassian.net/browse/LPD-100047)

## What is being fixed

Deleting an account, organization, or user account removed only that entity's own JSM asset object. Its assignment asset objects (Account Team Role, Account Contact Role, and Team Contact Role Assignments) were left behind as live orphans, and a delete that failed transiently was never retried, so entity assets could dangle as well.

## How it is being fixed

Assignment asset object types gain a Deleted attribute, and JiraAssetService can soft delete an asset object by patching that attribute instead of removing the record. Entity delete paths now cascade: before deleting the entity asset, each synchronizer soft deletes the assignments that reference it, continuing past per-object failures. JiraAssetPersistence retries transient delete failures (5xx and 429) with bounded backoff and treats a 404 as an idempotent success. Anything the cascades miss is caught by the new OrphanedAssignmentReconciler, which runs at startup and on a nightly cron, finds live assignments whose reference attributes JSM cleared on delete, batch-resolves their external keys, and soft deletes the unresolvable ones — guarded by an isUpdatedSince check inside the asset lock so a concurrent legitimate write is never undone.

[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-100046]: https://liferay.atlassian.net/browse/LPD-100046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-100047]: https://liferay.atlassian.net/browse/LPD-100047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ