### PR TITLE
LPD-101288 Technical Task | Refresh contact asset attributes during account sync to JSM

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetObject.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/model/JiraAssetObject.java
@@ -62,10 +62,10 @@ public class JiraAssetObject {
 	 * return the id of the referenced object.
 	 */
 	public String getAttributeValue(String attributeName) {
-		String attributeId = _getAttributeId(attributeName);
+		Object value = _values.get(_getAttributeId(attributeName));
 
-		if (_values.containsKey(attributeId)) {
-			return String.valueOf(_values.get(attributeId));
+		if (value != null) {
+			return String.valueOf(value);
 		}
 
 		return _getValue(_getAttributeValueJSONObject(attributeName));

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSyncModel.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSyncModel.java
@@ -1,0 +1,323 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.headless.admin.user.client.dto.v1_0.PostalAddress;
+import com.liferay.headless.admin.user.client.dto.v1_0.Role;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.jira.model.JiraBusinessEvent;
+import com.liferay.one.jira.service.JiraBusinessEventService;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.model.EntitlementDefinition;
+import com.liferay.one.model.Project;
+import com.liferay.one.model.Property;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.OrganizationService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.RoleService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.FindUtil;
+import com.liferay.one.util.role.EmployeeRoles;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountSyncModel {
+
+	public AccountSyncModel(
+		Account account, CommerceOrderService commerceOrderService,
+		EntitlementService entitlementService,
+		ExternalLinkConverter externalLinkConverter,
+		JiraBusinessEventService jiraBusinessEventService,
+		OrganizationService organizationService, ProjectService projectService,
+		PropertyService propertyService, RoleService roleService,
+		UserAccountService userAccountService) {
+
+		_account = account;
+		_commerceOrderService = commerceOrderService;
+		_entitlementService = entitlementService;
+		_externalLinkConverter = externalLinkConverter;
+		_jiraBusinessEventService = jiraBusinessEventService;
+		_organizationService = organizationService;
+		_projectService = projectService;
+		_propertyService = propertyService;
+		_roleService = roleService;
+		_userAccountService = userAccountService;
+	}
+
+	public Account getAccount() {
+		return _account;
+	}
+
+	public List<Organization> getAccountOrganizations() throws Exception {
+		if (_accountOrganizations == null) {
+			_accountOrganizations =
+				_organizationService.getAccountOrganizations(_account.getId());
+		}
+
+		return _accountOrganizations;
+	}
+
+	public Map<String, Role> getAccountRolesByExternalReferenceCode()
+		throws Exception {
+
+		if (_accountRolesByExternalReferenceCode == null) {
+			_accountRolesByExternalReferenceCode = new LinkedHashMap<>();
+
+			for (Role role : _roleService.getAccountRoles()) {
+				_accountRolesByExternalReferenceCode.put(
+					role.getExternalReferenceCode(), role);
+			}
+		}
+
+		return _accountRolesByExternalReferenceCode;
+	}
+
+	public List<UserAccount> getAccountUserAccounts() throws Exception {
+		if (_accountUserAccounts == null) {
+			_accountUserAccounts = _userAccountService.getAccountUserAccounts(
+				_account.getId());
+		}
+
+		return _accountUserAccounts;
+	}
+
+	public List<EntitlementDefinition> getActiveEntitlementDefinitions()
+		throws Exception {
+
+		if (_activeEntitlementDefinitions == null) {
+			_activeEntitlementDefinitions =
+				_entitlementService.getActiveEntitlementDefinitions(
+					_account.getId());
+		}
+
+		return _activeEntitlementDefinitions;
+	}
+
+	public String getBusinessEventsFieldValue() throws Exception {
+		if (_businessEventsFieldValue == null) {
+			_businessEventsFieldValue = _toBusinessEventsFieldValue();
+		}
+
+		return _businessEventsFieldValue;
+	}
+
+	public List<UserAccount> getCustomerUserAccounts() throws Exception {
+		UserAccountBucket userAccountBucket = _getUserAccountBucket();
+
+		return userAccountBucket.getCustomerUserAccounts();
+	}
+
+	public List<Property> getExternalLinkProperties() throws Exception {
+		if (_externalLinkProperties != null) {
+			return _externalLinkProperties;
+		}
+
+		_externalLinkProperties = new ArrayList<>();
+
+		for (Property property : _getAccountProperties()) {
+			if (_externalLinkConverter.isExternalLinkProperty(property)) {
+				_externalLinkProperties.add(property);
+			}
+		}
+
+		return _externalLinkProperties;
+	}
+
+	public String getExternalReferenceCode() {
+		return _account.getExternalReferenceCode();
+	}
+
+	public List<PostalAddress> getPostalAddresses() {
+		AccountContactInformation accountContactInformation =
+			_account.getAccountContactInformation();
+
+		if (accountContactInformation == null) {
+			return null;
+		}
+
+		return ListUtil.fromArray(
+			accountContactInformation.getPostalAddresses());
+	}
+
+	public List<Project> getProjects() throws Exception {
+		if (_projects == null) {
+			_projects = _projectService.getProjects(_account.getId());
+		}
+
+		return _projects;
+	}
+
+	public String getSupportLanguage() throws Exception {
+		AccountSupportInfo accountSupportInfo = _getAccountSupportInfo();
+
+		return GetterUtil.getString(accountSupportInfo.getSupportLanguage());
+	}
+
+	public String getSupportRegion() throws Exception {
+		AccountSupportInfo accountSupportInfo = _getAccountSupportInfo();
+
+		return GetterUtil.getString(accountSupportInfo.getSupportRegion());
+	}
+
+	public List<UserAccount> getWorkerUserAccounts() throws Exception {
+		UserAccountBucket userAccountBucket = _getUserAccountBucket();
+
+		return userAccountBucket.getWorkerUserAccounts();
+	}
+
+	private void _addJiraBusinessEventLine(
+		List<String> lines, String fieldName, String value) {
+
+		if (Validator.isNull(value)) {
+			return;
+		}
+
+		lines.add(fieldName + ": " + value);
+	}
+
+	private List<Property> _getAccountProperties() throws Exception {
+		if (_accountProperties == null) {
+			_accountProperties = _propertyService.getAccountProperties(
+				_account.getId());
+		}
+
+		return _accountProperties;
+	}
+
+	private AccountSupportInfo _getAccountSupportInfo() throws Exception {
+		if (_accountSupportInfo == null) {
+			_accountSupportInfo = _commerceOrderService.getAccountSupportInfo(
+				_account.getId(), _account.getDefaultBillingAddressId());
+		}
+
+		return _accountSupportInfo;
+	}
+
+	private UserAccountBucket _getUserAccountBucket() throws Exception {
+		if (_userAccountBucket != null) {
+			return _userAccountBucket;
+		}
+
+		_userAccountBucket = new UserAccountBucket();
+
+		for (UserAccount accountUserAccount : getAccountUserAccounts()) {
+			AccountBrief accountBrief = FindUtil.findFirst(
+				accountUserAccount.getAccountBriefs(),
+				accountBrief1 -> Objects.equals(
+					_account.getExternalReferenceCode(),
+					accountBrief1.getExternalReferenceCode()));
+
+			if (accountBrief == null) {
+				_log.error(
+					"accountBrief is null for user account = " +
+						accountUserAccount);
+
+				continue;
+			}
+
+			RoleBrief roleBrief = FindUtil.findFirst(
+				accountBrief.getRoleBriefs(),
+				roleBrief1 -> _employeeRoleNames.contains(
+					roleBrief1.getName()));
+
+			if (roleBrief != null) {
+				_userAccountBucket.addWorkerUserAccount(accountUserAccount);
+			}
+			else {
+				_userAccountBucket.addCustomerUserAccount(accountUserAccount);
+			}
+		}
+
+		return _userAccountBucket;
+	}
+
+	private String _toBusinessEventFieldValuePart(
+		JiraBusinessEvent jiraBusinessEvent) {
+
+		List<String> lines = new ArrayList<>();
+
+		_addJiraBusinessEventLine(lines, "name", jiraBusinessEvent.getName());
+		_addJiraBusinessEventLine(
+			lines, "targetGoLiveDateTime",
+			jiraBusinessEvent.getPlannedEventDate());
+		_addJiraBusinessEventLine(
+			lines, "description", jiraBusinessEvent.getDescription());
+		_addJiraBusinessEventLine(
+			lines, "type", jiraBusinessEvent.getEventTypeName());
+		_addJiraBusinessEventLine(
+			lines, "currentVersion",
+			jiraBusinessEvent.getCurrentLiferayVersionName());
+		_addJiraBusinessEventLine(
+			lines, "newVersion", jiraBusinessEvent.getNewLiferayVersionName());
+
+		return StringUtil.merge(lines, ",\n");
+	}
+
+	private String _toBusinessEventsFieldValue() throws Exception {
+		List<String> parts = new ArrayList<>();
+
+		List<JiraBusinessEvent> jiraBusinessEvents =
+			_jiraBusinessEventService.getJiraBusinessEvents(
+				_account.getExternalReferenceCode());
+
+		for (JiraBusinessEvent jiraBusinessEvent : jiraBusinessEvents) {
+			String part = _toBusinessEventFieldValuePart(jiraBusinessEvent);
+
+			if (Validator.isNotNull(part)) {
+				parts.add(part);
+			}
+		}
+
+		return StringUtil.merge(parts, "\n\n");
+	}
+
+	private static final Log _log = LogFactory.getLog(AccountSyncModel.class);
+
+	private final Account _account;
+	private List<Organization> _accountOrganizations;
+	private List<Property> _accountProperties;
+	private Map<String, Role> _accountRolesByExternalReferenceCode;
+	private AccountSupportInfo _accountSupportInfo;
+	private List<UserAccount> _accountUserAccounts;
+	private List<EntitlementDefinition> _activeEntitlementDefinitions;
+	private String _businessEventsFieldValue;
+	private final CommerceOrderService _commerceOrderService;
+	private final List<String> _employeeRoleNames = EmployeeRoles.getNames();
+	private final EntitlementService _entitlementService;
+	private final ExternalLinkConverter _externalLinkConverter;
+	private List<Property> _externalLinkProperties;
+	private final JiraBusinessEventService _jiraBusinessEventService;
+	private final OrganizationService _organizationService;
+	private List<Project> _projects;
+	private final ProjectService _projectService;
+	private final PropertyService _propertyService;
+	private final RoleService _roleService;
+	private UserAccountBucket _userAccountBucket;
+	private final UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -133,6 +133,8 @@ public class AccountSynchronizer {
 		_syncAccountOrganizationAssignments(
 			account, accountOrganizations, startDate);
 
+		_syncUserAccounts(accountUserAccounts);
+
 		List<Project> projects = _projectService.getProjects(account.getId());
 
 		if (!projects.isEmpty()) {
@@ -579,6 +581,37 @@ public class AccountSynchronizer {
 		}
 	}
 
+	private void _syncUserAccounts(List<UserAccount> userAccounts) {
+		int failureCount = 0;
+
+		for (UserAccount userAccount : userAccounts) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Syncing user account " +
+						userAccount.getExternalReferenceCode() + " to JSM");
+			}
+
+			try {
+				_userAccountSynchronizer.syncUserAccount(userAccount);
+			}
+			catch (Exception exception) {
+				failureCount++;
+
+				_log.error(
+					"Unable to sync user account " +
+						userAccount.getExternalReferenceCode() + " to JSM",
+					exception);
+			}
+		}
+
+		if (failureCount > 0) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to sync ", failureCount, " of ",
+					userAccounts.size(), " user accounts to JSM"));
+		}
+	}
+
 	private String _toBusinessEventFieldValuePart(
 		JiraBusinessEvent jiraBusinessEvent) {
 
@@ -686,6 +719,9 @@ public class AccountSynchronizer {
 
 	@Autowired
 	private UserAccountService _userAccountService;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
 
 	private static class UserAccountBucket {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -40,6 +40,8 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -118,12 +120,20 @@ public class AccountSynchronizer {
 		_syncContactRoleAssignments(accountSyncModel, startDate);
 		_syncAccountOrganizationAssignments(accountSyncModel, startDate);
 
-		_syncUserAccounts(accountSyncModel.getAccountUserAccounts());
+		List<UserAccount> userAccountsToSync = new ArrayList<>(
+			accountSyncModel.getAccountUserAccounts());
 
 		for (Project project : accountSyncModel.getProjects()) {
 			try {
-				_syncProject(
-					_createProjectSyncModel(accountSyncModel, project));
+				ProjectSyncModel projectSyncModel = _createProjectSyncModel(
+					accountSyncModel, project);
+
+				_syncProject(projectSyncModel);
+
+				userAccountsToSync.addAll(
+					projectSyncModel.getCustomerUserAccounts());
+				userAccountsToSync.addAll(
+					projectSyncModel.getWorkerUserAccounts());
 			}
 			catch (Exception exception) {
 				_log.error(
@@ -132,6 +142,8 @@ public class AccountSynchronizer {
 					exception);
 			}
 		}
+
+		_syncUserAccounts(userAccountsToSync);
 	}
 
 	public void syncAccountUserAccounts(Account account) throws Exception {
@@ -176,7 +188,17 @@ public class AccountSynchronizer {
 		AccountSyncModel accountSyncModel = _createAccountSyncModel(
 			_accountService.getAccount(accountExternalReferenceCode));
 
-		_syncProject(_createProjectSyncModel(accountSyncModel, project));
+		ProjectSyncModel projectSyncModel = _createProjectSyncModel(
+			accountSyncModel, project);
+
+		_syncProject(projectSyncModel);
+
+		List<UserAccount> userAccounts = new ArrayList<>(
+			projectSyncModel.getCustomerUserAccounts());
+
+		userAccounts.addAll(projectSyncModel.getWorkerUserAccounts());
+
+		_syncUserAccounts(userAccounts);
 	}
 
 	private AccountSyncModel _createAccountSyncModel(Account account) {
@@ -419,15 +441,26 @@ public class AccountSynchronizer {
 		}
 	}
 
-	private void _syncUserAccounts(List<UserAccount> userAccounts) {
+	private void _syncUserAccounts(Collection<UserAccount> userAccounts) {
+		List<String> seenUserAccountExternalKeys = new ArrayList<>();
+
 		int failureCount = 0;
 
 		for (UserAccount userAccount : userAccounts) {
+			if (seenUserAccountExternalKeys.contains(
+					userAccount.getExternalReferenceCode())) {
+
+				continue;
+			}
+
 			if (_log.isInfoEnabled()) {
 				_log.info(
 					"Syncing user account " +
 						userAccount.getExternalReferenceCode() + " to JSM");
 			}
+
+			seenUserAccountExternalKeys.add(
+				userAccount.getExternalReferenceCode());
 
 			try {
 				_userAccountSynchronizer.syncUserAccount(userAccount);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -7,9 +7,7 @@ package com.liferay.one.jira.synchronizer;
 
 import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
-import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
 import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
-import com.liferay.headless.admin.user.client.dto.v1_0.Role;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.constants.AccountConstants;
@@ -21,11 +19,9 @@ import com.liferay.one.jira.converter.PostalAddressConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.exception.AccountNotFoundException;
 import com.liferay.one.jira.model.JiraAssetObject;
-import com.liferay.one.jira.model.JiraBusinessEvent;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.jira.service.JiraBusinessEventService;
 import com.liferay.one.jira.util.JiraSyncLock;
-import com.liferay.one.model.AccountSupportInfo;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.Project;
 import com.liferay.one.model.ProjectMembership;
@@ -40,15 +36,10 @@ import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.RoleService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.FindUtil;
-import com.liferay.one.util.role.EmployeeRoles;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -117,42 +108,28 @@ public class AccountSynchronizer {
 
 		Date startDate = new Date();
 
-		List<UserAccount> accountUserAccounts =
-			_userAccountService.getAccountUserAccounts(account.getId());
-		List<Organization> accountOrganizations =
-			_organizationService.getAccountOrganizations(account.getId());
-
-		Map<String, Object> accountAttributeValues = _getAccountAttributeValues(
-			account, accountUserAccounts, accountOrganizations);
+		AccountSyncModel accountSyncModel = _createAccountSyncModel(account);
 
 		_syncAccountAsset(
-			account, accountAttributeValues, account.getExternalReferenceCode(),
-			account.getName());
+			account, account.getExternalReferenceCode(), account.getName(),
+			jiraAssetObject -> _setAttributeValues(
+				accountSyncModel, jiraAssetObject));
 
-		_syncContactRoleAssignments(account, accountUserAccounts, startDate);
-		_syncAccountOrganizationAssignments(
-			account, accountOrganizations, startDate);
+		_syncContactRoleAssignments(accountSyncModel, startDate);
+		_syncAccountOrganizationAssignments(accountSyncModel, startDate);
 
-		_syncUserAccounts(accountUserAccounts);
+		_syncUserAccounts(accountSyncModel.getAccountUserAccounts());
 
-		List<Project> projects = _projectService.getProjects(account.getId());
-
-		if (!projects.isEmpty()) {
-			Map<String, Role> accountRolesByExternalReferenceCode =
-				_getAccountRolesByExternalReferenceCode();
-
-			for (Project project : projects) {
-				try {
-					_syncProject(
-						account, project, accountAttributeValues,
-						accountRolesByExternalReferenceCode);
-				}
-				catch (Exception exception) {
-					_log.error(
-						"Unable to sync project " +
-							project.getExternalReferenceCode(),
-						exception);
-				}
+		for (Project project : accountSyncModel.getProjects()) {
+			try {
+				_syncProject(
+					_createProjectSyncModel(accountSyncModel, project));
+			}
+			catch (Exception exception) {
+				_log.error(
+					"Unable to sync project " +
+						project.getExternalReferenceCode(),
+					exception);
 			}
 		}
 	}
@@ -164,29 +141,20 @@ public class AccountSynchronizer {
 					account.getExternalReferenceCode() + " to JSM");
 		}
 
-		UserAccountBucket accountUserAccountBucket =
-			_getAccountUserAccountBucket(
-				account,
-				_userAccountService.getAccountUserAccounts(account.getId()));
+		AccountSyncModel accountSyncModel = _createAccountSyncModel(account);
 
 		_syncAccountAsset(
-			account,
-			LinkedHashMapBuilder.<String, Object>put(
-				AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
-				_jiraAssetService.getOrCreateReferenceObjectIds(
-					_contactConverter,
-					accountUserAccountBucket.getCustomerUserAccounts(),
-					UserAccount::getExternalReferenceCode,
-					_contactConverter::toAssetObject)
-			).put(
-				AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
-				_jiraAssetService.getOrCreateReferenceObjectIds(
-					_contactConverter,
-					accountUserAccountBucket.getWorkerUserAccounts(),
-					UserAccount::getExternalReferenceCode,
-					_contactConverter::toAssetObject)
-			).build(),
-			account.getExternalReferenceCode(), account.getName());
+			account, account.getExternalReferenceCode(), account.getName(),
+			jiraAssetObject -> {
+				jiraAssetObject.setAttributeValue(
+					AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
+					_toContactObjectIds(
+						accountSyncModel.getCustomerUserAccounts()));
+				jiraAssetObject.setAttributeValue(
+					AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
+					_toContactObjectIds(
+						accountSyncModel.getWorkerUserAccounts()));
+			});
 	}
 
 	public void syncProject(Project project) throws Exception {
@@ -205,235 +173,100 @@ public class AccountSynchronizer {
 					" has no account external reference code");
 		}
 
-		Account account = _accountService.getAccount(
-			accountExternalReferenceCode);
+		AccountSyncModel accountSyncModel = _createAccountSyncModel(
+			_accountService.getAccount(accountExternalReferenceCode));
 
-		List<UserAccount> accountUserAccounts =
-			_userAccountService.getAccountUserAccounts(account.getId());
-		List<Organization> accountOrganizations =
-			_organizationService.getAccountOrganizations(account.getId());
-
-		_syncProject(
-			account, project,
-			_getAccountAttributeValues(
-				account, accountUserAccounts, accountOrganizations),
-			_getAccountRolesByExternalReferenceCode());
+		_syncProject(_createProjectSyncModel(accountSyncModel, project));
 	}
 
-	private void _addJiraBusinessEventLine(
-		List<String> lines, String fieldName, String value) {
-
-		if (Validator.isNull(value)) {
-			return;
-		}
-
-		lines.add(fieldName + ": " + value);
+	private AccountSyncModel _createAccountSyncModel(Account account) {
+		return new AccountSyncModel(
+			account, _commerceOrderService, _entitlementService,
+			_externalLinkConverter, _jiraBusinessEventService,
+			_organizationService, _projectService, _propertyService,
+			_roleService, _userAccountService);
 	}
 
-	private Map<String, Object> _getAccountAttributeValues(
-			Account account, List<UserAccount> accountUserAccounts,
-			List<Organization> accountOrganizations)
+	private ProjectSyncModel _createProjectSyncModel(
+		AccountSyncModel accountSyncModel, Project project) {
+
+		return new ProjectSyncModel(
+			accountSyncModel, _entitlementService, project,
+			_projectMembershipService, _userAccountService);
+	}
+
+	private void _setAttributeValues(
+			AccountSyncModel accountSyncModel, JiraAssetObject jiraAssetObject)
 		throws Exception {
 
-		UserAccountBucket accountUserAccountBucket =
-			_getAccountUserAccountBucket(account, accountUserAccounts);
-
-		AccountSupportInfo accountSupportInfo =
-			_commerceOrderService.getAccountSupportInfo(
-				account.getId(), account.getDefaultBillingAddressId());
-
-		return LinkedHashMapBuilder.<String, Object>put(
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_ASSIGNED_TEAMS,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_teamConverter, accountOrganizations,
+				_teamConverter, accountSyncModel.getAccountOrganizations(),
 				Organization::getExternalReferenceCode,
-				_teamConverter::toAssetObject)
-		).put(
+				_teamConverter::toAssetObject));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_BUSINESS_EVENTS,
-			_toBusinessEventsFieldValue(account)
-		).put(
+			accountSyncModel.getBusinessEventsFieldValue());
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_contactConverter,
-				accountUserAccountBucket.getCustomerUserAccounts(),
-				UserAccount::getExternalReferenceCode,
-				_contactConverter::toAssetObject)
-		).put(
+			_toContactObjectIds(accountSyncModel.getCustomerUserAccounts()));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_entitlementConverter,
-				_entitlementService.getActiveEntitlementDefinitions(
-					account.getId()),
-				EntitlementDefinition::getDisplayName,
-				_entitlementConverter::toAssetObject)
-		).put(
+			_toEntitlementObjectIds(
+				accountSyncModel.getActiveEntitlementDefinitions()));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_EXTERNAL_LINKS,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_externalLinkConverter, _getExternalLinkProperties(account),
+				_externalLinkConverter,
+				accountSyncModel.getExternalLinkProperties(),
 				Property::getExternalReferenceCode,
-				_externalLinkConverter::toAssetObject)
-		).put(
+				_externalLinkConverter::toAssetObject));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_LANGUAGE,
-			GetterUtil.getString(accountSupportInfo.getSupportLanguage())
-		).put(
+			accountSyncModel.getSupportLanguage());
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_POSTAL_ADDRESSES,
-			() -> {
-				AccountContactInformation accountContactInformation =
-					account.getAccountContactInformation();
-
-				if (accountContactInformation == null) {
-					return null;
-				}
-
-				return _jiraAssetService.getOrCreateReferenceObjectIds(
-					_postalAddressConverter,
-					ListUtil.fromArray(
-						accountContactInformation.getPostalAddresses()),
-					postalAddress -> String.valueOf(postalAddress.getId()),
-					_postalAddressConverter::toAssetObject);
-			}
-		).put(
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_postalAddressConverter, accountSyncModel.getPostalAddresses(),
+				postalAddress -> String.valueOf(postalAddress.getId()),
+				_postalAddressConverter::toAssetObject));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_SUPPORT_REGION,
-			GetterUtil.getString(accountSupportInfo.getSupportRegion())
-		).put(
+			accountSyncModel.getSupportRegion());
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_contactConverter,
-				accountUserAccountBucket.getWorkerUserAccounts(),
-				UserAccount::getExternalReferenceCode,
-				_contactConverter::toAssetObject)
-		).build();
+			_toContactObjectIds(accountSyncModel.getWorkerUserAccounts()));
 	}
 
-	private Map<String, Role> _getAccountRolesByExternalReferenceCode()
+	private void _setAttributeValues(
+			JiraAssetObject jiraAssetObject, ProjectSyncModel projectSyncModel)
 		throws Exception {
 
-		Map<String, Role> accountRolesByExternalReferenceCode =
-			new LinkedHashMap<>();
+		_setAttributeValues(
+			projectSyncModel.getAccountSyncModel(), jiraAssetObject);
 
-		for (Role role : _roleService.getAccountRoles()) {
-			accountRolesByExternalReferenceCode.put(
-				role.getExternalReferenceCode(), role);
-		}
-
-		return accountRolesByExternalReferenceCode;
-	}
-
-	private UserAccountBucket _getAccountUserAccountBucket(
-		Account account, List<UserAccount> accountUserAccounts) {
-
-		UserAccountBucket accountUserAccountBucket = new UserAccountBucket();
-
-		for (UserAccount accountUserAccount : accountUserAccounts) {
-			AccountBrief accountBrief = FindUtil.findFirst(
-				accountUserAccount.getAccountBriefs(),
-				accountBrief1 -> Objects.equals(
-					account.getExternalReferenceCode(),
-					accountBrief1.getExternalReferenceCode()));
-
-			if (accountBrief == null) {
-				_log.error(
-					"accountBrief is null for user account = " +
-						accountUserAccount);
-
-				continue;
-			}
-
-			RoleBrief roleBrief = FindUtil.findFirst(
-				accountBrief.getRoleBriefs(),
-				roleBrief1 -> _employeeRoleNames.contains(
-					roleBrief1.getName()));
-
-			if (roleBrief != null) {
-				accountUserAccountBucket.addWorkerUserAccount(
-					accountUserAccount);
-			}
-			else {
-				accountUserAccountBucket.addCustomerUserAccount(
-					accountUserAccount);
-			}
-		}
-
-		return accountUserAccountBucket;
-	}
-
-	private List<Property> _getExternalLinkProperties(Account account)
-		throws Exception {
-
-		List<Property> externalLinkProperties = new ArrayList<>();
-
-		List<Property> properties = _propertyService.getAccountProperties(
-			account.getId());
-
-		for (Property property : properties) {
-			if (_externalLinkConverter.isExternalLinkProperty(property)) {
-				externalLinkProperties.add(property);
-			}
-		}
-
-		return externalLinkProperties;
-	}
-
-	private Map<String, Object> _getProjectAttributeValues(
-			Map<String, Object> accountAttributeValues,
-			Map<String, Role> accountRolesByExternalReferenceCode,
-			Project project, List<ProjectMembership> projectMemberships)
-		throws Exception {
-
-		List<UserAccount> customerUserAccounts = new ArrayList<>();
-		List<UserAccount> workerUserAccounts = new ArrayList<>();
-
-		for (ProjectMembership projectMembership : projectMemberships) {
-			UserAccount userAccount = _userAccountService.getUserAccount(
-				projectMembership.getUserId());
-
-			Role role = accountRolesByExternalReferenceCode.get(
-				projectMembership.getRoleExternalReferenceCode());
-
-			if ((role != null) && _employeeRoleNames.contains(role.getName())) {
-				workerUserAccounts.add(userAccount);
-			}
-			else {
-				customerUserAccounts.add(userAccount);
-			}
-		}
-
-		return LinkedHashMapBuilder.<String, Object>putAll(
-			accountAttributeValues
-		).put(
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_contactConverter, customerUserAccounts,
-				UserAccount::getExternalReferenceCode,
-				_contactConverter::toAssetObject)
-		).put(
+			_toContactObjectIds(projectSyncModel.getCustomerUserAccounts()));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_entitlementConverter,
-				_entitlementService.getActiveEntitlementDefinitions(
-					project.getExternalReferenceCode()),
-				EntitlementDefinition::getDisplayName,
-				_entitlementConverter::toAssetObject)
-		).put(
+			_toEntitlementObjectIds(
+				projectSyncModel.getActiveEntitlementDefinitions()));
+		jiraAssetObject.setAttributeValue(
 			AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
-			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_contactConverter, workerUserAccounts,
-				UserAccount::getExternalReferenceCode,
-				_contactConverter::toAssetObject)
-		).build();
+			_toContactObjectIds(projectSyncModel.getWorkerUserAccounts()));
 	}
 
 	private void _syncAccountAsset(
-			Account account, Map<String, Object> attributeValues,
-			String externalKey, String name)
+			Account account, String externalKey, String name,
+			UnsafeConsumer<JiraAssetObject, Exception> unsafeConsumer)
 		throws Exception {
 
 		JiraAssetObject assetObject = _accountConverter.toAssetObject(
 			account, externalKey, name);
 
-		for (Map.Entry<String, Object> entry : attributeValues.entrySet()) {
-			assetObject.setAttributeValue(entry.getKey(), entry.getValue());
-		}
+		unsafeConsumer.accept(assetObject);
 
 		_jiraSyncLock.withLock(
 			externalKey,
@@ -441,18 +274,21 @@ public class AccountSynchronizer {
 	}
 
 	private void _syncAccountOrganizationAssignments(
-		Account account, List<Organization> organizations, Date startDate) {
+			AccountSyncModel accountSyncModel, Date startDate)
+		throws Exception {
 
 		Set<String> organizationExternalKeys = new LinkedHashSet<>();
 
-		for (Organization organization : organizations) {
+		for (Organization organization :
+				accountSyncModel.getAccountOrganizations()) {
+
 			organizationExternalKeys.add(
 				organization.getExternalReferenceCode());
 
 			try {
 				_accountOrganizationSynchronizer.syncAssignOrganization(
 					organization.getExternalReferenceCode(),
-					account.getExternalReferenceCode());
+					accountSyncModel.getExternalReferenceCode());
 			}
 			catch (Exception exception) {
 				_log.error(
@@ -466,29 +302,31 @@ public class AccountSynchronizer {
 
 		try {
 			_accountOrganizationSynchronizer.syncUnassignStaleOrganizations(
-				account.getExternalReferenceCode(), organizationExternalKeys,
-				startDate);
+				accountSyncModel.getExternalReferenceCode(),
+				organizationExternalKeys, startDate);
 		}
 		catch (Exception exception) {
 			_log.error(
 				"Unable to unassign stale organizations from account " +
-					account.getExternalReferenceCode(),
+					accountSyncModel.getExternalReferenceCode(),
 				exception);
 		}
 	}
 
 	private void _syncContactRoleAssignments(
-		Account account, List<UserAccount> accountUserAccounts,
-		Date startDate) {
+			AccountSyncModel accountSyncModel, Date startDate)
+		throws Exception {
 
 		Map<String, Set<String>> roleExternalKeysByUserAccountExternalKey =
 			new LinkedHashMap<>();
 
-		for (UserAccount accountUserAccount : accountUserAccounts) {
+		for (UserAccount accountUserAccount :
+				accountSyncModel.getAccountUserAccounts()) {
+
 			AccountBrief accountBrief = FindUtil.findFirst(
 				accountUserAccount.getAccountBriefs(),
 				accountBrief1 -> Objects.equals(
-					account.getExternalReferenceCode(),
+					accountSyncModel.getExternalReferenceCode(),
 					accountBrief1.getExternalReferenceCode()));
 
 			if (accountBrief == null) {
@@ -514,7 +352,7 @@ public class AccountSynchronizer {
 					_accountUserAccountRoleSynchronizer.syncAssignRole(
 						roleBrief.getExternalReferenceCode(),
 						accountUserAccount.getExternalReferenceCode(),
-						account.getExternalReferenceCode());
+						accountSyncModel.getExternalReferenceCode());
 				}
 				catch (Exception exception) {
 					_log.error(
@@ -528,41 +366,41 @@ public class AccountSynchronizer {
 
 		try {
 			_accountUserAccountRoleSynchronizer.syncUnassignStaleRoles(
-				account.getExternalReferenceCode(),
+				accountSyncModel.getExternalReferenceCode(),
 				roleExternalKeysByUserAccountExternalKey, startDate);
 		}
 		catch (Exception exception) {
 			_log.error(
 				"Unable to unassign stale contact roles for account " +
-					account.getExternalReferenceCode(),
+					accountSyncModel.getExternalReferenceCode(),
 				exception);
 		}
 	}
 
-	private void _syncProject(
-			Account account, Project project,
-			Map<String, Object> accountAttributeValues,
-			Map<String, Role> accountRolesByExternalReferenceCode)
+	private void _syncProject(ProjectSyncModel projectSyncModel)
 		throws Exception {
 
-		List<ProjectMembership> projectMemberships =
-			_projectMembershipService.getProjectMemberships(
-				project.getExternalReferenceCode());
+		AccountSyncModel accountSyncModel =
+			projectSyncModel.getAccountSyncModel();
+		Project project = projectSyncModel.getProject();
 
 		_syncAccountAsset(
-			account,
-			_getProjectAttributeValues(
-				accountAttributeValues, accountRolesByExternalReferenceCode,
-				project, projectMemberships),
-			project.getExternalReferenceCode(), project.getName());
+			accountSyncModel.getAccount(), project.getExternalReferenceCode(),
+			project.getName(),
+			jiraAssetObject -> _setAttributeValues(
+				jiraAssetObject, projectSyncModel));
 
-		_syncProjectMemberships(project, projectMemberships);
+		_syncProjectMemberships(projectSyncModel);
 	}
 
-	private void _syncProjectMemberships(
-		Project project, List<ProjectMembership> projectMemberships) {
+	private void _syncProjectMemberships(ProjectSyncModel projectSyncModel)
+		throws Exception {
 
-		for (ProjectMembership projectMembership : projectMemberships) {
+		Project project = projectSyncModel.getProject();
+
+		for (ProjectMembership projectMembership :
+				projectSyncModel.getProjectMemberships()) {
+
 			try {
 				UserAccount userAccount = _userAccountService.getUserAccount(
 					projectMembership.getUserId());
@@ -612,46 +450,20 @@ public class AccountSynchronizer {
 		}
 	}
 
-	private String _toBusinessEventFieldValuePart(
-		JiraBusinessEvent jiraBusinessEvent) {
-
-		List<String> lines = new ArrayList<>();
-
-		_addJiraBusinessEventLine(lines, "name", jiraBusinessEvent.getName());
-		_addJiraBusinessEventLine(
-			lines, "targetGoLiveDateTime",
-			jiraBusinessEvent.getPlannedEventDate());
-		_addJiraBusinessEventLine(
-			lines, "description", jiraBusinessEvent.getDescription());
-		_addJiraBusinessEventLine(
-			lines, "type", jiraBusinessEvent.getEventTypeName());
-		_addJiraBusinessEventLine(
-			lines, "currentVersion",
-			jiraBusinessEvent.getCurrentLiferayVersionName());
-		_addJiraBusinessEventLine(
-			lines, "newVersion", jiraBusinessEvent.getNewLiferayVersionName());
-
-		return StringUtil.merge(lines, ",\n");
+	private List<String> _toContactObjectIds(List<UserAccount> userAccounts) {
+		return _jiraAssetService.getOrCreateReferenceObjectIds(
+			_contactConverter, userAccounts,
+			UserAccount::getExternalReferenceCode,
+			_contactConverter::toAssetObject);
 	}
 
-	private String _toBusinessEventsFieldValue(Account account)
-		throws Exception {
+	private List<String> _toEntitlementObjectIds(
+		List<EntitlementDefinition> entitlementDefinitions) {
 
-		List<String> parts = new ArrayList<>();
-
-		List<JiraBusinessEvent> jiraBusinessEvents =
-			_jiraBusinessEventService.getJiraBusinessEvents(
-				account.getExternalReferenceCode());
-
-		for (JiraBusinessEvent businessEvent : jiraBusinessEvents) {
-			String part = _toBusinessEventFieldValuePart(businessEvent);
-
-			if (Validator.isNotNull(part)) {
-				parts.add(part);
-			}
-		}
-
-		return StringUtil.merge(parts, "\n\n");
+		return _jiraAssetService.getOrCreateReferenceObjectIds(
+			_entitlementConverter, entitlementDefinitions,
+			EntitlementDefinition::getDisplayName,
+			_entitlementConverter::toAssetObject);
 	}
 
 	private static final Log _log = LogFactory.getLog(
@@ -675,8 +487,6 @@ public class AccountSynchronizer {
 
 	@Autowired
 	private ContactConverter _contactConverter;
-
-	private final List<String> _employeeRoleNames = EmployeeRoles.getNames();
 
 	@Autowired
 	private EntitlementConverter _entitlementConverter;
@@ -722,29 +532,5 @@ public class AccountSynchronizer {
 
 	@Autowired
 	private UserAccountSynchronizer _userAccountSynchronizer;
-
-	private static class UserAccountBucket {
-
-		public void addCustomerUserAccount(UserAccount userAccount) {
-			_customerUserAccounts.add(userAccount);
-		}
-
-		public void addWorkerUserAccount(UserAccount userAccount) {
-			_workerUserAccounts.add(userAccount);
-		}
-
-		public List<UserAccount> getCustomerUserAccounts() {
-			return _customerUserAccounts;
-		}
-
-		public List<UserAccount> getWorkerUserAccounts() {
-			return _workerUserAccounts;
-		}
-
-		private final List<UserAccount> _customerUserAccounts =
-			new ArrayList<>();
-		private final List<UserAccount> _workerUserAccounts = new ArrayList<>();
-
-	}
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/ProjectSyncModel.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/ProjectSyncModel.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Role;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.model.EntitlementDefinition;
+import com.liferay.one.model.Project;
+import com.liferay.one.model.ProjectMembership;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProjectMembershipService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.one.util.role.EmployeeRoles;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Drew Brokke
+ */
+public class ProjectSyncModel {
+
+	public ProjectSyncModel(
+		AccountSyncModel accountSyncModel,
+		EntitlementService entitlementService, Project project,
+		ProjectMembershipService projectMembershipService,
+		UserAccountService userAccountService) {
+
+		_accountSyncModel = accountSyncModel;
+		_entitlementService = entitlementService;
+		_project = project;
+		_projectMembershipService = projectMembershipService;
+		_userAccountService = userAccountService;
+	}
+
+	public AccountSyncModel getAccountSyncModel() {
+		return _accountSyncModel;
+	}
+
+	public List<EntitlementDefinition> getActiveEntitlementDefinitions()
+		throws Exception {
+
+		if (_activeEntitlementDefinitions == null) {
+			_activeEntitlementDefinitions =
+				_entitlementService.getActiveEntitlementDefinitions(
+					_project.getExternalReferenceCode());
+		}
+
+		return _activeEntitlementDefinitions;
+	}
+
+	public List<UserAccount> getCustomerUserAccounts() throws Exception {
+		UserAccountBucket userAccountBucket = _getUserAccountBucket();
+
+		return userAccountBucket.getCustomerUserAccounts();
+	}
+
+	public Project getProject() {
+		return _project;
+	}
+
+	public List<ProjectMembership> getProjectMemberships() throws Exception {
+		if (_projectMemberships == null) {
+			_projectMemberships =
+				_projectMembershipService.getProjectMemberships(
+					_project.getExternalReferenceCode());
+		}
+
+		return _projectMemberships;
+	}
+
+	public List<UserAccount> getWorkerUserAccounts() throws Exception {
+		UserAccountBucket userAccountBucket = _getUserAccountBucket();
+
+		return userAccountBucket.getWorkerUserAccounts();
+	}
+
+	private UserAccountBucket _getUserAccountBucket() throws Exception {
+		if (_userAccountBucket != null) {
+			return _userAccountBucket;
+		}
+
+		Map<String, Role> accountRolesByExternalReferenceCode =
+			_accountSyncModel.getAccountRolesByExternalReferenceCode();
+
+		_userAccountBucket = new UserAccountBucket();
+
+		for (ProjectMembership projectMembership : getProjectMemberships()) {
+			UserAccount userAccount = _userAccountService.getUserAccount(
+				projectMembership.getUserId());
+
+			Role role = accountRolesByExternalReferenceCode.get(
+				projectMembership.getRoleExternalReferenceCode());
+
+			if ((role != null) && _employeeRoleNames.contains(role.getName())) {
+				_userAccountBucket.addWorkerUserAccount(userAccount);
+			}
+			else {
+				_userAccountBucket.addCustomerUserAccount(userAccount);
+			}
+		}
+
+		return _userAccountBucket;
+	}
+
+	private final AccountSyncModel _accountSyncModel;
+	private List<EntitlementDefinition> _activeEntitlementDefinitions;
+	private final List<String> _employeeRoleNames = EmployeeRoles.getNames();
+	private final EntitlementService _entitlementService;
+	private final Project _project;
+	private List<ProjectMembership> _projectMemberships;
+	private final ProjectMembershipService _projectMembershipService;
+	private UserAccountBucket _userAccountBucket;
+	private final UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountBucket.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountBucket.java
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Drew Brokke
+ */
+public class UserAccountBucket {
+
+	public void addCustomerUserAccount(UserAccount userAccount) {
+		_customerUserAccounts.add(userAccount);
+	}
+
+	public void addWorkerUserAccount(UserAccount userAccount) {
+		_workerUserAccounts.add(userAccount);
+	}
+
+	public List<UserAccount> getCustomerUserAccounts() {
+		return Collections.unmodifiableList(_customerUserAccounts);
+	}
+
+	public List<UserAccount> getWorkerUserAccounts() {
+		return Collections.unmodifiableList(_workerUserAccounts);
+	}
+
+	private final List<UserAccount> _customerUserAccounts = new ArrayList<>();
+	private final List<UserAccount> _workerUserAccounts = new ArrayList<>();
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountSynchronizerTest.java
@@ -29,6 +29,7 @@ import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.service.UserAccountService;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 
@@ -114,6 +115,8 @@ public class AccountSynchronizerTest {
 			Collections.emptyList()
 		);
 
+		_userAccountSynchronizer = Mockito.mock(UserAccountSynchronizer.class);
+
 		_accountOrganizationSynchronizer = Mockito.mock(
 			AccountOrganizationSynchronizer.class);
 		_accountUserAccountRoleSynchronizer = Mockito.mock(
@@ -163,6 +166,9 @@ public class AccountSynchronizerTest {
 			Mockito.mock(TeamConverter.class));
 		ReflectionTestUtils.setField(
 			_accountSynchronizer, "_userAccountService", _userAccountService);
+		ReflectionTestUtils.setField(
+			_accountSynchronizer, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
 	}
 
 	@Test
@@ -259,6 +265,60 @@ public class AccountSynchronizerTest {
 	}
 
 	@Test
+	public void testSyncAccountSyncsAccountUserAccounts() throws Exception {
+		UserAccount failingUserAccount = new UserAccount();
+
+		failingUserAccount.setExternalReferenceCode("failing-user-account-erc");
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setExternalReferenceCode("user-account-erc");
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(Mockito.anyLong())
+		).thenReturn(
+			Arrays.asList(failingUserAccount, userAccount)
+		);
+
+		Mockito.doThrow(
+			new Exception("Unable to sync user account")
+		).when(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			failingUserAccount
+		);
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
+		account.setId(1L);
+		account.setName("Test Account");
+
+		_accountSynchronizer.syncAccount(account);
+
+		InOrder inOrder = Mockito.inOrder(
+			_jiraAssetService, _userAccountSynchronizer);
+
+		inOrder.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.any(), Mockito.any()
+		);
+
+		inOrder.verify(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			failingUserAccount
+		);
+
+		inOrder.verify(
+			_userAccountSynchronizer
+		).syncUserAccount(
+			userAccount
+		);
+	}
+
+	@Test
 	public void testSyncAccountUnassignsStaleAssignments() throws Exception {
 		RoleBrief roleBrief = new RoleBrief();
 
@@ -273,6 +333,7 @@ public class AccountSynchronizerTest {
 
 		userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
 		userAccount.setExternalReferenceCode("user-account-erc");
+		userAccount.setId(2L);
 
 		Mockito.when(
 			_userAccountService.getAccountUserAccounts(Mockito.anyLong())
@@ -361,5 +422,6 @@ public class AccountSynchronizerTest {
 	private JiraAssetService _jiraAssetService;
 	private OrganizationService _organizationService;
 	private UserAccountService _userAccountService;
+	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437).
Subtask: [LPD-101288](https://liferay.atlassian.net/browse/LPD-101288).

This ensures a full Contact attribute sync after Account and Project syncs.

A new idea in this PR is a "SyncModel" which is just a wrapper around the core model (e.g. Account) with fat getters that memoize the result. This makes it easier to pull together all the users that will need to be synced across all Accounts and Projects synced in a single run.

[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-101288]: https://liferay.atlassian.net/browse/LPD-101288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ