### PR TITLE
LPD-89437 LPD-102069 Reference project accounts on JSM contacts

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/skills/one-pr/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-pr/SKILL.md
@@ -60,6 +60,7 @@ Name the state in a sentence or two — a note, not a report:
 In every case but the first, **do not push, do not open the pull request, and do not transition the Jira ticket yet.** Ask once, with `AskUserQuestion`, offering these two in this order:
 
 1. **Run `/one-review` first** — the recommendation, and the first option every time. Stop the run here, and hand it back so they can invoke `/one-review` themselves.
+
 1. **Open the pull request anyway** — proceed to everything below, Jira transition included.
 
 Nothing goes out on a default or a shrug. The pull request is opened only when the author picks it, either at that question or by saying so afterward.

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -13,6 +13,7 @@ import com.liferay.one.exception.InvalidUsageProductException;
 import com.liferay.one.exception.ProjectNotFoundException;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
+import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.model.BaseUsageStrategy;
 import com.liferay.one.model.Entitlement;
@@ -81,7 +82,8 @@ public class ProjectRestController extends OneBaseRestController {
 		if (_projectMembershipService.deleteProjectMembership(
 				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-			_syncMembership(projectId, userId);
+			_syncDeletedMembership(
+				accountRoleExternalReferenceCode, projectId, userId);
 		}
 	}
 
@@ -168,7 +170,8 @@ public class ProjectRestController extends OneBaseRestController {
 		if (_projectMembershipService.addProjectMembership(
 				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-			_syncMembership(projectId, userId);
+			_syncAddedMembership(
+				accountRoleExternalReferenceCode, projectId, userId);
 		}
 	}
 
@@ -185,6 +188,18 @@ public class ProjectRestController extends OneBaseRestController {
 			_projectService.getProject(externalReferenceCode));
 
 		return new ResponseEntity<>(HttpStatus.OK);
+	}
+
+	private UserAccount _fetchUserAccount(long userId) {
+		try {
+			return _userAccountService.getUserAccount(userId);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to get user account for user " + userId, exception);
+
+			return null;
+		}
 	}
 
 	private String _getAccountKey(Project project) throws Exception {
@@ -340,35 +355,83 @@ public class ProjectRestController extends OneBaseRestController {
 		return false;
 	}
 
-	private void _syncMembership(
+	private void _syncAddedMembership(
+		String accountRoleExternalReferenceCode,
 		String projectExternalReferenceCode, long userId) {
 
-		_syncProjectAndAccountUserAccounts(projectExternalReferenceCode);
+		UserAccount userAccount = _fetchUserAccount(userId);
 
-		UserAccount userAccount = null;
+		if (userAccount == null) {
+			return;
+		}
+
+		_syncMembership(projectExternalReferenceCode, userAccount);
 
 		try {
-			userAccount = _userAccountService.getUserAccount(userId);
+			_accountUserAccountRoleSynchronizer.syncAssignRole(
+				accountRoleExternalReferenceCode,
+				userAccount.getExternalReferenceCode(),
+				projectExternalReferenceCode);
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to get user account for user " + userId, exception);
+				StringBundler.concat(
+					"Unable to sync contact role ",
+					accountRoleExternalReferenceCode, " for user ",
+					userAccount.getId()),
+				exception);
+		}
+	}
 
+	private void _syncDeletedMembership(
+		String accountRoleExternalReferenceCode,
+		String projectExternalReferenceCode, long userId) {
+
+		UserAccount userAccount = _fetchUserAccount(userId);
+
+		if (userAccount == null) {
 			return;
 		}
+
+		_syncMembership(projectExternalReferenceCode, userAccount);
+
+		try {
+			_accountUserAccountRoleSynchronizer.syncUnassignRole(
+				accountRoleExternalReferenceCode,
+				userAccount.getExternalReferenceCode(),
+				projectExternalReferenceCode);
+		}
+		catch (Exception exception) {
+			_log.error(
+				StringBundler.concat(
+					"Unable to sync contact role ",
+					accountRoleExternalReferenceCode, " for user ",
+					userAccount.getId()),
+				exception);
+		}
+	}
+
+	private void _syncMembership(
+		String projectExternalReferenceCode, UserAccount userAccount) {
+
+		_syncProjectAndAccountUserAccounts(projectExternalReferenceCode);
 
 		try {
 			_userAccountSynchronizer.syncUserAccountAccounts(userAccount);
 		}
 		catch (Exception exception) {
-			_log.error("Unable to sync accounts for user " + userId, exception);
+			_log.error(
+				"Unable to sync accounts for user " + userAccount.getId(),
+				exception);
 		}
 
 		try {
 			_userAccountSynchronizer.syncUserAccountRoles(userAccount);
 		}
 		catch (Exception exception) {
-			_log.error("Unable to sync roles for user " + userId, exception);
+			_log.error(
+				"Unable to sync roles for user " + userAccount.getId(),
+				exception);
 		}
 	}
 
@@ -427,6 +490,10 @@ public class ProjectRestController extends OneBaseRestController {
 
 	@Autowired
 	private AccountSynchronizer _accountSynchronizer;
+
+	@Autowired
+	private AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer;
 
 	@Autowired
 	private BusinessEventPermission _businessEventPermission;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -5,6 +5,7 @@
 
 package com.liferay.one;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.CommerceProductConstants;
 import com.liferay.one.constants.PropertyConstants;
 import com.liferay.one.exception.GoogleCloudFunctionUnavailableException;
@@ -12,6 +13,7 @@ import com.liferay.one.exception.InvalidUsageProductException;
 import com.liferay.one.exception.ProjectNotFoundException;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.model.BaseUsageStrategy;
 import com.liferay.one.model.Entitlement;
 import com.liferay.one.model.EntitlementDefinition;
@@ -25,6 +27,7 @@ import com.liferay.one.service.GoogleCloudFunctionService;
 import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -76,6 +79,8 @@ public class ProjectRestController extends OneBaseRestController {
 
 		_projectMembershipService.deleteProjectMembership(
 			jwt, projectId, accountRoleExternalReferenceCode, userId);
+
+		_syncMembership(userId);
 	}
 
 	@GetMapping("/{externalReferenceCode}/jira/object-key")
@@ -160,6 +165,8 @@ public class ProjectRestController extends OneBaseRestController {
 
 		_projectMembershipService.addProjectMembership(
 			jwt, projectId, accountRoleExternalReferenceCode, userId);
+
+		_syncMembership(userId);
 	}
 
 	@PostMapping("/{externalReferenceCode}/sync-to-jsm")
@@ -330,6 +337,34 @@ public class ProjectRestController extends OneBaseRestController {
 		return false;
 	}
 
+	private void _syncMembership(long userId) {
+		UserAccount userAccount = null;
+
+		try {
+			userAccount = _userAccountService.getUserAccount(userId);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to get user account for user " + userId, exception);
+
+			return;
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountAccounts(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to sync accounts for user " + userId, exception);
+		}
+
+		try {
+			_userAccountSynchronizer.syncUserAccountRoles(userAccount);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to sync roles for user " + userId, exception);
+		}
+	}
+
 	private static final DateTimeFormatter _BILLING_PERIOD_DATE_TIME_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyy-MM");
 
@@ -362,5 +397,11 @@ public class ProjectRestController extends OneBaseRestController {
 
 	@Autowired
 	private PropertyService _propertyService;
+
+	@Autowired
+	private UserAccountService _userAccountService;
+
+	@Autowired
+	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -77,10 +77,11 @@ public class ProjectRestController extends OneBaseRestController {
 			@PathVariable String accountRoleExternalReferenceCode)
 		throws Exception {
 
-		_projectMembershipService.deleteProjectMembership(
-			jwt, projectId, accountRoleExternalReferenceCode, userId);
+		if (_projectMembershipService.deleteProjectMembership(
+				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-		_syncMembership(userId);
+			_syncMembership(userId);
+		}
 	}
 
 	@GetMapping("/{externalReferenceCode}/jira/object-key")
@@ -163,10 +164,11 @@ public class ProjectRestController extends OneBaseRestController {
 			@PathVariable String accountRoleExternalReferenceCode)
 		throws Exception {
 
-		_projectMembershipService.addProjectMembership(
-			jwt, projectId, accountRoleExternalReferenceCode, userId);
+		if (_projectMembershipService.addProjectMembership(
+				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-		_syncMembership(userId);
+			_syncMembership(userId);
+		}
 	}
 
 	@PostMapping("/{externalReferenceCode}/sync-to-jsm")

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -21,6 +21,7 @@ import com.liferay.one.model.ExperienceUsageStrategy;
 import com.liferay.one.model.Project;
 import com.liferay.one.model.SaaSUsageStrategy;
 import com.liferay.one.permission.BusinessEventPermission;
+import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommerceProductService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.GoogleCloudFunctionService;
@@ -342,16 +343,7 @@ public class ProjectRestController extends OneBaseRestController {
 	private void _syncMembership(
 		String projectExternalReferenceCode, long userId) {
 
-		try {
-			_accountSynchronizer.syncProjectUserAccounts(
-				_projectService.getProject(projectExternalReferenceCode));
-		}
-		catch (Exception exception) {
-			_log.error(
-				"Unable to sync users for project " +
-					projectExternalReferenceCode,
-				exception);
-		}
+		_syncProjectAndAccountUserAccounts(projectExternalReferenceCode);
 
 		UserAccount userAccount = null;
 
@@ -380,6 +372,47 @@ public class ProjectRestController extends OneBaseRestController {
 		}
 	}
 
+	private void _syncProjectAndAccountUserAccounts(
+		String projectExternalReferenceCode) {
+
+		Project project = null;
+
+		try {
+			project = _projectService.getProject(projectExternalReferenceCode);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to get project " + projectExternalReferenceCode,
+				exception);
+
+			return;
+		}
+
+		try {
+			_accountSynchronizer.syncProjectUserAccounts(project);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync users for project " +
+					projectExternalReferenceCode,
+				exception);
+		}
+
+		String accountExternalReferenceCode =
+			project.getAccountExternalReferenceCode();
+
+		try {
+			_accountSynchronizer.syncAccountUserAccounts(
+				_accountService.getAccount(accountExternalReferenceCode));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync users for account " +
+					accountExternalReferenceCode,
+				exception);
+		}
+	}
+
 	private static final DateTimeFormatter _BILLING_PERIOD_DATE_TIME_FORMATTER =
 		DateTimeFormatter.ofPattern("yyyy-MM");
 
@@ -388,6 +421,9 @@ public class ProjectRestController extends OneBaseRestController {
 
 	@Autowired
 	private AccountAssetService _accountAssetService;
+
+	@Autowired
+	private AccountService _accountService;
 
 	@Autowired
 	private AccountSynchronizer _accountSynchronizer;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/ProjectRestController.java
@@ -80,7 +80,7 @@ public class ProjectRestController extends OneBaseRestController {
 		if (_projectMembershipService.deleteProjectMembership(
 				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-			_syncMembership(userId);
+			_syncMembership(projectId, userId);
 		}
 	}
 
@@ -167,7 +167,7 @@ public class ProjectRestController extends OneBaseRestController {
 		if (_projectMembershipService.addProjectMembership(
 				jwt, projectId, accountRoleExternalReferenceCode, userId)) {
 
-			_syncMembership(userId);
+			_syncMembership(projectId, userId);
 		}
 	}
 
@@ -339,7 +339,20 @@ public class ProjectRestController extends OneBaseRestController {
 		return false;
 	}
 
-	private void _syncMembership(long userId) {
+	private void _syncMembership(
+		String projectExternalReferenceCode, long userId) {
+
+		try {
+			_accountSynchronizer.syncProjectUserAccounts(
+				_projectService.getProject(projectExternalReferenceCode));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to sync users for project " +
+					projectExternalReferenceCode,
+				exception);
+		}
+
 		UserAccount userAccount = null;
 
 		try {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -176,17 +176,8 @@ public class AccountSynchronizer {
 					" to JSM");
 		}
 
-		String accountExternalReferenceCode =
-			project.getAccountExternalReferenceCode();
-
-		if (Validator.isNull(accountExternalReferenceCode)) {
-			throw new AccountNotFoundException(
-				"Project " + project.getExternalReferenceCode() +
-					" has no account external reference code");
-		}
-
 		AccountSyncModel accountSyncModel = _createAccountSyncModel(
-			_accountService.getAccount(accountExternalReferenceCode));
+			_getProjectAccount(project));
 
 		ProjectSyncModel projectSyncModel = _createProjectSyncModel(
 			accountSyncModel, project);
@@ -208,8 +199,7 @@ public class AccountSynchronizer {
 					project.getExternalReferenceCode() + " to JSM");
 		}
 
-		Account account = _accountService.getAccount(
-			project.getAccountExternalReferenceCode());
+		Account account = _getProjectAccount(project);
 
 		AccountSyncModel accountSyncModel = _createAccountSyncModel(account);
 
@@ -244,6 +234,19 @@ public class AccountSynchronizer {
 		return new ProjectSyncModel(
 			accountSyncModel, _entitlementService, project,
 			_projectMembershipService, _userAccountService);
+	}
+
+	private Account _getProjectAccount(Project project) throws Exception {
+		String accountExternalReferenceCode =
+			project.getAccountExternalReferenceCode();
+
+		if (Validator.isNull(accountExternalReferenceCode)) {
+			throw new AccountNotFoundException(
+				"Project " + project.getExternalReferenceCode() +
+					" has no account external reference code");
+		}
+
+		return _accountService.getAccount(accountExternalReferenceCode);
 	}
 
 	private void _setAttributeValues(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/AccountSynchronizer.java
@@ -201,6 +201,35 @@ public class AccountSynchronizer {
 		_syncUserAccounts(userAccounts);
 	}
 
+	public void syncProjectUserAccounts(Project project) throws Exception {
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				"Syncing user accounts for project " +
+					project.getExternalReferenceCode() + " to JSM");
+		}
+
+		Account account = _accountService.getAccount(
+			project.getAccountExternalReferenceCode());
+
+		AccountSyncModel accountSyncModel = _createAccountSyncModel(account);
+
+		ProjectSyncModel projectSyncModel = _createProjectSyncModel(
+			accountSyncModel, project);
+
+		_syncAccountAsset(
+			account, project.getExternalReferenceCode(), project.getName(),
+			jiraAssetObject -> {
+				jiraAssetObject.setAttributeValue(
+					AccountConstants.ATTRIBUTE_NAME_CUSTOMER_CONTACTS,
+					_toContactObjectIds(
+						projectSyncModel.getCustomerUserAccounts()));
+				jiraAssetObject.setAttributeValue(
+					AccountConstants.ATTRIBUTE_NAME_WORKER_CONTACTS,
+					_toContactObjectIds(
+						projectSyncModel.getWorkerUserAccounts()));
+			});
+	}
+
 	private AccountSyncModel _createAccountSyncModel(Account account) {
 		return new AccountSyncModel(
 			account, _commerceOrderService, _entitlementService,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/ProjectSyncModel.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/ProjectSyncModel.java
@@ -15,8 +15,13 @@ import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.role.EmployeeRoles;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * @author Drew Brokke
@@ -86,11 +91,35 @@ public class ProjectSyncModel {
 		Map<String, Role> accountRolesByExternalReferenceCode =
 			_accountSyncModel.getAccountRolesByExternalReferenceCode();
 
+		List<ProjectMembership> projectMemberships = getProjectMemberships();
+
+		List<Long> userIds = new ArrayList<>();
+
+		for (ProjectMembership projectMembership : projectMemberships) {
+			userIds.add(projectMembership.getUserId());
+		}
+
+		Map<Long, UserAccount> userAccountsByUserId = new LinkedHashMap<>();
+
+		for (UserAccount userAccount :
+				_userAccountService.getUserAccounts(userIds)) {
+
+			userAccountsByUserId.put(userAccount.getId(), userAccount);
+		}
+
 		_userAccountBucket = new UserAccountBucket();
 
-		for (ProjectMembership projectMembership : getProjectMemberships()) {
-			UserAccount userAccount = _userAccountService.getUserAccount(
+		for (ProjectMembership projectMembership : projectMemberships) {
+			UserAccount userAccount = userAccountsByUserId.get(
 				projectMembership.getUserId());
+
+			if (userAccount == null) {
+				_log.error(
+					"Unable to get user account for user " +
+						projectMembership.getUserId());
+
+				continue;
+			}
 
 			Role role = accountRolesByExternalReferenceCode.get(
 				projectMembership.getRoleExternalReferenceCode());
@@ -105,6 +134,8 @@ public class ProjectSyncModel {
 
 		return _userAccountBucket;
 	}
+
+	private static final Log _log = LogFactory.getLog(ProjectSyncModel.class);
 
 	private final AccountSyncModel _accountSyncModel;
 	private List<EntitlementDefinition> _activeEntitlementDefinitions;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSyncModel.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSyncModel.java
@@ -13,8 +13,10 @@ import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccountContactInformation;
 import com.liferay.one.jira.converter.ExternalLinkConverter;
 import com.liferay.one.model.EntitlementDefinition;
+import com.liferay.one.model.ProjectMembership;
 import com.liferay.one.model.Property;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.portal.kernel.util.ListUtil;
 
@@ -30,10 +32,12 @@ public class UserAccountSyncModel {
 	public UserAccountSyncModel(
 		EntitlementService entitlementService,
 		ExternalLinkConverter externalLinkConverter,
+		ProjectMembershipService projectMembershipService,
 		PropertyService propertyService, UserAccount userAccount) {
 
 		_entitlementService = entitlementService;
 		_externalLinkConverter = externalLinkConverter;
+		_projectMembershipService = projectMembershipService;
 		_propertyService = propertyService;
 		_userAccount = userAccount;
 	}
@@ -45,6 +49,26 @@ public class UserAccountSyncModel {
 		}
 
 		return _accountBriefs;
+	}
+
+	public List<String> getAccountExternalReferenceCodes() throws Exception {
+		if (_accountExternalReferenceCodes != null) {
+			return _accountExternalReferenceCodes;
+		}
+
+		List<String> accountExternalReferenceCodes = new ArrayList<>();
+
+		for (AccountBrief accountBrief : getAccountBriefs()) {
+			accountExternalReferenceCodes.add(
+				accountBrief.getExternalReferenceCode());
+		}
+
+		accountExternalReferenceCodes.addAll(
+			_getProjectExternalReferenceCodes());
+
+		_accountExternalReferenceCodes = accountExternalReferenceCodes;
+
+		return _accountExternalReferenceCodes;
 	}
 
 	public List<EntitlementDefinition> getEntitlementDefinitions()
@@ -148,6 +172,27 @@ public class UserAccountSyncModel {
 		return _userAccount;
 	}
 
+	private List<String> _getProjectExternalReferenceCodes() throws Exception {
+		if (_projectExternalReferenceCodes != null) {
+			return _projectExternalReferenceCodes;
+		}
+
+		List<String> projectExternalReferenceCodes = new ArrayList<>();
+
+		List<ProjectMembership> projectMemberships =
+			_projectMembershipService.getProjectMembershipsByUserId(
+				_userAccount.getId());
+
+		for (ProjectMembership projectMembership : projectMemberships) {
+			projectExternalReferenceCodes.add(
+				projectMembership.getProjectExternalReferenceCode());
+		}
+
+		_projectExternalReferenceCodes = projectExternalReferenceCodes;
+
+		return _projectExternalReferenceCodes;
+	}
+
 	private List<Property> _getUserAccountProperties() throws Exception {
 		if (_userAccountProperties == null) {
 			_userAccountProperties = _propertyService.getUserAccountProperties(
@@ -158,11 +203,14 @@ public class UserAccountSyncModel {
 	}
 
 	private List<AccountBrief> _accountBriefs;
+	private List<String> _accountExternalReferenceCodes;
 	private List<EntitlementDefinition> _entitlementDefinitions;
 	private final EntitlementService _entitlementService;
 	private final ExternalLinkConverter _externalLinkConverter;
 	private List<Property> _externalLinkProperties;
 	private List<OrganizationBrief> _organizationBriefs;
+	private List<String> _projectExternalReferenceCodes;
+	private final ProjectMembershipService _projectMembershipService;
 	private final PropertyService _propertyService;
 	private List<RoleBrief> _roleBriefs;
 	private List<Phone> _telephones;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSyncModel.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSyncModel.java
@@ -1,0 +1,172 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.synchronizer;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccountContactInformation;
+import com.liferay.one.jira.converter.ExternalLinkConverter;
+import com.liferay.one.model.EntitlementDefinition;
+import com.liferay.one.model.Property;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.PropertyService;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Drew Brokke
+ */
+public class UserAccountSyncModel {
+
+	public UserAccountSyncModel(
+		EntitlementService entitlementService,
+		ExternalLinkConverter externalLinkConverter,
+		PropertyService propertyService, UserAccount userAccount) {
+
+		_entitlementService = entitlementService;
+		_externalLinkConverter = externalLinkConverter;
+		_propertyService = propertyService;
+		_userAccount = userAccount;
+	}
+
+	public List<AccountBrief> getAccountBriefs() {
+		if (_accountBriefs == null) {
+			_accountBriefs = ListUtil.fromArray(
+				_userAccount.getAccountBriefs());
+		}
+
+		return _accountBriefs;
+	}
+
+	public List<EntitlementDefinition> getEntitlementDefinitions()
+		throws Exception {
+
+		if (_entitlementDefinitions != null) {
+			return _entitlementDefinitions;
+		}
+
+		List<EntitlementDefinition> entitlementDefinitions = new ArrayList<>();
+
+		for (AccountBrief accountBrief : getAccountBriefs()) {
+			entitlementDefinitions.addAll(
+				_entitlementService.getActiveEntitlementDefinitions(
+					accountBrief.getId()));
+		}
+
+		_entitlementDefinitions = entitlementDefinitions;
+
+		return _entitlementDefinitions;
+	}
+
+	public List<Property> getExternalLinkProperties() throws Exception {
+		if (_externalLinkProperties != null) {
+			return _externalLinkProperties;
+		}
+
+		List<Property> externalLinkProperties = new ArrayList<>();
+
+		for (Property property : _getUserAccountProperties()) {
+			if (_externalLinkConverter.isExternalLinkProperty(property)) {
+				externalLinkProperties.add(property);
+			}
+		}
+
+		_externalLinkProperties = externalLinkProperties;
+
+		return _externalLinkProperties;
+	}
+
+	public String getExternalReferenceCode() {
+		return _userAccount.getExternalReferenceCode();
+	}
+
+	public List<OrganizationBrief> getOrganizationBriefs() {
+		if (_organizationBriefs == null) {
+			_organizationBriefs = ListUtil.fromArray(
+				_userAccount.getOrganizationBriefs());
+		}
+
+		return _organizationBriefs;
+	}
+
+	public List<RoleBrief> getRoleBriefs() {
+		if (_roleBriefs != null) {
+			return _roleBriefs;
+		}
+
+		_roleBriefs = new ArrayList<>();
+
+		for (AccountBrief accountBrief : getAccountBriefs()) {
+			RoleBrief[] accountRoleBriefs = accountBrief.getRoleBriefs();
+
+			if (accountRoleBriefs != null) {
+				Collections.addAll(_roleBriefs, accountRoleBriefs);
+			}
+		}
+
+		for (OrganizationBrief organizationBrief : getOrganizationBriefs()) {
+			RoleBrief[] organizationRoleBriefs =
+				organizationBrief.getRoleBriefs();
+
+			if (organizationRoleBriefs != null) {
+				Collections.addAll(_roleBriefs, organizationRoleBriefs);
+			}
+		}
+
+		return _roleBriefs;
+	}
+
+	public List<Phone> getTelephones() {
+		if (_telephones != null) {
+			return _telephones;
+		}
+
+		UserAccountContactInformation userAccountContactInformation =
+			_userAccount.getUserAccountContactInformation();
+
+		if (userAccountContactInformation == null) {
+			_telephones = Collections.emptyList();
+		}
+		else {
+			_telephones = ListUtil.fromArray(
+				userAccountContactInformation.getTelephones());
+		}
+
+		return _telephones;
+	}
+
+	public UserAccount getUserAccount() {
+		return _userAccount;
+	}
+
+	private List<Property> _getUserAccountProperties() throws Exception {
+		if (_userAccountProperties == null) {
+			_userAccountProperties = _propertyService.getUserAccountProperties(
+				_userAccount.getId());
+		}
+
+		return _userAccountProperties;
+	}
+
+	private List<AccountBrief> _accountBriefs;
+	private List<EntitlementDefinition> _entitlementDefinitions;
+	private final EntitlementService _entitlementService;
+	private final ExternalLinkConverter _externalLinkConverter;
+	private List<Property> _externalLinkProperties;
+	private List<OrganizationBrief> _organizationBriefs;
+	private final PropertyService _propertyService;
+	private List<RoleBrief> _roleBriefs;
+	private List<Phone> _telephones;
+	private final UserAccount _userAccount;
+	private List<Property> _userAccountProperties;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
@@ -23,9 +23,12 @@ import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.Property;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.util.KeyedLock;
 import com.liferay.petra.string.StringBundler;
+
+import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -86,7 +89,9 @@ public class UserAccountSynchronizer {
 			() -> _syncUserAccount(_createUserAccountSyncModel(userAccount)));
 	}
 
-	public void syncUserAccountAccounts(UserAccount userAccount) {
+	public void syncUserAccountAccounts(UserAccount userAccount)
+		throws Exception {
+
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				"Syncing accounts for user account " +
@@ -101,9 +106,7 @@ public class UserAccountSynchronizer {
 
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
-			_jiraAssetService.fetchReferenceObjectIds(
-				_accountConverter, userAccountSyncModel.getAccountBriefs(),
-				AccountBrief::getExternalReferenceCode));
+			_getAccountObjectIds(userAccountSyncModel));
 
 		_keyedLock.withLock(
 			userAccount.getExternalReferenceCode(),
@@ -162,8 +165,18 @@ public class UserAccountSynchronizer {
 		UserAccount userAccount) {
 
 		return new UserAccountSyncModel(
-			_entitlementService, _externalLinkConverter, _propertyService,
-			userAccount);
+			_entitlementService, _externalLinkConverter,
+			_projectMembershipService, _propertyService, userAccount);
+	}
+
+	private List<String> _getAccountObjectIds(
+			UserAccountSyncModel userAccountSyncModel)
+		throws Exception {
+
+		return _jiraAssetService.fetchReferenceObjectIds(
+			_accountConverter,
+			userAccountSyncModel.getAccountExternalReferenceCodes(),
+			externalReferenceCode -> externalReferenceCode);
 	}
 
 	private void _syncContactRoleAssignments(
@@ -243,9 +256,7 @@ public class UserAccountSynchronizer {
 
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
-			_jiraAssetService.fetchReferenceObjectIds(
-				_accountConverter, userAccountSyncModel.getAccountBriefs(),
-				AccountBrief::getExternalReferenceCode));
+			_getAccountObjectIds(userAccountSyncModel));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			_jiraAssetService.fetchReferenceObjectIds(
@@ -319,6 +330,9 @@ public class UserAccountSynchronizer {
 
 	@Autowired
 	private PhoneConverter _phoneConverter;
+
+	@Autowired
+	private ProjectMembershipService _projectMembershipService;
 
 	@Autowired
 	private PropertyService _propertyService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizer.java
@@ -10,7 +10,6 @@ import com.liferay.headless.admin.user.client.dto.v1_0.OrganizationBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
-import com.liferay.headless.admin.user.client.dto.v1_0.UserAccountContactInformation;
 import com.liferay.one.jira.constants.ContactConstants;
 import com.liferay.one.jira.converter.AccountConverter;
 import com.liferay.one.jira.converter.ContactConverter;
@@ -27,11 +26,6 @@ import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.util.KeyedLock;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.util.ListUtil;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -89,7 +83,7 @@ public class UserAccountSynchronizer {
 	public void syncUserAccount(UserAccount userAccount) throws Exception {
 		_keyedLock.withLock(
 			userAccount.getExternalReferenceCode(),
-			() -> _syncUserAccount(userAccount));
+			() -> _syncUserAccount(_createUserAccountSyncModel(userAccount)));
 	}
 
 	public void syncUserAccountAccounts(UserAccount userAccount) {
@@ -99,14 +93,16 @@ public class UserAccountSynchronizer {
 					userAccount.getExternalReferenceCode() + " to JSM");
 		}
 
+		UserAccountSyncModel userAccountSyncModel = _createUserAccountSyncModel(
+			userAccount);
+
 		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
 			userAccount);
 
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_accountConverter,
-				ListUtil.fromArray(userAccount.getAccountBriefs()),
+				_accountConverter, userAccountSyncModel.getAccountBriefs(),
 				AccountBrief::getExternalReferenceCode));
 
 		_keyedLock.withLock(
@@ -121,14 +117,16 @@ public class UserAccountSynchronizer {
 					userAccount.getExternalReferenceCode() + " to JSM");
 		}
 
+		UserAccountSyncModel userAccountSyncModel = _createUserAccountSyncModel(
+			userAccount);
+
 		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
 			userAccount);
 
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_TEAMS,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_teamConverter,
-				ListUtil.fromArray(userAccount.getOrganizationBriefs()),
+				_teamConverter, userAccountSyncModel.getOrganizationBriefs(),
 				OrganizationBrief::getExternalReferenceCode));
 
 		_keyedLock.withLock(
@@ -143,13 +141,16 @@ public class UserAccountSynchronizer {
 					userAccount.getExternalReferenceCode() + " to JSM");
 		}
 
+		UserAccountSyncModel userAccountSyncModel = _createUserAccountSyncModel(
+			userAccount);
+
 		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
 			userAccount);
 
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_contactRoleConverter, _getRoleBriefs(userAccount),
+				_contactRoleConverter, userAccountSyncModel.getRoleBriefs(),
 				RoleBrief::getExternalReferenceCode));
 
 		_keyedLock.withLock(
@@ -157,81 +158,20 @@ public class UserAccountSynchronizer {
 			() -> _jiraAssetService.upsert(_contactConverter, jiraAssetObject));
 	}
 
-	private List<EntitlementDefinition> _getEntitlementDefinitions(
-			List<AccountBrief> accountBriefs)
-		throws Exception {
+	private UserAccountSyncModel _createUserAccountSyncModel(
+		UserAccount userAccount) {
 
-		List<EntitlementDefinition> entitlementDefinitions = new ArrayList<>();
-
-		for (AccountBrief accountBrief : accountBriefs) {
-			entitlementDefinitions.addAll(
-				_entitlementService.getActiveEntitlementDefinitions(
-					accountBrief.getId()));
-		}
-
-		return entitlementDefinitions;
-	}
-
-	private List<Property> _getExternalLinkProperties(UserAccount userAccount)
-		throws Exception {
-
-		List<Property> externalLinkProperties = new ArrayList<>();
-
-		List<Property> properties = _propertyService.getUserAccountProperties(
-			userAccount.getId());
-
-		for (Property property : properties) {
-			if (_externalLinkConverter.isExternalLinkProperty(property)) {
-				externalLinkProperties.add(property);
-			}
-		}
-
-		return externalLinkProperties;
-	}
-
-	private List<RoleBrief> _getRoleBriefs(UserAccount userAccount) {
-		List<RoleBrief> roleBriefs = new ArrayList<>();
-
-		for (AccountBrief accountBrief :
-				ListUtil.fromArray(userAccount.getAccountBriefs())) {
-
-			RoleBrief[] accountRoleBriefs = accountBrief.getRoleBriefs();
-
-			if (accountRoleBriefs != null) {
-				Collections.addAll(roleBriefs, accountRoleBriefs);
-			}
-		}
-
-		for (OrganizationBrief organizationBrief :
-				ListUtil.fromArray(userAccount.getOrganizationBriefs())) {
-
-			RoleBrief[] organizationRoleBriefs =
-				organizationBrief.getRoleBriefs();
-
-			if (organizationRoleBriefs != null) {
-				Collections.addAll(roleBriefs, organizationRoleBriefs);
-			}
-		}
-
-		return roleBriefs;
-	}
-
-	private List<Phone> _getTelephones(UserAccount userAccount) {
-		UserAccountContactInformation userAccountContactInformation =
-			userAccount.getUserAccountContactInformation();
-
-		if (userAccountContactInformation == null) {
-			return Collections.emptyList();
-		}
-
-		return ListUtil.fromArray(
-			userAccountContactInformation.getTelephones());
+		return new UserAccountSyncModel(
+			_entitlementService, _externalLinkConverter, _propertyService,
+			userAccount);
 	}
 
 	private void _syncContactRoleAssignments(
-		UserAccount userAccount, List<AccountBrief> accountBriefs) {
+		UserAccountSyncModel userAccountSyncModel) {
 
-		for (AccountBrief accountBrief : accountBriefs) {
+		for (AccountBrief accountBrief :
+				userAccountSyncModel.getAccountBriefs()) {
+
 			RoleBrief[] roleBriefs = accountBrief.getRoleBriefs();
 
 			if (roleBriefs == null) {
@@ -242,7 +182,7 @@ public class UserAccountSynchronizer {
 				try {
 					_accountUserAccountRoleSynchronizer.syncAssignRole(
 						roleBrief.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode(),
+						userAccountSyncModel.getExternalReferenceCode(),
 						accountBrief.getExternalReferenceCode());
 				}
 				catch (Exception exception) {
@@ -257,9 +197,11 @@ public class UserAccountSynchronizer {
 	}
 
 	private void _syncOrganizationRoleAssignments(
-		UserAccount userAccount, List<OrganizationBrief> organizationBriefs) {
+		UserAccountSyncModel userAccountSyncModel) {
 
-		for (OrganizationBrief organizationBrief : organizationBriefs) {
+		for (OrganizationBrief organizationBrief :
+				userAccountSyncModel.getOrganizationBriefs()) {
+
 			RoleBrief[] roleBriefs = organizationBrief.getRoleBriefs();
 
 			if (roleBriefs == null) {
@@ -270,7 +212,7 @@ public class UserAccountSynchronizer {
 				try {
 					_organizationUserAccountRoleSynchronizer.syncAssignRole(
 						roleBrief.getExternalReferenceCode(),
-						userAccount.getExternalReferenceCode(),
+						userAccountSyncModel.getExternalReferenceCode(),
 						organizationBrief.getExternalReferenceCode());
 				}
 				catch (Exception exception) {
@@ -285,17 +227,16 @@ public class UserAccountSynchronizer {
 		}
 	}
 
-	private void _syncUserAccount(UserAccount userAccount) throws Exception {
+	private void _syncUserAccount(UserAccountSyncModel userAccountSyncModel)
+		throws Exception {
+
+		UserAccount userAccount = userAccountSyncModel.getUserAccount();
+
 		if (_log.isInfoEnabled()) {
 			_log.info(
 				"Syncing user account " +
 					userAccount.getExternalReferenceCode() + " to JSM");
 		}
-
-		List<AccountBrief> accountBriefs = ListUtil.fromArray(
-			userAccount.getAccountBriefs());
-		List<OrganizationBrief> organizationBriefs = ListUtil.fromArray(
-			userAccount.getOrganizationBriefs());
 
 		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
 			userAccount);
@@ -303,41 +244,42 @@ public class UserAccountSynchronizer {
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_accountConverter, accountBriefs,
+				_accountConverter, userAccountSyncModel.getAccountBriefs(),
 				AccountBrief::getExternalReferenceCode));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_contactRoleConverter, _getRoleBriefs(userAccount),
+				_contactRoleConverter, userAccountSyncModel.getRoleBriefs(),
 				RoleBrief::getExternalReferenceCode));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_ENTITLEMENTS,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
 				_entitlementConverter,
-				_getEntitlementDefinitions(accountBriefs),
+				userAccountSyncModel.getEntitlementDefinitions(),
 				EntitlementDefinition::getDisplayName,
 				_entitlementConverter::toAssetObject));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_EXTERNAL_LINKS,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_externalLinkConverter, _getExternalLinkProperties(userAccount),
+				_externalLinkConverter,
+				userAccountSyncModel.getExternalLinkProperties(),
 				Property::getExternalReferenceCode,
 				_externalLinkConverter::toAssetObject));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_TEAMS,
 			_jiraAssetService.fetchReferenceObjectIds(
-				_teamConverter, organizationBriefs,
+				_teamConverter, userAccountSyncModel.getOrganizationBriefs(),
 				OrganizationBrief::getExternalReferenceCode));
 		jiraAssetObject.setAttributeValue(
 			ContactConstants.ATTRIBUTE_NAME_PHONES,
 			_jiraAssetService.getOrCreateReferenceObjectIds(
-				_phoneConverter, _getTelephones(userAccount),
+				_phoneConverter, userAccountSyncModel.getTelephones(),
 				Phone::getPhoneNumber, _phoneConverter::toAssetObject));
 
 		_jiraAssetService.upsert(_contactConverter, jiraAssetObject);
 
-		_syncContactRoleAssignments(userAccount, accountBriefs);
-		_syncOrganizationRoleAssignments(userAccount, organizationBriefs);
+		_syncContactRoleAssignments(userAccountSyncModel);
+		_syncOrganizationRoleAssignments(userAccountSyncModel);
 	}
 
 	private static final Log _log = LogFactory.getLog(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
@@ -27,7 +27,12 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class ProjectMembershipService extends OneBaseService {
 
-	public void addProjectMembership(
+	/**
+	 * @return <code>true</code> if a project membership was added;
+	 *         <code>false</code> if one already existed or the project was not
+	 *         found
+	 */
+	public boolean addProjectMembership(
 			Jwt jwt, String projectExternalReferenceCode,
 			String roleExternalReferenceCode, long userId)
 		throws Exception {
@@ -37,14 +42,14 @@ public class ProjectMembershipService extends OneBaseService {
 			userId);
 
 		if (!projectMemberships.isEmpty()) {
-			return;
+			return false;
 		}
 
 		Project project = _projectService.fetchProject(
 			projectExternalReferenceCode, jwt);
 
 		if (project == null) {
-			return;
+			return false;
 		}
 
 		if (!_userAccountService.hasAccountUserAccount(
@@ -74,6 +79,8 @@ public class ProjectMembershipService extends OneBaseService {
 				"/o/c/projectmemberships"
 			).build(
 			).toUri());
+
+		return true;
 	}
 
 	public void addProjectMembership(
@@ -131,7 +138,11 @@ public class ProjectMembershipService extends OneBaseService {
 			).toUri());
 	}
 
-	public void deleteProjectMembership(
+	/**
+	 * @return <code>true</code> if at least one project membership was deleted;
+	 *         <code>false</code> if none matched
+	 */
+	public boolean deleteProjectMembership(
 			Jwt jwt, String projectExternalReferenceCode,
 			String roleExternalReferenceCode, long userId)
 		throws Exception {
@@ -139,6 +150,10 @@ public class ProjectMembershipService extends OneBaseService {
 		List<ProjectMembership> projectMemberships = _getProjectMemberships(
 			jwt, projectExternalReferenceCode, roleExternalReferenceCode,
 			userId);
+
+		if (projectMemberships.isEmpty()) {
+			return false;
+		}
 
 		for (ProjectMembership projectMembership : projectMemberships) {
 			delete(
@@ -150,6 +165,8 @@ public class ProjectMembershipService extends OneBaseService {
 					projectMembership.getExternalReferenceCode()
 				).toUri());
 		}
+
+		return true;
 	}
 
 	public ProjectMembership fetchProjectMembership(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/ProjectMembershipService.java
@@ -213,6 +213,15 @@ public class ProjectMembershipService extends OneBaseService {
 			ProjectMembership::new);
 	}
 
+	public List<ProjectMembership> getProjectMembershipsByUserId(long userId)
+		throws Exception {
+
+		return getAllItems(
+			"/o/c/projectmemberships",
+			"r_userToProjectMembership_userId eq '" + userId + "'",
+			ProjectMembership::new);
+	}
+
 	private List<ProjectMembership> _getProjectMemberships(
 			Jwt jwt, String projectExternalReferenceCode,
 			String roleExternalReferenceCode, long userId)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/UserAccountService.java
@@ -12,9 +12,14 @@ import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
 import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.admin.user.client.resource.v1_0.UserAccountResource;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -161,6 +166,39 @@ public class UserAccountService extends OneBaseService {
 		return userAccountResource.getUserAccountByEmailAddress(emailAddress);
 	}
 
+	public List<UserAccount> getUserAccounts(Collection<Long> userIds)
+		throws Exception {
+
+		if ((userIds == null) || userIds.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		UserAccountResource userAccountResource = _buildUserAccountResource(
+			"nestedFields", "customFields");
+
+		List<Long> uniqueUserIds = new ArrayList<>(
+			new LinkedHashSet<>(userIds));
+
+		List<UserAccount> userAccounts = new ArrayList<>();
+
+		for (int i = 0; i < uniqueUserIds.size(); i += _FILTER_BATCH_SIZE) {
+			List<Long> batchUserIds = uniqueUserIds.subList(
+				i, Math.min(i + _FILTER_BATCH_SIZE, uniqueUserIds.size()));
+
+			Page<UserAccount> userAccountsPage =
+				userAccountResource.getUserAccountsPage(
+					null,
+					StringBundler.concat(
+						"id in ('", StringUtil.merge(batchUserIds, "','"),
+						"')"),
+					Pagination.of(1, batchUserIds.size()), null);
+
+			userAccounts.addAll(userAccountsPage.getItems());
+		}
+
+		return userAccounts;
+	}
+
 	public boolean hasAccountUserAccount(long accountId, long userId)
 		throws Exception {
 
@@ -240,6 +278,8 @@ public class UserAccountService extends OneBaseService {
 			parameters
 		).build();
 	}
+
+	private static final int _FILTER_BATCH_SIZE = 100;
 
 	private static final int _PAGE_SIZE = 500;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/ProjectRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/ProjectRestControllerTest.java
@@ -5,21 +5,29 @@
 
 package com.liferay.one;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.constants.CommerceProductConstants;
 import com.liferay.one.constants.PropertyConstants;
 import com.liferay.one.exception.GoogleCloudFunctionUnavailableException;
 import com.liferay.one.exception.InvalidUsageProductException;
 import com.liferay.one.exception.ProjectNotFoundException;
+import com.liferay.one.jira.synchronizer.AccountSynchronizer;
+import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
+import com.liferay.one.jira.synchronizer.UserAccountSynchronizer;
 import com.liferay.one.model.BaseUsageStrategy;
 import com.liferay.one.model.Entitlement;
 import com.liferay.one.model.ExperienceUsageStrategy;
 import com.liferay.one.model.Project;
 import com.liferay.one.permission.BusinessEventPermission;
+import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommerceProductService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.GoogleCloudFunctionService;
+import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.ProjectService;
 import com.liferay.one.service.PropertyService;
+import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
@@ -50,6 +58,14 @@ public class ProjectRestControllerTest {
 		_projectRestController = new ProjectRestController();
 
 		ReflectionTestUtils.setField(
+			_projectRestController, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_projectRestController, "_accountSynchronizer",
+			_accountSynchronizer);
+		ReflectionTestUtils.setField(
+			_projectRestController, "_accountUserAccountRoleSynchronizer",
+			_accountUserAccountRoleSynchronizer);
+		ReflectionTestUtils.setField(
 			_projectRestController, "_businessEventPermission",
 			_businessEventPermission);
 		ReflectionTestUtils.setField(
@@ -61,9 +77,17 @@ public class ProjectRestControllerTest {
 			_projectRestController, "_googleCloudFunctionService",
 			_googleCloudFunctionService);
 		ReflectionTestUtils.setField(
+			_projectRestController, "_projectMembershipService",
+			_projectMembershipService);
+		ReflectionTestUtils.setField(
 			_projectRestController, "_projectService", _projectService);
 		ReflectionTestUtils.setField(
 			_projectRestController, "_propertyService", _propertyService);
+		ReflectionTestUtils.setField(
+			_projectRestController, "_userAccountService", _userAccountService);
+		ReflectionTestUtils.setField(
+			_projectRestController, "_userAccountSynchronizer",
+			_userAccountSynchronizer);
 
 		Mockito.when(
 			_projectService.fetchProject(_PROJECT_EXTERNAL_REFERENCE_CODE)
@@ -72,6 +96,65 @@ public class ProjectRestControllerTest {
 		);
 
 		_setUpProductName(_PRODUCT_NAME_EXPERIENCE);
+	}
+
+	@Test
+	public void testDeleteProjectMembershipsDoesNotSyncWhenNothingDeleted()
+		throws Exception {
+
+		Mockito.when(
+			_projectMembershipService.deleteProjectMembership(
+				null, _PROJECT_EXTERNAL_REFERENCE_CODE,
+				_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE, _USER_ID)
+		).thenReturn(
+			false
+		);
+
+		_deleteProjectMemberships();
+
+		_assertNoSync();
+	}
+
+	@Test
+	public void testDeleteProjectMembershipsSyncsWhenDeleted()
+		throws Exception {
+
+		Mockito.when(
+			_projectMembershipService.deleteProjectMembership(
+				null, _PROJECT_EXTERNAL_REFERENCE_CODE,
+				_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE, _USER_ID)
+		).thenReturn(
+			true
+		);
+
+		_whenSyncDependencies();
+
+		_deleteProjectMemberships();
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncProjectUserAccounts(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountUserAccounts(
+			_account
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountAccounts(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_accountUserAccountRoleSynchronizer
+		).syncUnassignRole(
+			_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE,
+			_USER_EXTERNAL_REFERENCE_CODE, _PROJECT_EXTERNAL_REFERENCE_CODE
+		);
 	}
 
 	@Test
@@ -505,6 +588,71 @@ public class ProjectRestControllerTest {
 			"Product is required", problemDetail.getDetail());
 	}
 
+	@Test
+	public void testPostProjectMembershipsDoesNotSyncWhenNothingAdded()
+		throws Exception {
+
+		Mockito.when(
+			_projectMembershipService.addProjectMembership(
+				null, _PROJECT_EXTERNAL_REFERENCE_CODE,
+				_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE, _USER_ID)
+		).thenReturn(
+			false
+		);
+
+		_postProjectMemberships();
+
+		_assertNoSync();
+	}
+
+	@Test
+	public void testPostProjectMembershipsSyncsWhenAdded() throws Exception {
+		Mockito.when(
+			_projectMembershipService.addProjectMembership(
+				null, _PROJECT_EXTERNAL_REFERENCE_CODE,
+				_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE, _USER_ID)
+		).thenReturn(
+			true
+		);
+
+		_whenSyncDependencies();
+
+		_postProjectMemberships();
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncProjectUserAccounts(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccountUserAccounts(
+			_account
+		);
+
+		Mockito.verify(
+			_userAccountSynchronizer
+		).syncUserAccountAccounts(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_accountUserAccountRoleSynchronizer
+		).syncAssignRole(
+			_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE,
+			_USER_EXTERNAL_REFERENCE_CODE, _PROJECT_EXTERNAL_REFERENCE_CODE
+		);
+	}
+
+	private void _assertNoSync() throws Exception {
+		Mockito.verifyNoInteractions(_accountService);
+		Mockito.verifyNoInteractions(_accountSynchronizer);
+		Mockito.verifyNoInteractions(_accountUserAccountRoleSynchronizer);
+		Mockito.verifyNoInteractions(_userAccountService);
+		Mockito.verifyNoInteractions(_userAccountSynchronizer);
+	}
+
 	private String _createComposableUsage() {
 		return new JSONObject(
 		).put(
@@ -574,6 +722,12 @@ public class ProjectRestControllerTest {
 			));
 	}
 
+	private void _deleteProjectMemberships() throws Exception {
+		_projectRestController.deleteProjectMemberships(
+			null, _PROJECT_EXTERNAL_REFERENCE_CODE, _USER_ID,
+			_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE);
+	}
+
 	private JSONObject _getMetricsJSONObject() throws Exception {
 		ResponseEntity<String> responseEntity = _getUsage();
 
@@ -596,6 +750,12 @@ public class ProjectRestControllerTest {
 		return _projectRestController.getUsage(
 			null, _PROJECT_EXTERNAL_REFERENCE_CODE,
 			_PRODUCT_EXTERNAL_REFERENCE_CODE);
+	}
+
+	private void _postProjectMemberships() throws Exception {
+		_projectRestController.postProjectMemberships(
+			null, _PROJECT_EXTERNAL_REFERENCE_CODE, _USER_ID,
+			_ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE);
 	}
 
 	private void _setUpComposableUsage() throws Exception {
@@ -647,10 +807,38 @@ public class ProjectRestControllerTest {
 		);
 	}
 
+	private void _whenSyncDependencies() throws Exception {
+		Mockito.when(
+			_accountService.getAccount(_ACCOUNT_EXTERNAL_REFERENCE_CODE)
+		).thenReturn(
+			_account
+		);
+
+		Mockito.when(
+			_projectService.getProject(_PROJECT_EXTERNAL_REFERENCE_CODE)
+		).thenReturn(
+			_createProject()
+		);
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setExternalReferenceCode(_USER_EXTERNAL_REFERENCE_CODE);
+		userAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+	}
+
 	private static final String _ACCOUNT_EXTERNAL_REFERENCE_CODE =
 		"0015Y00002ABCDEabc";
 
 	private static final long _ACCOUNT_ID = 40001;
+
+	private static final String _ACCOUNT_ROLE_EXTERNAL_REFERENCE_CODE =
+		"ACCT-ROLE-001";
 
 	private static final long _CPRODUCT_ID = 55501;
 
@@ -666,6 +854,18 @@ public class ProjectRestControllerTest {
 
 	private static final String _PROJECT_EXTERNAL_REFERENCE_CODE = "PRJCT-004";
 
+	private static final String _USER_EXTERNAL_REFERENCE_CODE = "USER-001";
+
+	private static final long _USER_ID = 1L;
+
+	private final Account _account = new Account();
+	private final AccountService _accountService = Mockito.mock(
+		AccountService.class);
+	private final AccountSynchronizer _accountSynchronizer = Mockito.mock(
+		AccountSynchronizer.class);
+	private final AccountUserAccountRoleSynchronizer
+		_accountUserAccountRoleSynchronizer = Mockito.mock(
+			AccountUserAccountRoleSynchronizer.class);
 	private final BusinessEventPermission _businessEventPermission =
 		Mockito.mock(BusinessEventPermission.class);
 	private final CommerceProductService _commerceProductService = Mockito.mock(
@@ -674,10 +874,16 @@ public class ProjectRestControllerTest {
 		EntitlementService.class);
 	private final GoogleCloudFunctionService _googleCloudFunctionService =
 		Mockito.mock(GoogleCloudFunctionService.class);
+	private final ProjectMembershipService _projectMembershipService =
+		Mockito.mock(ProjectMembershipService.class);
 	private ProjectRestController _projectRestController;
 	private final ProjectService _projectService = Mockito.mock(
 		ProjectService.class);
 	private final PropertyService _propertyService = Mockito.mock(
 		PropertyService.class);
+	private final UserAccountService _userAccountService = Mockito.mock(
+		UserAccountService.class);
+	private final UserAccountSynchronizer _userAccountSynchronizer =
+		Mockito.mock(UserAccountSynchronizer.class);
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.one.jira.synchronizer;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.one.jira.constants.ContactConstants;
 import com.liferay.one.jira.converter.AccountConverter;
@@ -16,13 +17,17 @@ import com.liferay.one.jira.converter.PhoneConverter;
 import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.model.ProjectMembership;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.util.KeyedLock;
 import com.liferay.petra.function.UnsafeRunnable;
 
+import java.util.Arrays;
 import java.util.Collections;
+
+import org.json.JSONObject;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,12 +46,15 @@ public class UserAccountSynchronizerTest {
 	public void setUp() throws Exception {
 		_userAccountSynchronizer = new UserAccountSynchronizer();
 
+		_accountConverter = Mockito.mock(AccountConverter.class);
 		_accountUserAccountRoleSynchronizer = Mockito.mock(
 			AccountUserAccountRoleSynchronizer.class);
 		_contactConverter = Mockito.mock(ContactConverter.class);
 		_jiraAssetService = Mockito.mock(JiraAssetService.class);
 		_organizationUserAccountRoleSynchronizer = Mockito.mock(
 			OrganizationUserAccountRoleSynchronizer.class);
+		_projectMembershipService = Mockito.mock(
+			ProjectMembershipService.class);
 
 		PropertyService propertyService = Mockito.mock(PropertyService.class);
 
@@ -65,8 +73,7 @@ public class UserAccountSynchronizerTest {
 		);
 
 		ReflectionTestUtils.setField(
-			_userAccountSynchronizer, "_accountConverter",
-			Mockito.mock(AccountConverter.class));
+			_userAccountSynchronizer, "_accountConverter", _accountConverter);
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_accountUserAccountRoleSynchronizer",
 			_accountUserAccountRoleSynchronizer);
@@ -97,7 +104,7 @@ public class UserAccountSynchronizerTest {
 			Mockito.mock(PhoneConverter.class));
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_projectMembershipService",
-			Mockito.mock(ProjectMembershipService.class));
+			_projectMembershipService);
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_propertyService", propertyService);
 		ReflectionTestUtils.setField(
@@ -208,6 +215,17 @@ public class UserAccountSynchronizerTest {
 	}
 
 	@Test
+	public void testSyncUserAccountAccountsUpsertsProjectReferences()
+		throws Exception {
+
+		_whenProjectMembership();
+
+		_userAccountSynchronizer.syncUserAccountAccounts(_createUserAccount());
+
+		_verifyFetchesAccountAndProjectReferences();
+	}
+
+	@Test
 	public void testSyncUserAccountOrganizationsUpsertsOrganizationReferences()
 		throws Exception {
 
@@ -225,6 +243,15 @@ public class UserAccountSynchronizerTest {
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			() -> _userAccountSynchronizer.syncUserAccountRoles(
 				_createUserAccount()));
+	}
+
+	@Test
+	public void testSyncUserAccountUpsertsProjectReferences() throws Exception {
+		_whenProjectMembership();
+
+		_userAccountSynchronizer.syncUserAccount(_createUserAccount());
+
+		_verifyFetchesAccountAndProjectReferences();
 	}
 
 	private void _assertUpsertsAttribute(
@@ -246,18 +273,63 @@ public class UserAccountSynchronizerTest {
 		);
 	}
 
+	private AccountBrief _createAccountBrief() {
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setExternalReferenceCode(_ACCOUNT_EXTERNAL_REFERENCE_CODE);
+		accountBrief.setId(1L);
+
+		return accountBrief;
+	}
+
 	private UserAccount _createUserAccount() {
 		UserAccount userAccount = new UserAccount();
 
+		userAccount.setAccountBriefs(
+			new AccountBrief[] {_createAccountBrief()});
 		userAccount.setExternalReferenceCode(_EXTERNAL_REFERENCE_CODE);
 		userAccount.setId(1L);
 
 		return userAccount;
 	}
 
+	private void _verifyFetchesAccountAndProjectReferences() {
+		Mockito.verify(
+			_jiraAssetService
+		).fetchReferenceObjectIds(
+			Mockito.eq(_accountConverter),
+			Mockito.eq(
+				Arrays.asList(
+					_ACCOUNT_EXTERNAL_REFERENCE_CODE,
+					_PROJECT_EXTERNAL_REFERENCE_CODE)),
+			Mockito.any()
+		);
+	}
+
+	private void _whenProjectMembership() throws Exception {
+		Mockito.when(
+			_projectMembershipService.getProjectMembershipsByUserId(1L)
+		).thenReturn(
+			Collections.singletonList(
+				new ProjectMembership(
+					new JSONObject(
+					).put(
+						"r_projectToProjectMembership_c_projectERC",
+						_PROJECT_EXTERNAL_REFERENCE_CODE
+					)))
+		);
+	}
+
+	private static final String _ACCOUNT_EXTERNAL_REFERENCE_CODE =
+		"test-account-external-reference-code";
+
 	private static final String _EXTERNAL_REFERENCE_CODE =
 		"test-external-reference-code";
 
+	private static final String _PROJECT_EXTERNAL_REFERENCE_CODE =
+		"test-project-external-reference-code";
+
+	private AccountConverter _accountConverter;
 	private AccountUserAccountRoleSynchronizer
 		_accountUserAccountRoleSynchronizer;
 	private ContactConverter _contactConverter;
@@ -265,6 +337,7 @@ public class UserAccountSynchronizerTest {
 	private JiraAssetService _jiraAssetService;
 	private OrganizationUserAccountRoleSynchronizer
 		_organizationUserAccountRoleSynchronizer;
+	private ProjectMembershipService _projectMembershipService;
 	private UserAccountSynchronizer _userAccountSynchronizer;
 
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/UserAccountSynchronizerTest.java
@@ -17,8 +17,10 @@ import com.liferay.one.jira.converter.TeamConverter;
 import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProjectMembershipService;
 import com.liferay.one.service.PropertyService;
 import com.liferay.one.util.KeyedLock;
+import com.liferay.petra.function.UnsafeRunnable;
 
 import java.util.Collections;
 
@@ -93,6 +95,9 @@ public class UserAccountSynchronizerTest {
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_phoneConverter",
 			Mockito.mock(PhoneConverter.class));
+		ReflectionTestUtils.setField(
+			_userAccountSynchronizer, "_projectMembershipService",
+			Mockito.mock(ProjectMembershipService.class));
 		ReflectionTestUtils.setField(
 			_userAccountSynchronizer, "_propertyService", propertyService);
 		ReflectionTestUtils.setField(
@@ -193,7 +198,9 @@ public class UserAccountSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncUserAccountAccountsUpsertsAccountReferences() {
+	public void testSyncUserAccountAccountsUpsertsAccountReferences()
+		throws Exception {
+
 		_assertUpsertsAttribute(
 			ContactConstants.ATTRIBUTE_NAME_ACCOUNT,
 			() -> _userAccountSynchronizer.syncUserAccountAccounts(
@@ -201,7 +208,9 @@ public class UserAccountSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncUserAccountOrganizationsUpsertsOrganizationReferences() {
+	public void testSyncUserAccountOrganizationsUpsertsOrganizationReferences()
+		throws Exception {
+
 		_assertUpsertsAttribute(
 			ContactConstants.ATTRIBUTE_NAME_TEAMS,
 			() -> _userAccountSynchronizer.syncUserAccountOrganizations(
@@ -209,7 +218,9 @@ public class UserAccountSynchronizerTest {
 	}
 
 	@Test
-	public void testSyncUserAccountRolesUpsertsRoleReferences() {
+	public void testSyncUserAccountRolesUpsertsRoleReferences()
+		throws Exception {
+
 		_assertUpsertsAttribute(
 			ContactConstants.ATTRIBUTE_NAME_CONTACT_ROLES,
 			() -> _userAccountSynchronizer.syncUserAccountRoles(
@@ -217,9 +228,10 @@ public class UserAccountSynchronizerTest {
 	}
 
 	private void _assertUpsertsAttribute(
-		String attributeName, Runnable runnable) {
+			String attributeName, UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
 
-		runnable.run();
+		unsafeRunnable.run();
 
 		Mockito.verify(
 			_jiraAssetObject


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-102069](https://liferay.atlassian.net/browse/LPD-102069)

## What is being fixed

- A Contact's `Account` attribute listed only direct account memberships, not the user's projects.
- Project membership changes never reached JSM — stale project/account contact lists, unsynced contact roles.

## How it is being fixed

- **`UserAccountSyncModel`** — new per-call model holding everything a contact sync needs, memoized. Replaces the ad-hoc private helpers so all four sync entry points share one view.
- **Account attribute = accounts ∪ projects**, resolved through the account converter. Correct because projects are already stored in JSM as Account-type assets keyed by their own ERC.
- **`add`/`deleteProjectMembership` now return whether anything changed** — a no-op request does no JSM work. On a real change: project asset, parent account asset, member contact, and contact role assignment all sync.
- **`AccountSynchronizer.syncProjectUserAccounts`** — the project-asset half of the above.
- **Batched `UserAccountService.getUserAccounts`** replaces a call per member in `ProjectSyncModel`.

## Follow-ups

- [LPD-102860](https://liferay.atlassian.net/browse/LPD-102860) — contact sync aborts wholesale if one attribute's source fails
- [LPD-102868](https://liferay.atlassian.net/browse/LPD-102868) — project-scoped entitlements not synced


[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-102069]: https://liferay.atlassian.net/browse/LPD-102069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-102860]: https://liferay.atlassian.net/browse/LPD-102860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ