### PR TITLE
LPD-91426 Port the license key read endpoints

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -16,16 +16,19 @@ import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.model.AccountInvitation;
+import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
 import com.liferay.one.permission.AdminPermission;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.permission.ProjectMembershipPermission;
 import com.liferay.one.service.AccountInvitationEmailService;
 import com.liferay.one.service.AccountInvitationService;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
@@ -185,6 +188,21 @@ public class AccountsRestController extends OneBaseRestController {
 		return new ResponseEntity<>(
 			_accountAssetService.getAccountObjectKey(externalReferenceCode),
 			HttpStatus.OK);
+	}
+
+	@GetMapping("/{externalReferenceCode}/license-keys")
+	public List<LicenseKey> getLicenseKeys(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
+		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
+
+		return _licenseKeyService.getLicenseKeysByAccountEntryId(
+			account.getId());
 	}
 
 	@PostMapping("/{externalReferenceCode}/invitations")
@@ -824,6 +842,12 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private KeyedLock _keyedLock;
+
+	@Autowired
+	private LicenseKeyPermission _licenseKeyPermission;
+
+	@Autowired
+	private LicenseKeyService _licenseKeyService;
 
 	@Autowired
 	private OktaService _oktaService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -60,6 +60,21 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		}
 	}
 
+	@GetMapping("/{licenseKeyId}")
+	public LicenseKey getLicenseKey(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("licenseKeyId") long licenseKeyId)
+		throws Exception {
+
+		LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
+			jwt, licenseKeyId);
+
+		_licenseKeyPermission.check(
+			licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
+
+		return licenseKey;
+	}
+
 	@GetMapping("/{licenseKeyId}/download")
 	public ResponseEntity<String> getLicenseKeysDownload(
 			@AuthenticationPrincipal Jwt jwt, @PathVariable long licenseKeyId)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -12,6 +12,7 @@ import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
+import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.LicenseKeyService;
@@ -73,6 +74,30 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
 
 		return licenseKey;
+	}
+
+	@GetMapping
+	public ResponseEntity<String> getLicenseKeys(
+			@AuthenticationPrincipal Jwt jwt, @RequestParam("page") int page,
+			@RequestParam("pageSize") int pageSize)
+		throws Exception {
+
+		_adminPermission.check(jwt);
+
+		if ((pageSize < 1) || (pageSize > _MAX_PAGE_SIZE)) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST,
+				"The page size must be between 1 and " + _MAX_PAGE_SIZE);
+		}
+
+		return ResponseEntity.ok(
+		).contentType(
+			MediaType.APPLICATION_JSON
+		).body(
+			_licenseKeyService.getLicenseKeysPage(
+				page, pageSize
+			).toString()
+		);
 	}
 
 	@GetMapping("/{licenseKeyId}/download")
@@ -200,6 +225,11 @@ public class LicenseKeysRestController extends OneBaseRestController {
 				userAccount.getId());
 		}
 	}
+
+	private static final int _MAX_PAGE_SIZE = 100;
+
+	@Autowired
+	private AdminPermission _adminPermission;
 
 	@Autowired
 	private CommerceOrderService _commerceOrderService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/OneBaseRestController.java
@@ -10,6 +10,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.exception.CommonLicenseKeyEntitlementException;
 import com.liferay.one.exception.LicenseKeyActiveException;
 import com.liferay.one.exception.LicenseKeyValidationException;
+import com.liferay.one.exception.NoSuchAccountException;
 import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.exception.ProjectNotFoundException;
 import com.liferay.one.jira.exception.AccountNotFoundException;
@@ -92,6 +93,18 @@ public abstract class OneBaseRestController extends BaseRestController {
 
 		return _toResponseEntity(
 			HttpStatus.BAD_REQUEST, licenseKeyValidationException.getMessage());
+	}
+
+	@ExceptionHandler(NoSuchAccountException.class)
+	public ResponseEntity<?> handleException(
+		NoSuchAccountException noSuchAccountException) {
+
+		if (_log.isWarnEnabled()) {
+			_log.warn(noSuchAccountException);
+		}
+
+		return _toResponseEntity(
+			HttpStatus.NOT_FOUND, "The account was not found");
 	}
 
 	@ExceptionHandler(NoSuchLicenseKeyException.class)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/NoSuchAccountException.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/exception/NoSuchAccountException.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.exception;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class NoSuchAccountException extends Exception {
+
+	public NoSuchAccountException(String message) {
+		super(message);
+	}
+
+	public NoSuchAccountException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public NoSuchAccountException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/LicenseKey.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/model/LicenseKey.java
@@ -5,6 +5,8 @@
 
 package com.liferay.one.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.time.Instant;
 
 import org.json.JSONObject;
@@ -92,6 +94,7 @@ public class LicenseKey {
 		return _ipAddresses;
 	}
 
+	@JsonIgnore
 	public String getKey() {
 		return _key;
 	}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/AccountService.java
@@ -20,6 +20,7 @@ import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountResource;
 import com.liferay.headless.admin.user.client.resource.v1_0.AccountRoleResource;
+import com.liferay.one.exception.NoSuchAccountException;
 import com.liferay.one.salesforce.model.SalesforceAccount;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -247,8 +248,21 @@ public class AccountService extends OneBaseService {
 			HttpHeaders.AUTHORIZATION, "Bearer " + jwt.getTokenValue()
 		).build();
 
-		return accountResource.getAccountByExternalReferenceCode(
-			externalReferenceCode);
+		try {
+			return accountResource.getAccountByExternalReferenceCode(
+				externalReferenceCode);
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			if ((problem != null) && isNotFound(problem.getStatus())) {
+				throw new NoSuchAccountException(
+					"No account exists with external reference code " +
+						externalReferenceCode);
+			}
+
+			throw problemException;
+		}
 	}
 
 	public String getAccountRoleExternalReferenceCode(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -422,17 +422,23 @@ public class LicenseKeyService extends OneBaseService {
 	public JSONObject getLicenseKeysPage(int page, int pageSize)
 		throws Exception {
 
-		return new JSONObject(
-			get(
-				getAuthorization(),
-				UriComponentsBuilder.fromPath(
-					"/o/c/licensekeys"
-				).queryParam(
-					"page", page
-				).queryParam(
-					"pageSize", pageSize
-				).build(
-				).toUri()));
+		String response = get(
+			getAuthorization(),
+			UriComponentsBuilder.fromPath(
+				"/o/c/licensekeys"
+			).queryParam(
+				"page", page
+			).queryParam(
+				"pageSize", pageSize
+			).build(
+			).toUri());
+
+		if (Validator.isNull(response)) {
+			throw new Exception(
+				"Unable to read page " + page + " of the license keys");
+		}
+
+		return new JSONObject(response);
 	}
 
 	public boolean hasValidLicenseKeyTypeFree(String domains, String owner)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -399,6 +399,15 @@ public class LicenseKeyService extends OneBaseService {
 				"') and (owner eq '", _escapeODataString(owner), "')"));
 	}
 
+	public List<LicenseKey> getLicenseKeysByAccountEntryId(long accountEntryId)
+		throws Exception {
+
+		return getLicenseKeys(
+			StringBundler.concat(
+				"r_accountEntryToLicenseKey_accountEntryId eq '",
+				accountEntryId, "'"));
+	}
+
 	public List<LicenseKey> getLicenseKeysByName(
 			boolean active, String productName, String serverId)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -410,6 +410,22 @@ public class LicenseKeyService extends OneBaseService {
 				_escapeODataString(serverId), "')"));
 	}
 
+	public JSONObject getLicenseKeysPage(int page, int pageSize)
+		throws Exception {
+
+		return new JSONObject(
+			get(
+				getAuthorization(),
+				UriComponentsBuilder.fromPath(
+					"/o/c/licensekeys"
+				).queryParam(
+					"page", page
+				).queryParam(
+					"pageSize", pageSize
+				).build(
+				).toUri()));
+	}
+
 	public boolean hasValidLicenseKeyTypeFree(String domains, String owner)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -14,16 +14,19 @@ import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.model.AccountInvitation;
+import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
+import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.permission.ProjectMembershipPermission;
 import com.liferay.one.service.AccountInvitationEmailService;
 import com.liferay.one.service.AccountInvitationService;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
@@ -34,6 +37,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.lang.reflect.Field;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -325,6 +329,37 @@ public class AccountsRestControllerTest {
 		Assertions.assertEquals(1, roleNamesJSONArray.length());
 		Assertions.assertEquals(
 			"Account Administrator", roleNamesJSONArray.getString(0));
+	}
+
+	@Test
+	public void testGetLicenseKeys() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		List<LicenseKey> licenseKeys = Collections.singletonList(
+			Mockito.mock(LicenseKey.class));
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysByAccountEntryId(_ACCOUNT_ID)
+		).thenReturn(
+			licenseKeys
+		);
+
+		Assertions.assertSame(
+			licenseKeys,
+			accountsRestController.getLicenseKeys(
+				null, _EXTERNAL_REFERENCE_CODE));
+
+		Mockito.verify(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
 	}
 
 	@Test
@@ -1410,6 +1445,11 @@ public class AccountsRestControllerTest {
 		ReflectionTestUtils.setField(
 			accountsRestController, "_keyedLock", new KeyedLock());
 		ReflectionTestUtils.setField(
+			accountsRestController, "_licenseKeyPermission",
+			_licenseKeyPermission);
+		ReflectionTestUtils.setField(
+			accountsRestController, "_licenseKeyService", _licenseKeyService);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_oktaService", _oktaService);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_projectMembershipPermission",
@@ -1547,6 +1587,10 @@ public class AccountsRestControllerTest {
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
 		EntitlementService.class);
+	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(
+		LicenseKeyPermission.class);
+	private final LicenseKeyService _licenseKeyService = Mockito.mock(
+		LicenseKeyService.class);
 	private final OktaService _oktaService = Mockito.mock(OktaService.class);
 	private final ProjectMembershipPermission _projectMembershipPermission =
 		Mockito.mock(ProjectMembershipPermission.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -12,6 +12,7 @@ import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
+import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.LicenseKeyService;
@@ -19,6 +20,8 @@ import com.liferay.one.service.SubscriptionEntryService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+
+import org.json.JSONObject;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -84,6 +87,34 @@ public class LicenseKeysRestControllerTest {
 			_licenseKeyPermission
 		).check(
 			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
+	}
+
+	@Test
+	public void testGetLicenseKeys() throws Exception {
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		JSONObject pageJSONObject = new JSONObject(
+			"{\"items\": [], \"totalCount\": 0}");
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysPage(1, 20)
+		).thenReturn(
+			pageJSONObject
+		);
+
+		ResponseEntity<String> responseEntity =
+			licenseKeysRestController.getLicenseKeys(null, 1, 20);
+
+		Assertions.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+		Assertions.assertEquals(
+			pageJSONObject.toString(), responseEntity.getBody());
+
+		Mockito.verify(
+			_adminPermission
+		).check(
+			null
 		);
 	}
 
@@ -222,6 +253,58 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysThrowsBadRequestWhenPageSizeIsOutOfRange()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		for (int pageSize : new int[] {0, -1, 101}) {
+			ResponseStatusException responseStatusException =
+				Assertions.assertThrows(
+					ResponseStatusException.class,
+					() -> licenseKeysRestController.getLicenseKeys(
+						null, 1, pageSize));
+
+			Assertions.assertEquals(
+				HttpStatus.BAD_REQUEST,
+				responseStatusException.getStatusCode());
+		}
+
+		Mockito.verify(
+			_licenseKeyService, Mockito.never()
+		).getLicenseKeysPage(
+			Mockito.anyInt(), Mockito.anyInt()
+		);
+	}
+
+	@Test
+	public void testGetLicenseKeysThrowsForbiddenWhenNotAdmin()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		Mockito.doThrow(
+			new PrincipalException()
+		).when(
+			_adminPermission
+		).check(
+			null
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> licenseKeysRestController.getLicenseKeys(null, 1, 20));
+
+		Mockito.verify(
+			_licenseKeyService, Mockito.never()
+		).getLicenseKeysPage(
+			Mockito.anyInt(), Mockito.anyInt()
+		);
+	}
+
+	@Test
 	public void testGetSubscriptionsReturnsFalseWhenNotSubscribed()
 		throws Exception {
 
@@ -352,8 +435,6 @@ public class LicenseKeysRestControllerTest {
 			HttpStatus.CONFLICT, responseStatusException.getStatusCode());
 	}
 
-
-
 	@Test
 	public void testPutSubscriptions() throws Exception {
 		LicenseKeysRestController licenseKeysRestController =
@@ -472,6 +553,9 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		ReflectionTestUtils.setField(
+			licenseKeysRestController, "_adminPermission", _adminPermission);
+
+		ReflectionTestUtils.setField(
 			licenseKeysRestController, "_commerceOrderService",
 			_commerceOrderService);
 
@@ -498,6 +582,8 @@ public class LicenseKeysRestControllerTest {
 
 	private static final long _USER_ID = 123L;
 
+	private final AdminPermission _adminPermission = Mockito.mock(
+		AdminPermission.class);
 	private final CommerceOrderService _commerceOrderService = Mockito.mock(
 		CommerceOrderService.class);
 	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -59,6 +59,35 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKey() throws Exception {
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ID
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKey(Mockito.any(), Mockito.anyLong())
+		).thenReturn(
+			licenseKey
+		);
+
+		Assertions.assertSame(
+			licenseKey, licenseKeysRestController.getLicenseKey(null, 1L));
+
+		Mockito.verify(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
+	}
+
+	@Test
 	public void testGetLicenseKeysDownload() throws Exception {
 		LicenseKeysRestController licenseKeysRestController =
 			_createController();
@@ -322,6 +351,8 @@ public class LicenseKeysRestControllerTest {
 		Assertions.assertEquals(
 			HttpStatus.CONFLICT, responseStatusException.getStatusCode());
 	}
+
+
 
 	@Test
 	public void testPutSubscriptions() throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/model/LicenseKeyTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/model/LicenseKeyTest.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyTest {
+
+	@Test
+	public void testSerializationOmitsKey() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		objectMapper.registerModule(new JavaTimeModule());
+
+		String json = objectMapper.writeValueAsString(
+			new LicenseKey(
+				new JSONObject(
+				).put(
+					"customExpirationDate", "2027-01-01T00:00:00Z"
+				).put(
+					"id", 1L
+				).put(
+					"key", _KEY
+				).put(
+					"name", "key-1"
+				).put(
+					"startDate", "2026-01-01T00:00:00Z"
+				)));
+
+		Assertions.assertFalse(
+			json.contains(_KEY),
+			"The license key material must not be serialized: " + json);
+		Assertions.assertTrue(json.contains("key-1"), json);
+	}
+
+	private static final String _KEY = "SECRET-KEY-MATERIAL";
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91426
https://liferay.atlassian.net/browse/LPD-89440

## What is being fixed

This is AC #1 of LPD-89440, the LicenseKeyResource GET endpoints. The Spring Boot client extension already served the subscription check, but not the single key read, the admin list, or an account's list, so three of the four reads the OSGi resource answered had no equivalent.

Worth stating explicitly, because it is the reason these endpoints matter rather than a mechanical port: the front end reaches license keys by calling `/o/c/licensekeys` directly, scoped by a filter it supplies itself. `C_LICENSE_KEY` is defined with `scope: company` and is not among the nine objects in `05-object-definition-account-entry-restricted`, so that filter is the only thing narrowing the result to one account. These endpoints resolve the account server side and check permission against the resolved id, which is the boundary the direct call does not have.

## How it is being fixed

- `GET /license-keys/{licenseKeyId}` reads one key, gated by account view permission on that key's own account rather than returning any key to any authenticated caller.
- `GET /license-keys` is the admin list, behind the existing administrator check, returning one page.
- `GET /accounts/{externalReferenceCode}/license-keys` lists an account's keys, gated by account view permission.

The fourth endpoint the AC names, the subscription check, was already ported and is untouched here.

The path variable is `externalReferenceCode` rather than the legacy `accountKey`: the other eleven mappings on `AccountsRestController` use that name, and it is what `AccountService.getAccount(String externalReferenceCode, Jwt jwt)` receives.

## Pagination on the admin list

The admin list takes `page` and `pageSize` and asks the object API for that page, rather than walking every page to build a list. `data-access.md` names license keys as a set that grows with the company, so an uncapped read is a time bomb; `pageSize` is validated server side against a maximum of 100 so a caller cannot widen it. The raw page is passed through, which keeps the `totalCount` an admin table needs — the same shape `CommonLicenseKeysRestController` already returns for its admin list.

The two account-scoped reads return a plain JSON array rather than the legacy Vulcan `Page` envelope, because the rest of this client extension returns lists everywhere and introducing an envelope on those alone would be inconsistent. The AC allows the envelope to match legacy or to be documented instead.

## A change wider than the AC

The last commit makes an unknown account external reference code return 404 instead of 500. Looking one up previously let the headless client's `ProblemException` propagate to the catch-all handler, so a bad code produced "An unexpected error occurred" with a stack trace. `AccountService` already translates an upstream 404 in its two `fetch` methods via `isNotFound`, and `OneBaseRestController` already maps a not-found exception to 404, so the lookup now throws a new `NoSuchAccountException`.

That method has fourteen callers, so nine other endpoints on `AccountsRestController` also change from 500 to 404 for an unknown code. No caller catches `ProblemException` — only `AccountService` does, in the two `fetch` methods, which do not route through this call — and `ProblemException` is checked, so every caller already declared `throws Exception`. Happy to split this into its own ticket if the widened scope is unwelcome.

The exception is new rather than the existing `AccountNotFoundException` because that one lives in the `jira` package, and a second class of the same name would have to be fully qualified in the controller that handles both.

## Testing

480 unit tests pass. The three endpoints are covered for the happy path, the admin-only rejection, and the page size guard; the guard was mutation tested by deleting it, which fails that test.

Verified against a local LEC k3s environment, with the deployed jar confirmed by md5 against the build:

| request | result |
| --- | --- |
| no or malformed bearer token, every endpoint | 401 |
| `GET /license-keys` as an administrator | 200 |
| `GET /accounts/{erc}/license-keys` for a real account | 200 |
| `GET /accounts/NO_SUCH_ACCT/license-keys` | 404, was 500 |

## Not covered here

Nothing consumes these endpoints yet — the front end still calls `/o/c/licensekeys` directly, and its date-range filtering runs in the browser over one fetched page. Moving that filtering server side belongs with whichever ticket switches the front end over.
