### PR TITLE
LPD-101851 Surface license key download and activation errors

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/en_US.ts
@@ -1368,6 +1368,7 @@ export default {
 	'unable-to-assign-roles': 'Unable to assign roles',
 	'unable-to-connect-to-file-server': 'Unable to connect to file server.',
 	'unable-to-delete-attachment': 'Unable to delete attachment.',
+	'unable-to-download-the-license-key': 'Unable to download the license key.',
 	'unable-to-download-your-license-file-please-try-again-and-or-contact-support-via-the-manage-menu-on-the-dashboard':
 		'Unable to download your license file.  Please try again and/or contact support via the manage menu on the dashboard.',
 	'unable-to-invite-member': 'Unable to invite member.',
@@ -1517,6 +1518,8 @@ export default {
 		'You do not have access to this page.',
 	'you-do-not-have-access-to-upload-files':
 		'You do not have access to upload files.',
+	'you-do-not-have-an-active-enterprise-search-subscription':
+		'You do not have an active Enterprise Search subscription.',
 	'you-have-reached-the-maximum-number-of-active-trials-allowed-to-start-a-new-trial-please-end-one-of-your-existing-trials-first':
 		'You have reached the maximum number of active trials allowed. To start a new trial, please end one of your existing trials first.',
 	'you-havent-published-any-apps-yet': "You haven't published any apps yet.",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/es_ES.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/es_ES.ts
@@ -122,6 +122,8 @@ export default {
 	'unable-to-connect-to-file-server':
 		'No es posible conectarse al servidor de archivos',
 	'unable-to-delete-attachment': 'No se pudo eliminar el adjunto.',
+	'unable-to-download-the-license-key':
+		'No se pudo descargar la clave de licencia.',
 	'unable-to-load-the-license-keys':
 		'No se pudieron cargar las claves de licencia.',
 	'upgrade': 'Actualización',
@@ -136,6 +138,8 @@ export default {
 	'x-tickets': '{0} Tickets',
 	'you-do-not-have-access-to-upload-files':
 		'No tienes permiso para subir archivos',
+	'you-do-not-have-an-active-enterprise-search-subscription':
+		'No tienes una suscripción activa de Enterprise Search.',
 	'you-need-administrator-or-requester-role-on-this-project-to-upload-a-file':
 		'Necesitas el rol Administrador o Solicitante en este proyecto para poder subir archivos.',
 	'your-attachment-is-uploaded-however-we-encountered-a-problem-posting-your-comment-the-system-is-automatically-retrying-to-send-it':

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/ja_JP.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/ja_JP.ts
@@ -119,6 +119,8 @@ export default {
 	'try-again-later': '後でもう一度試してください。',
 	'unable-to-connect-to-file-server': 'ファイルサーバーに接続できない',
 	'unable-to-delete-attachment': '添付ファイルを削除できませんでした。',
+	'unable-to-download-the-license-key':
+		'ライセンスキーをダウンロードできませんでした。',
 	'unable-to-load-the-license-keys': 'ライセンスキーを読み込めませんでした。',
 	'upgrade': 'アップグレード',
 	'upload': 'アップロード',
@@ -132,6 +134,8 @@ export default {
 	'x-tickets': '{0} チケット',
 	'you-do-not-have-access-to-upload-files':
 		'ファイルをアップロードする権限がない',
+	'you-do-not-have-an-active-enterprise-search-subscription':
+		'有効なEnterprise Searchサブスクリプションがありません。',
 	'you-need-administrator-or-requester-role-on-this-project-to-upload-a-file':
 		'ファイルをアップロードするには、このプロジェクトの管理者または要求者のロールが必要です。',
 	'your-attachment-is-uploaded-however-we-encountered-a-problem-posting-your-comment-the-system-is-automatically-retrying-to-send-it':

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/pt_BR.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/i18n/pt_BR.ts
@@ -123,6 +123,8 @@ export default {
 	'unable-to-connect-to-file-server':
 		'Não foi possível conectar ao servidor de arquivos.',
 	'unable-to-delete-attachment': 'Não foi possível excluir o anexo.',
+	'unable-to-download-the-license-key':
+		'Não foi possível baixar a chave de licença.',
 	'unable-to-load-the-license-keys':
 		'Não foi possível carregar as chaves de licença.',
 	'upgrade': 'Atualização',
@@ -137,6 +139,8 @@ export default {
 	'x-tickets': '{0} Tickets',
 	'you-do-not-have-access-to-upload-files':
 		'Você não tem acesso para enviar arquivos.',
+	'you-do-not-have-an-active-enterprise-search-subscription':
+		'Você não tem uma assinatura ativa do Enterprise Search.',
 	'you-need-administrator-or-requester-role-on-this-project-to-upload-a-file':
 		'Você precisa ter o papel de Administrador ou Solicitante neste projeto para enviar um arquivo.',
 	'your-attachment-is-uploaded-however-we-encountered-a-problem-posting-your-comment-the-system-is-automatically-retrying-to-send-it':

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/Admin/LicenseKeyUploads/LicenseKeyUploads.tsx
@@ -167,11 +167,22 @@ function LicenseKeyUploadsPanel({productGroup}: LicenseKeyUploadsPanelProps) {
 			actions={[
 				{
 					label: 'download',
-					onClick: () =>
-						CommonLicenseKeys.downloadCommonLicenseKey(
-							row.id,
-							row.name
-						),
+					onClick: async () => {
+						try {
+							await CommonLicenseKeys.downloadCommonLicenseKey(
+								row.id,
+								row.name
+							);
+						}
+						catch {
+							Liferay.Util.openToast({
+								message: i18n.translate(
+									'unable-to-download-the-license-key'
+								),
+								type: 'danger',
+							});
+						}
+					},
 				},
 				{
 					label: 'delete',

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/components/EnterpriseSearchActivation/EnterpriseSearchActivation.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/components/EnterpriseSearchActivation/EnterpriseSearchActivation.tsx
@@ -5,11 +5,13 @@
 
 import {ClaySelect} from '@clayui/form';
 import {format} from 'date-fns';
-import {useMemo, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import useSWR from 'swr';
 import Button from '~/components/Button/Button';
 import {DetailedCard} from '~/components/DetailedCard/DetailedCard';
 import {translate} from '~/i18n';
+import FetcherError from '~/services/fetcher/FetcherError';
+import {Liferay} from '~/services/liferay/liferay';
 import CommonLicenseKeys, {
 	CommonLicenseKey,
 } from '~/services/spring-boot/CommonLicenseKeys';
@@ -33,7 +35,7 @@ function termLabel(key: CommonLicenseKey): string {
 }
 
 export default function EnterpriseSearchActivation() {
-	const {data} = useSWR<APIResponse<CommonLicenseKey>>(
+	const {data, error} = useSWR<APIResponse<CommonLicenseKey>>(
 		['common-license-keys', 'ENTERPRISE_SEARCH'],
 		() =>
 			CommonLicenseKeys.getCommonLicenseKeys({
@@ -42,6 +44,17 @@ export default function EnterpriseSearchActivation() {
 				productGroup: 'ENTERPRISE_SEARCH',
 			})
 	);
+
+	const notEntitled = (error as FetcherError)?.status === 403;
+
+	useEffect(() => {
+		if (error && !notEntitled) {
+			Liferay.Util.openToast({
+				message: translate('unable-to-load-the-license-keys'),
+				type: 'danger',
+			});
+		}
+	}, [error, notEntitled]);
 
 	const keys = useMemo(() => data?.items ?? [], [data]);
 
@@ -70,12 +83,22 @@ export default function EnterpriseSearchActivation() {
 	const selectedTerm =
 		terms.find((key) => String(key.id) === termId) ?? terms[0];
 
-	const handleDownload = () => {
-		if (selectedTerm) {
-			CommonLicenseKeys.downloadCommonLicenseKey(
+	const handleDownload = async () => {
+		if (!selectedTerm) {
+			return;
+		}
+
+		try {
+			await CommonLicenseKeys.downloadCommonLicenseKey(
 				selectedTerm.id,
 				selectedTerm.name
 			);
+		}
+		catch {
+			Liferay.Util.openToast({
+				message: translate('unable-to-download-the-license-key'),
+				type: 'danger',
+			});
 		}
 	};
 
@@ -86,80 +109,98 @@ export default function EnterpriseSearchActivation() {
 			className="mt-3"
 			clayIcon="key"
 		>
-			<p className="mt-3 text-neutral-7">
-				{translate(
-					'select-an-active-enterprise-search-subscription-to-download-the-activation-key'
-				)}
-			</p>
-
-			<div
-				className="d-flex flex-wrap"
-				style={{gap: 'var(--spacer-4)', maxWidth: '32rem'}}
-			>
-				<div className="flex-grow-1">
-					<label htmlFor="enterprise-search-subscription">
-						{translate('subscription')}
-					</label>
-
-					<ClaySelect
-						id="enterprise-search-subscription"
-						onChange={(event) => {
-							setSubscription(event.target.value);
-							setTermId('');
-						}}
-						value={selectedSubscription}
-					>
-						{subscriptions.map((option) => (
-							<ClaySelect.Option
-								key={option}
-								label={option}
-								value={option}
-							/>
-						))}
-					</ClaySelect>
-				</div>
-
-				<div className="flex-grow-1">
-					<label htmlFor="enterprise-search-term">
-						{translate('subscription-term')}
-					</label>
-
-					<ClaySelect
-						id="enterprise-search-term"
-						onChange={(event) => setTermId(event.target.value)}
-						value={selectedTerm ? String(selectedTerm.id) : ''}
-					>
-						{terms.map((key) => (
-							<ClaySelect.Option
-								key={key.id}
-								label={termLabel(key)}
-								value={String(key.id)}
-							/>
-						))}
-					</ClaySelect>
-				</div>
-			</div>
-
-			<Button
-				className="mt-4"
-				disabled={!selectedTerm}
-				displayType="secondary"
-				onClick={handleDownload}
-				prependIcon="download"
-			>
-				{translate('download-key')}
-			</Button>
-
-			<p className="mt-4 text-neutral-7">
-				{translate(
-					'for-instructions-on-how-to-setup-your-software-read'
-				)}{' '}
-				<a href={GETTING_STARTED_URL} rel="noopener" target="_blank">
+			{notEntitled ? (
+				<p className="mt-3 text-neutral-7">
 					{translate(
-						'getting-started-with-liferay-enterprise-search-article'
+						'you-do-not-have-an-active-enterprise-search-subscription'
 					)}
-				</a>
-			</p>
+				</p>
+			) : (
+				<>
+					<p className="mt-3 text-neutral-7">
+						{translate(
+							'select-an-active-enterprise-search-subscription-to-download-the-activation-key'
+						)}
+					</p>
+
+					<div
+						className="d-flex flex-wrap"
+						style={{gap: 'var(--spacer-4)', maxWidth: '32rem'}}
+					>
+						<div className="flex-grow-1">
+							<label htmlFor="enterprise-search-subscription">
+								{translate('subscription')}
+							</label>
+
+							<ClaySelect
+								id="enterprise-search-subscription"
+								onChange={(event) => {
+									setSubscription(event.target.value);
+									setTermId('');
+								}}
+								value={selectedSubscription}
+							>
+								{subscriptions.map((option) => (
+									<ClaySelect.Option
+										key={option}
+										label={option}
+										value={option}
+									/>
+								))}
+							</ClaySelect>
+						</div>
+
+						<div className="flex-grow-1">
+							<label htmlFor="enterprise-search-term">
+								{translate('subscription-term')}
+							</label>
+
+							<ClaySelect
+								id="enterprise-search-term"
+								onChange={(event) =>
+									setTermId(event.target.value)
+								}
+								value={
+									selectedTerm ? String(selectedTerm.id) : ''
+								}
+							>
+								{terms.map((key) => (
+									<ClaySelect.Option
+										key={key.id}
+										label={termLabel(key)}
+										value={String(key.id)}
+									/>
+								))}
+							</ClaySelect>
+						</div>
+					</div>
+
+					<Button
+						className="mt-4"
+						disabled={!selectedTerm}
+						displayType="secondary"
+						onClick={handleDownload}
+						prependIcon="download"
+					>
+						{translate('download-key')}
+					</Button>
+
+					<p className="mt-4 text-neutral-7">
+						{translate(
+							'for-instructions-on-how-to-setup-your-software-read'
+						)}{' '}
+						<a
+							href={GETTING_STARTED_URL}
+							rel="noopener"
+							target="_blank"
+						>
+							{translate(
+								'getting-started-with-liferay-enterprise-search-article'
+							)}
+						</a>
+					</p>
+				</>
+			)}
 		</DetailedCard>
 	);
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101851

## What is being fixed

The common license key download actions gave no feedback when a download
failed. In the admin License Key Uploads table and the customer Enterprise
Search activation card, a failed download left the user with nothing — no
toast, no message — unlike the upload and delete actions, which already
report failure. The customer activation card also ignored its list request
error entirely, so an account that is not entitled to Enterprise Search, or
a request that genuinely failed, rendered a blank card with no explanation.

## How it is being fixed

The admin and customer download actions now wrap the download in a try/catch
and show a danger toast on failure. The customer activation card
distinguishes a permission denial from a real failure: a 403 from the
entitlement gate means the account has no active Enterprise Search
subscription, so it shows an inline message rather than an error toast, while
any other failure shows the danger toast. New language keys cover the two
messages across all four locales.