### PR TITLE
LPD-98516 Fix the SEO Studio purchase flow on the product page

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/ProductPurchase/pages/LiferayProduct/SEOStudio/SEOStudioRequirementsModal.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/ProductPurchase/pages/LiferayProduct/SEOStudio/SEOStudioRequirementsModal.tsx
@@ -29,6 +29,8 @@ const SEOStudioRequirementsModal: React.FC<SEOStudioRequirementsModalProps> = ({
 		await onContinue().catch(console.error);
 
 		setLoading(false);
+
+		onOpenChange(false);
 	};
 
 	return (

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/configuration.json
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/configuration.json
@@ -1,23 +1,23 @@
 {
 	"fieldSets": [
 		{
-			"label": "Configuration",
 			"fields": [
 				{
-					"name": "buttonText",
-					"label": "Button text",
-					"type": "text",
 					"defaultValue": "Get App",
-					"description": "Button text"
+					"description": "Button text",
+					"label": "Button text",
+					"name": "buttonText",
+					"type": "text"
 				},
 				{
-					"name": "useDescription",
-					"label": "Use Description",
-					"type": "checkbox",
 					"defaultValue": true,
-					"description": "Adds purchase description"
+					"description": "Adds purchase description",
+					"label": "Use Description",
+					"name": "useDescription",
+					"type": "checkbox"
 				}
-			]
+			],
+			"label": "Configuration"
 		}
 	]
 }

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/configuration.json
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/configuration.json
@@ -1,4 +1,23 @@
 {
 	"fieldSets": [
+		{
+			"label": "Configuration",
+			"fields": [
+				{
+					"name": "buttonText",
+					"label": "Button text",
+					"type": "text",
+					"defaultValue": "Get App",
+					"description": "Button text"
+				},
+				{
+					"name": "useDescription",
+					"label": "Use Description",
+					"type": "checkbox",
+					"defaultValue": true,
+					"description": "Adds purchase description"
+				}
+			]
+		}
 	]
 }

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/index.html
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/index.html
@@ -1,3 +1,6 @@
+[#assign buttonText = configuration.buttonText!"Get App"] [#assign
+useDescription = configuration.useDescription!true]
+
 <span class="d-none product-id" data-lfr-editable-type="text" data-lfr-editable-id="product-id">#</span>
 
 <div class="d-flex justify-content-center">
@@ -20,9 +23,11 @@
 		Contact Sales
 	</a>
 
-	<button class="btn btn-primary d-none" id="get-app" type="button">
-		Get App
+	<button class="btn btn-primary d-none main-button" id="get-app" type="button">
+		${buttonText}
 	</button>
 </div>
 
-<small class="d-flex justify-content-end" id="get-app-description"></small>
+[#if useDescription]
+<small class="d-flex justify-content-end text-nowrap" id="get-app-description"></small>
+[/#if]

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/index.html
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/fragments/group/marketplace-base-fragments/fragments/get-app-button/index.html
@@ -1,5 +1,5 @@
-[#assign buttonText = configuration.buttonText!"Get App"] [#assign
-useDescription = configuration.useDescription!true]
+[#assign buttonText = configuration.buttonText!"Get App"]
+[#assign useDescription = configuration.useDescription!true]
 
 <span class="d-none product-id" data-lfr-editable-type="text" data-lfr-editable-id="product-id">#</span>
 

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/layout-page-templates/display-page-templates/seo-studio/page-definition.json
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-site-initializer/site-initializer/layout-page-templates/display-page-templates/seo-studio/page-definition.json
@@ -485,6 +485,14 @@
 															"id": "product-id",
 															"value": {
 																"fragmentLink": {
+																},
+																"text": {
+																	"mapping": {
+																		"fieldKey": "CPDefinition_cProductId",
+																		"itemReference": {
+																			"contextSource": "DisplayPageItem"
+																		}
+																	}
 																}
 															}
 														}


### PR DESCRIPTION
The requirements modal stayed open after the user continued through the SEO Studio purchase flow, and the Get App button on the product page could not be reused for SEO Studio because its label and description were hardcoded.

The modal now closes once the continue handler settles. The Get App button fragment exposes `buttonText` and `useDescription` configuration fields so the same fragment serves both the regular product page and the SEO Studio page, and the SEO Studio display page template maps the `product-id` editable element to `CPDefinition_cProductId` so the button resolves the product it belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)