### PR TITLE
LPD-102340 Escape the theme name in the Plugins Admin themes list

### DIFF
--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/themes.jspf
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/themes.jspf
@@ -69,7 +69,7 @@ List<Theme> themes = ThemeLocalServiceUtil.getThemes(company.getCompanyId());
 				<aui:a href="<%= showEditPluginHREF ? rowURL.toString() : null %>">
 					<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="plugin-thumbnail" src="<%= curTheme.getStaticResourcePath() + HtmlUtil.escapeAttribute(curTheme.getImagesPath()) %>/thumbnail.png" />
 
-					<strong><%= curTheme.getName() %></strong>
+					<strong><%= HtmlUtil.escape(curTheme.getName()) %></strong>
 				</aui:a>
 
 				<%


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102340

## What Is Being Fixed

The Plugins Admin themes list rendered the theme name straight into `themes.jspf` without escaping, so stored theme metadata was interpreted as markup instead of text. A FindSecBugs and AI-assisted review of the 2025.q1.20 branch surfaced it.

## How It Is Being Fixed

The theme name is passed through `HtmlUtil.escape` before it reaches the `<strong>` element, matching how the surrounding attributes in the same file are already escaped with `HtmlUtil.escapeAttribute`. The fix is ported from LPD-97914, which collected the whole set of these findings but was never merged into master.

## Why Are There No Tests?

This is a one-line output-escaping change in a JSP fragment. There is no unit or integration test layer for JSP rendering in this admin portlet, and a Playwright test asserting a single escaped label would cost more to maintain than it catches. Escaping is verified by the JSP compile in pr-check and by review of the one-line diff.

## PR Check

**pr-check: PASS** — tested on `207c5e6d5a43373154abfbfe90dc4420c6481dfb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "207c5e6d5a43373154abfbfe90dc4420c6481dfb"} -->
