### PR TITLE
LPD-89437 LPD-101487 Bound the JSM stale assignment sweep query

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizer.java
@@ -13,6 +13,7 @@ import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.one.util.FindUtil;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
@@ -74,29 +75,25 @@ public class AccountOrganizationSynchronizer {
 		List<JiraAssetObject> jiraAssetObjects =
 			_jiraAssetService.getJiraAssetObjects(
 				_accountTeamRoleAssignmentConverter,
-				aqlBuilder -> {
-					aqlBuilder.andEquals(
-						accountExternalKey,
-						AccountTeamRoleAssignmentConstants.
-							ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
-					).andEquals(
-						false,
-						AccountTeamRoleAssignmentConstants.
-							ATTRIBUTE_NAME_DELETED
-					);
-
-					if (!organizationExternalKeys.isEmpty()) {
-						aqlBuilder.andNotIn(
-							organizationExternalKeys,
-							AccountTeamRoleAssignmentConstants.
-								ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY);
-					}
-				});
+				aqlBuilder -> aqlBuilder.andEquals(
+					accountExternalKey,
+					AccountTeamRoleAssignmentConstants.
+						ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
+				).andEquals(
+					false,
+					AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED
+				));
 
 		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
 			String organizationExternalKey = jiraAssetObject.getAttributeValue(
 				AccountTeamRoleAssignmentConstants.
 					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY);
+
+			if (FindUtil.containsIgnoreCase(
+					organizationExternalKeys, organizationExternalKey)) {
+
+				continue;
+			}
 
 			try {
 				_jiraSyncLock.withLock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizer.java
@@ -13,6 +13,7 @@ import com.liferay.one.jira.converter.ContactRoleConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.util.JiraSyncLock;
+import com.liferay.one.util.FindUtil;
 import com.liferay.petra.string.StringBundler;
 
 import java.util.Date;
@@ -90,26 +91,23 @@ public class AccountUserAccountRoleSynchronizer {
 		List<JiraAssetObject> jiraAssetObjects =
 			_jiraAssetService.getJiraAssetObjects(
 				_accountContactRoleAssignmentConverter,
-				aqlBuilder -> {
-					aqlBuilder.andEquals(
-						accountExternalKey,
-						AccountContactRoleAssignmentConstants.
-							ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
-					).andEquals(
-						false,
-						AccountContactRoleAssignmentConstants.
-							ATTRIBUTE_NAME_DELETED
-					);
-
-					if (!names.isEmpty()) {
-						aqlBuilder.andNotIn(
-							names,
-							AccountContactRoleAssignmentConstants.
-								ATTRIBUTE_NAME_NAME);
-					}
-				});
+				aqlBuilder -> aqlBuilder.andEquals(
+					accountExternalKey,
+					AccountContactRoleAssignmentConstants.
+						ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY
+				).andEquals(
+					false,
+					AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED
+				));
 
 		for (JiraAssetObject jiraAssetObject : jiraAssetObjects) {
+			String name = jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME);
+
+			if (FindUtil.containsIgnoreCase(names, name)) {
+				continue;
+			}
+
 			String roleExternalKey = jiraAssetObject.getAttributeValue(
 				AccountContactRoleAssignmentConstants.
 					ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/util/AQLUtil.java
@@ -96,26 +96,6 @@ public class AQLUtil {
 			return this;
 		}
 
-		public Builder andNotIn(
-			Collection<String> values, String... fieldNames) {
-
-			if (values.isEmpty()) {
-				throw new IllegalArgumentException(
-					"A NOT IN clause requires at least one value");
-			}
-
-			_sb.append(" AND ");
-			_sb.append(_field(fieldNames));
-			_sb.append(" NOT IN (");
-			_sb.append(
-				StringUtil.merge(
-					TransformUtil.transform(values, AQLUtil::_quote),
-					StringPool.COMMA_AND_SPACE));
-			_sb.append(")");
-
-			return this;
-		}
-
 		public String build() {
 			return _sb.toString();
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/FindUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/FindUtil.java
@@ -5,7 +5,10 @@
 
 package com.liferay.one.util;
 
+import com.liferay.portal.kernel.util.StringUtil;
+
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -13,6 +16,22 @@ import java.util.function.Predicate;
  * @author Drew Brokke
  */
 public class FindUtil {
+
+	public static boolean containsIgnoreCase(
+		Collection<String> collection, String value) {
+
+		if (collection == null) {
+			return false;
+		}
+
+		for (String string : collection) {
+			if (StringUtil.equalsIgnoreCase(string, value)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 	public static <T> T findFirst(List<T> list, Predicate<T> predicate) {
 		if (list == null) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -13,7 +13,7 @@ import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.one.jira.util.JiraSyncLock;
-import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Collections;
 import java.util.Date;
@@ -148,27 +148,7 @@ public class AccountOrganizationSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncUnassignStaleOrganizationsExcludesCurrentAssignments()
-		throws Exception {
-
-		AtomicReference<String> aqlAtomicReference = _captureAQL();
-
-		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
-			_ACCOUNT_EXTERNAL_KEY,
-			Collections.singleton(_ORGANIZATION_EXTERNAL_KEY), new Date());
-
-		Assertions.assertEquals(
-			StringBundler.concat(
-				"base AND \"Account External Key\" = \"account-erc\" AND ",
-				"\"Deleted\" = false AND \"Team External Key\" NOT IN ",
-				"(\"organization-erc\")"),
-			aqlAtomicReference.get());
-	}
-
-	@Test
-	public void testSyncUnassignStaleOrganizationsExcludesDeletedAssignments()
-		throws Exception {
-
+	public void testSyncUnassignStaleOrganizationsBaseAQL() throws Exception {
 		AtomicReference<String> aqlAtomicReference = _captureAQL();
 
 		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
@@ -178,6 +158,20 @@ public class AccountOrganizationSynchronizerTest {
 			"base AND \"Account External Key\" = \"account-erc\" AND " +
 				"\"Deleted\" = false",
 			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleOrganizationsSkipsCaseDifferingCurrentAssignments()
+		throws Exception {
+
+		_assertSkipped(StringUtil.toUpperCase(_ORGANIZATION_EXTERNAL_KEY));
+	}
+
+	@Test
+	public void testSyncUnassignStaleOrganizationsSkipsCurrentAssignments()
+		throws Exception {
+
+		_assertSkipped(_ORGANIZATION_EXTERNAL_KEY);
 	}
 
 	@Test
@@ -254,6 +248,26 @@ public class AccountOrganizationSynchronizerTest {
 		).upsert(
 			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
 			Mockito.any()
+		);
+	}
+
+	private void _assertSkipped(String organizationExternalKey) {
+		JiraAssetObject jiraAssetObject = _mockAssignment();
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
+			_ACCOUNT_EXTERNAL_KEY,
+			Collections.singleton(organizationExternalKey), new Date());
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).upsert(
+			Mockito.any(), Mockito.any(), Mockito.any()
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
@@ -15,6 +15,7 @@ import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.util.AQLUtil;
 import com.liferay.one.jira.util.JiraSyncLock;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Collections;
 import java.util.Date;
@@ -115,30 +116,7 @@ public class AccountUserAccountRoleSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncUnassignStaleRolesExcludesCurrentAssignments()
-		throws Exception {
-
-		AtomicReference<String> aqlAtomicReference = _captureAQL();
-
-		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
-			_ACCOUNT_EXTERNAL_KEY,
-			Collections.singletonMap(
-				_USER_ACCOUNT_EXTERNAL_KEY,
-				Collections.singleton(_ROLE_EXTERNAL_KEY)),
-			new Date());
-
-		Assertions.assertEquals(
-			StringBundler.concat(
-				"base AND \"Account External Key\" = \"account-erc\" AND ",
-				"\"Deleted\" = false AND \"Name\" NOT IN ",
-				"(\"role-erc;user-account-erc;account-erc\")"),
-			aqlAtomicReference.get());
-	}
-
-	@Test
-	public void testSyncUnassignStaleRolesExcludesDeletedAssignments()
-		throws Exception {
-
+	public void testSyncUnassignStaleRolesBaseAQL() throws Exception {
 		AtomicReference<String> aqlAtomicReference = _captureAQL();
 
 		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
@@ -148,6 +126,20 @@ public class AccountUserAccountRoleSynchronizerTest {
 			"base AND \"Account External Key\" = \"account-erc\" AND " +
 				"\"Deleted\" = false",
 			aqlAtomicReference.get());
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesSkipsCaseDifferingCurrentAssignments()
+		throws Exception {
+
+		_assertSkipped(StringUtil.toUpperCase(_NAME));
+	}
+
+	@Test
+	public void testSyncUnassignStaleRolesSkipsCurrentAssignments()
+		throws Exception {
+
+		_assertSkipped(_NAME);
 	}
 
 	@Test
@@ -232,6 +224,36 @@ public class AccountUserAccountRoleSynchronizerTest {
 		);
 	}
 
+	private void _assertSkipped(String name) {
+		JiraAssetObject jiraAssetObject = _mockAssignment(_ROLE_EXTERNAL_KEY);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME)
+		).thenReturn(
+			name
+		);
+
+		Mockito.when(
+			_jiraAssetService.getJiraAssetObjects(Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(jiraAssetObject)
+		);
+
+		_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
+			_ACCOUNT_EXTERNAL_KEY,
+			Collections.singletonMap(
+				_USER_ACCOUNT_EXTERNAL_KEY,
+				Collections.singleton(_ROLE_EXTERNAL_KEY)),
+			new Date());
+
+		Mockito.verify(
+			_jiraAssetService, Mockito.never()
+		).upsert(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
 	private AtomicReference<String> _captureAQL() {
 		AtomicReference<String> aqlAtomicReference = new AtomicReference<>();
 
@@ -277,6 +299,8 @@ public class AccountUserAccountRoleSynchronizerTest {
 	}
 
 	private static final String _ACCOUNT_EXTERNAL_KEY = "account-erc";
+
+	private static final String _NAME = "role-erc;user-account-erc;account-erc";
 
 	private static final String _ROLE_EXTERNAL_KEY = "role-erc";
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/FindUtilTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/FindUtilTest.java
@@ -5,6 +5,8 @@
 
 package com.liferay.one.util;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
@@ -14,6 +16,28 @@ import org.junit.jupiter.api.Test;
  * @author Drew Brokke
  */
 public class FindUtilTest {
+
+	@Test
+	public void testContainsIgnoreCase() {
+		List<String> values = List.of("Apple", "banana");
+
+		Assertions.assertTrue(FindUtil.containsIgnoreCase(values, "Apple"));
+		Assertions.assertTrue(FindUtil.containsIgnoreCase(values, "apple"));
+		Assertions.assertTrue(FindUtil.containsIgnoreCase(values, "BANANA"));
+
+		Assertions.assertFalse(FindUtil.containsIgnoreCase(values, "cherry"));
+		Assertions.assertFalse(FindUtil.containsIgnoreCase(values, null));
+
+		Assertions.assertFalse(FindUtil.containsIgnoreCase(null, "apple"));
+		Assertions.assertFalse(
+			FindUtil.containsIgnoreCase(Collections.emptyList(), "apple"));
+
+		Assertions.assertTrue(
+			FindUtil.containsIgnoreCase(Arrays.asList("apple", null), null));
+		Assertions.assertFalse(
+			FindUtil.containsIgnoreCase(
+				Arrays.asList("apple", null), "cherry"));
+	}
 
 	@Test
 	public void testFindFirst() {


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-101487](https://liferay.atlassian.net/browse/LPD-101487)

## What is being fixed

The stale sweep's AQL `NOT IN` clause listed every current membership, so the
query grew with the account. JSM could reject it if the query grew too large,
and the sweep would silently do nothing.

## How it is being fixed

Fetch every non-deleted assignment for the account and skip current memberships
in memory, matching AQL's case-insensitive semantics.


[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-101487]: https://liferay.atlassian.net/browse/LPD-101487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ