### PR TITLE
LPD-99435 Add tests for the Pub/Sub subscribers and provisioning

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/okta/pubsub/OktaAppCreatedPubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/okta/pubsub/OktaAppCreatedPubsubSubscriberTest.java
@@ -1,0 +1,175 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.okta.pubsub;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.jira.exception.AccountNotFoundException;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.PropertyService;
+
+import java.util.Collections;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class OktaAppCreatedPubsubSubscriberTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_subscriber = new OktaAppCreatedPubsubSubscriber();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_propertyService = Mockito.mock(PropertyService.class);
+
+		Account account = new Account();
+
+		account.setId(_ACCOUNT_ID);
+
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(_ACCOUNT_KEY)
+		).thenReturn(
+			account
+		);
+
+		ReflectionTestUtils.setField(
+			_subscriber, "_accountService", _accountService);
+		ReflectionTestUtils.setField(_subscriber, "_projectId", "test-project");
+		ReflectionTestUtils.setField(
+			_subscriber, "_propertyService", _propertyService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_subscription", "test-subscription");
+		ReflectionTestUtils.setField(_subscriber, "_topic", "test-topic");
+	}
+
+	@Test
+	public void testIsAutoCreateTopicReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isAutoCreateTopic());
+	}
+
+	@Test
+	public void testReceiveAddsOktaApplicationProperty() throws Exception {
+		_receiveMessage(_ACCOUNT_KEY, _APP_ID);
+
+		Mockito.verify(
+			_propertyService
+		).addProperty(
+			_ACCOUNT_ID, PropertyConstants.NAME_OKTA_APPLICATION, _APP_ID
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsWhenPropertyAlreadyExists() throws Exception {
+		Mockito.when(
+			_propertyService.getPropertyValue(
+				_ACCOUNT_ID, PropertyConstants.NAME_OKTA_APPLICATION)
+		).thenReturn(
+			"existing-app-id"
+		);
+
+		_receiveMessage(_ACCOUNT_KEY, _APP_ID);
+
+		Mockito.verify(
+			_propertyService, Mockito.never()
+		).addProperty(
+			Mockito.anyLong(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveThrowsOnMalformedPayload() {
+		Message message = new Message(
+			Collections.emptyMap(), "not json", "test-topic");
+
+		Assertions.assertThrows(
+			JSONException.class, () -> _subscriber.receive(message));
+	}
+
+	@Test
+	public void testReceiveThrowsWhenAccountKeyIsMissing() {
+		Assertions.assertThrows(
+			IllegalArgumentException.class, () -> _receiveMessage("", _APP_ID));
+	}
+
+	@Test
+	public void testReceiveThrowsWhenAccountNotFound() throws Exception {
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(
+				"unknown-account-key")
+		).thenReturn(
+			null
+		);
+
+		Assertions.assertThrows(
+			AccountNotFoundException.class,
+			() -> _receiveMessage("unknown-account-key", _APP_ID));
+	}
+
+	@Test
+	public void testReceiveThrowsWhenAppIdIsMissing() {
+		Assertions.assertThrows(
+			IllegalArgumentException.class,
+			() -> _receiveMessage(_ACCOUNT_KEY, ""));
+	}
+
+	@Test
+	public void testReceiveThrowsWhenPayloadHasNoAccountKeyOrAppId()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(), "{}", "test-topic");
+
+		Assertions.assertThrows(
+			IllegalArgumentException.class, () -> _subscriber.receive(message));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).fetchAccountByExternalReferenceCode(
+			Mockito.any()
+		);
+
+		Mockito.verifyNoInteractions(_propertyService);
+	}
+
+	private void _receiveMessage(String accountKey, String appId)
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"accountKey", accountKey
+			).put(
+				"appId", appId
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final String _ACCOUNT_KEY = "ACCOUNT-1";
+
+	private static final String _APP_ID = "APP-1";
+
+	private AccountService _accountService;
+	private PropertyService _propertyService;
+	private OktaAppCreatedPubsubSubscriber _subscriber;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/okta/pubsub/OktaUsersPubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/okta/pubsub/OktaUsersPubsubSubscriberTest.java
@@ -1,0 +1,648 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.okta.pubsub;
+
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.ProvisioningAssignmentService;
+import com.liferay.one.service.ProvisioningEmailService;
+import com.liferay.one.service.UserAccountService;
+
+import java.util.Collections;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class OktaUsersPubsubSubscriberTest {
+
+	@BeforeEach
+	public void setUp() {
+		_subscriber = new OktaUsersPubsubSubscriber();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_provisioningAssignmentService = Mockito.mock(
+			ProvisioningAssignmentService.class);
+		_provisioningEmailService = Mockito.mock(
+			ProvisioningEmailService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
+
+		ReflectionTestUtils.setField(
+			_subscriber, "_accountService", _accountService);
+		ReflectionTestUtils.setField(_subscriber, "_projectId", "test-project");
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningAssignmentService",
+			_provisioningAssignmentService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningEmailService",
+			_provisioningEmailService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_subscription", "test-subscription");
+		ReflectionTestUtils.setField(_subscriber, "_topic", "test-topic");
+		ReflectionTestUtils.setField(
+			_subscriber, "_userAccountService", _userAccountService);
+	}
+
+	@Test
+	public void testIsAutoCreateTopicReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isAutoCreateTopic());
+	}
+
+	@Test
+	public void testReceiveDoesNotSendSecondWelcomeEmailWhenAlreadyVerified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, true);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.account.update_profile", "ACTIVE");
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	@Test
+	public void testReceiveDoesNotSendWelcomeEmailWhenOktaStatusIsNotVerified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.account.update_profile", "PROVISIONED");
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	@Test
+	public void testReceiveDoesNotSetVerifiedWhenAlreadyVerified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, true);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(_EMAIL_ADDRESS, "user.lifecycle.activate", "ACTIVE");
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveDoesNotSetVerifiedWhenOktaStatusIsNotVerified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.lifecycle.activate", "PROVISIONED");
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveIgnoresAbsentEventType() throws Exception {
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"user", _createUserJSONObject(_EMAIL_ADDRESS, "ACTIVE")
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verifyNoInteractions(
+			_accountService, _provisioningAssignmentService,
+			_provisioningEmailService, _userAccountService);
+	}
+
+	@Test
+	public void testReceiveIgnoresUnknownEventType() throws Exception {
+		_receiveMessage(_EMAIL_ADDRESS, "user.unknown.event", "ACTIVE");
+
+		Mockito.verifyNoInteractions(
+			_accountService, _provisioningAssignmentService,
+			_provisioningEmailService, _userAccountService);
+	}
+
+	@Test
+	public void testReceiveRemovesAccountUserAccountBeforeUnassigningMembership()
+		throws Exception {
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setId(_FIRST_ACCOUNT_ID);
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, true, accountBrief);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.lifecycle.deactivate", "DEPROVISIONED");
+
+		InOrder inOrder = Mockito.inOrder(
+			_accountService, _provisioningAssignmentService);
+
+		inOrder.verify(
+			_accountService
+		).removeAccountUserAccount(
+			_FIRST_ACCOUNT_ID, _USER_ID
+		);
+
+		inOrder.verify(
+			_provisioningAssignmentService
+		).unassignAccountMembership(
+			_FIRST_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testReceiveRethrowsOnMalformedPayload() {
+		Message message = new Message(
+			Collections.emptyMap(), "not json", "test-topic");
+
+		Assertions.assertThrows(
+			Exception.class, () -> _subscriber.receive(message));
+	}
+
+	@Test
+	public void testReceiveReturnsQuietlyWhenAccountBriefsAreNull()
+		throws Exception {
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		userAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveMessage(
+				_EMAIL_ADDRESS, "user.lifecycle.deactivate", "DEPROVISIONED"));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).removeAccountUserAccount(
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService, Mockito.never()
+		).unassignAccountMembership(
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveSetsVerifiedOnActivateWhenUnverified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(_EMAIL_ADDRESS, "user.lifecycle.activate", "ACTIVE");
+
+		Mockito.verify(
+			_userAccountService
+		).setVerified(
+			_USER_ID
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	@Test
+	public void testReceiveSetsVerifiedOnCreateWhenUnverified()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(_EMAIL_ADDRESS, "user.lifecycle.create", "ACTIVE");
+
+		Mockito.verify(
+			_userAccountService
+		).setVerified(
+			_USER_ID
+		);
+	}
+
+	@Test
+	public void testReceiveSetsVerifiedThenSendsVerifiedWelcomeEmail()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.account.update_profile", "ACTIVE");
+
+		InOrder inOrder = Mockito.inOrder(
+			_provisioningEmailService, _userAccountService);
+
+		inOrder.verify(
+			_userAccountService
+		).setVerified(
+			_USER_ID
+		);
+
+		inOrder.verify(
+			_provisioningEmailService
+		).sendVerifiedWelcomeEmail(
+			userAccount
+		);
+	}
+
+	@Test
+	public void testReceiveSetsVerifiedThenSendsVerifiedWelcomeEmailOnPasswordUpdate()
+		throws Exception {
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, false);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.account.update_password", "ACTIVE");
+
+		InOrder inOrder = Mockito.inOrder(
+			_provisioningEmailService, _userAccountService);
+
+		inOrder.verify(
+			_userAccountService
+		).setVerified(
+			_USER_ID
+		);
+
+		inOrder.verify(
+			_provisioningEmailService
+		).sendVerifiedWelcomeEmail(
+			userAccount
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsDeactivateWhenNoPortalUserExists()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			null
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveMessage(
+				_EMAIL_ADDRESS, "user.lifecycle.deactivate", "DEPROVISIONED"));
+
+		Mockito.verifyNoInteractions(
+			_accountService, _provisioningAssignmentService);
+	}
+
+	@Test
+	public void testReceiveSkipsSyncContactWhenNoPortalUserExists()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			null
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveMessage(
+				_EMAIL_ADDRESS, "user.lifecycle.activate", "ACTIVE"));
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+
+		Mockito.verifyNoInteractions(
+			_accountService, _provisioningAssignmentService,
+			_provisioningEmailService);
+	}
+
+	@Test
+	public void testReceiveSkipsUpdateContactWhenNoPortalUserExists()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			null
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.account.update_profile", "ACTIVE");
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).setVerified(
+			Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsWhenEmailAddressIsAbsent() throws Exception {
+		_receiveMessage("", "user.lifecycle.activate", "ACTIVE");
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).fetchUserAccountByEmailAddress(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsWhenUserKeyIsAbsent() throws Exception {
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"eventType", "user.lifecycle.activate"
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verifyNoInteractions(
+			_accountService, _provisioningAssignmentService,
+			_provisioningEmailService);
+
+		Mockito.verify(
+			_userAccountService, Mockito.never()
+		).fetchUserAccountByEmailAddress(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveStopsProcessingRemainingMembershipsAfterFailure()
+		throws Exception {
+
+		AccountBrief firstAccountBrief = new AccountBrief();
+
+		firstAccountBrief.setId(_FIRST_ACCOUNT_ID);
+
+		AccountBrief secondAccountBrief = new AccountBrief();
+
+		secondAccountBrief.setId(_SECOND_ACCOUNT_ID);
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, true, firstAccountBrief,
+			secondAccountBrief);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to remove account user account")
+		).when(
+			_accountService
+		).removeAccountUserAccount(
+			_FIRST_ACCOUNT_ID, _USER_ID
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"eventType", "user.lifecycle.deactivate"
+			).put(
+				"user", _createUserJSONObject(_EMAIL_ADDRESS, "DEPROVISIONED")
+			).toString(),
+			"test-topic");
+
+		Assertions.assertThrows(
+			RuntimeException.class, () -> _subscriber.receive(message));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).removeAccountUserAccount(
+			_SECOND_ACCOUNT_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService, Mockito.never()
+		).unassignAccountMembership(
+			_SECOND_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testReceiveUnassignsAllMembershipsOnDeactivate()
+		throws Exception {
+
+		AccountBrief firstAccountBrief = new AccountBrief();
+
+		firstAccountBrief.setId(_FIRST_ACCOUNT_ID);
+
+		AccountBrief secondAccountBrief = new AccountBrief();
+
+		secondAccountBrief.setId(_SECOND_ACCOUNT_ID);
+
+		UserAccount userAccount = _createUserAccount(
+			_EMAIL_ADDRESS, _USER_ID, true, firstAccountBrief,
+			secondAccountBrief);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			userAccount
+		);
+
+		_receiveMessage(
+			_EMAIL_ADDRESS, "user.lifecycle.deactivate", "DEPROVISIONED");
+
+		Mockito.verify(
+			_accountService
+		).removeAccountUserAccount(
+			_FIRST_ACCOUNT_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_accountService
+		).removeAccountUserAccount(
+			_SECOND_ACCOUNT_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).unassignAccountMembership(
+			_FIRST_ACCOUNT_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).unassignAccountMembership(
+			_SECOND_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	private UserAccount _createUserAccount(
+		String emailAddress, long id, boolean verified,
+		AccountBrief... accountBriefs) {
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setAccountBriefs(accountBriefs);
+		userAccount.setEmailAddress(emailAddress);
+		userAccount.setId(id);
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(verified);
+
+		CustomField customField = new CustomField();
+
+		customField.setCustomValue(customValue);
+		customField.setName("verified");
+
+		userAccount.setCustomFields(new CustomField[] {customField});
+
+		return userAccount;
+	}
+
+	private JSONObject _createUserJSONObject(String email, String status) {
+		return new JSONObject(
+		).put(
+			"profile",
+			new JSONObject(
+			).put(
+				"email", email
+			)
+		).put(
+			"status", status
+		);
+	}
+
+	private void _receiveMessage(String email, String eventType, String status)
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"eventType", eventType
+			).put(
+				"user", _createUserJSONObject(email, status)
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+	}
+
+	private static final String _EMAIL_ADDRESS = "contact@example.com";
+
+	private static final long _FIRST_ACCOUNT_ID = 10L;
+
+	private static final long _SECOND_ACCOUNT_ID = 20L;
+
+	private static final long _USER_ID = 100L;
+
+	private AccountService _accountService;
+	private ProvisioningAssignmentService _provisioningAssignmentService;
+	private ProvisioningEmailService _provisioningEmailService;
+	private OktaUsersPubsubSubscriber _subscriber;
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/MessageTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/MessageTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.pubsub;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Felipe Franca
+ */
+public class MessageTest {
+
+	@Test
+	public void testGetAttributesReturnsEmptyMapWhenAttributesAreNull() {
+		Message message = new Message(null, "payload", "test-topic");
+
+		Map<String, String> attributes = message.getAttributes();
+
+		Assertions.assertTrue(attributes.isEmpty());
+	}
+
+	@Test
+	public void testGetAttributesReturnsUnmodifiableMap() {
+		Message message = new Message(
+			Map.of("key", "value"), "payload", "test-topic");
+
+		Map<String, String> attributes = message.getAttributes();
+
+		Assertions.assertThrows(
+			UnsupportedOperationException.class,
+			() -> attributes.put("key", "other value"));
+	}
+
+	@Test
+	public void testGetReturnsNullWhenAttributesAreNull() {
+		Message message = new Message(null, "payload", "test-topic");
+
+		Assertions.assertNull(message.get("key"));
+	}
+
+	@Test
+	public void testPutCreatesAttributesWhenAbsent() {
+		Message message = new Message(null, "payload", "test-topic");
+
+		message.put("key", "value");
+
+		Assertions.assertEquals("value", message.get("key"));
+	}
+
+	@Test
+	public void testSetAttributesCopiesSourceMap() {
+		Map<String, String> attributes = HashMapBuilder.put(
+			"key", "value"
+		).build();
+
+		Message message = new Message(attributes, "payload", "test-topic");
+
+		attributes.put("key", "mutated value");
+		attributes.put("otherKey", "other value");
+
+		Assertions.assertEquals("value", message.get("key"));
+		Assertions.assertNull(message.get("otherKey"));
+	}
+
+	@Test
+	public void testSetAttributesToNullClearsAttributes() {
+		Message message = new Message(
+			Map.of("key", "value"), "payload", "test-topic");
+
+		message.setAttributes(null);
+
+		Assertions.assertNull(message.get("key"));
+
+		Map<String, String> attributes = message.getAttributes();
+
+		Assertions.assertTrue(attributes.isEmpty());
+	}
+
+	@Test
+	public void testToStringIncludesTopicAttributesAndPayload() {
+		Message message = new Message(
+			Map.of("key", "value"), "payload", "test-topic");
+
+		Assertions.assertEquals(
+			"{topic=test-topic, attributes={key=value}, payload=payload}",
+			message.toString());
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/subscriber/BasePubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/subscriber/BasePubsubSubscriberTest.java
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.pubsub.subscriber;
+
+import com.liferay.one.pubsub.Message;
+import com.liferay.petra.string.StringPool;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class BasePubsubSubscriberTest {
+
+	@Test
+	public void testInitializeDoesNotStartSubscriberWhenProjectIdIsBlank() {
+		TestPubsubSubscriber testPubsubSubscriber = new TestPubsubSubscriber();
+
+		Assertions.assertDoesNotThrow(testPubsubSubscriber::initialize);
+
+		Assertions.assertNull(
+			ReflectionTestUtils.getField(testPubsubSubscriber, "_subscriber"));
+	}
+
+	@Test
+	public void testStopDoesNothingWhenSubscriberWasNeverStarted() {
+		TestPubsubSubscriber testPubsubSubscriber = new TestPubsubSubscriber();
+
+		Assertions.assertDoesNotThrow(testPubsubSubscriber::stop);
+	}
+
+	private static class TestPubsubSubscriber extends BasePubsubSubscriber {
+
+		@Override
+		public void receive(Message message) {
+		}
+
+		@Override
+		protected String getProjectId() {
+			return StringPool.BLANK;
+		}
+
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/subscriber/DeadLetterPubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/pubsub/subscriber/DeadLetterPubsubSubscriberTest.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.pubsub.subscriber;
+
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.service.NotificationQueueEntryService;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class DeadLetterPubsubSubscriberTest {
+
+	@BeforeEach
+	public void setUp() {
+		_subscriber = new DeadLetterPubsubSubscriber();
+
+		_notificationQueueEntryService = Mockito.mock(
+			NotificationQueueEntryService.class);
+
+		ReflectionTestUtils.setField(
+			_subscriber, "_emailAddressGlobal", _EMAIL_ADDRESS_GLOBAL);
+		ReflectionTestUtils.setField(
+			_subscriber, "_notificationQueueEntryService",
+			_notificationQueueEntryService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_notificationRecipient", _NOTIFICATION_RECIPIENT);
+		ReflectionTestUtils.setField(_subscriber, "_projectId", "test-project");
+		ReflectionTestUtils.setField(
+			_subscriber, "_subscription", "test-subscription");
+	}
+
+	@Test
+	public void testAttributeNameConstantsMatchGCPDeadLetterAttributes() {
+		Assertions.assertEquals(
+			"CloudPubSubDeadLetterSourceDeliveryCount",
+			BaseDeadLetterPubsubSubscriber.
+				SOURCE_DELIVERY_COUNT_ATTRIBUTE_NAME);
+		Assertions.assertEquals(
+			"CloudPubSubDeadLetterSourceSubscription",
+			BaseDeadLetterPubsubSubscriber.SOURCE_SUBSCRIPTION_ATTRIBUTE_NAME);
+	}
+
+	@Test
+	public void testGetTopicReturnsDeadLetterTopic() {
+		Assertions.assertEquals(
+			"one-liferay-dead-letter", _subscriber.getTopic());
+	}
+
+	@Test
+	public void testIsAutoCreateTopicReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isAutoCreateTopic());
+	}
+
+	@Test
+	public void testIsDeadLetterTopicEnabledReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isDeadLetterTopicEnabled());
+	}
+
+	@Test
+	public void testOnDeadLetterDefaultsToZeroAttemptsWhenAttributesAbsent()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(), "{\"a\":\"value\"}", "test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		ArgumentCaptor<String> bodyArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			bodyArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			bodyArgumentCaptor.getValue(
+			).contains(
+				"0 delivery attempts"
+			));
+	}
+
+	@Test
+	public void testOnDeadLetterDefaultsToZeroAttemptsWhenDeliveryCountIsNotNumeric()
+		throws Exception {
+
+		Assertions.assertDoesNotThrow(
+			() -> _subscriber.receive(
+				_createMessage("not a number", _SOURCE_SUBSCRIPTION)));
+
+		ArgumentCaptor<String> bodyArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			bodyArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			bodyArgumentCaptor.getValue(
+			).contains(
+				"0 delivery attempts"
+			));
+	}
+
+	@Test
+	public void testOnDeadLetterDropsMessageWhenRecipientBlank()
+		throws Exception {
+
+		ReflectionTestUtils.setField(_subscriber, "_notificationRecipient", "");
+
+		Assertions.assertDoesNotThrow(
+			() -> _subscriber.receive(
+				_createMessage("3", _SOURCE_SUBSCRIPTION)));
+
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	@Test
+	public void testOnDeadLetterEscapesPayloadInNotificationBody()
+		throws Exception {
+
+		Message message = new Message(
+			Map.of(
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_DELIVERY_COUNT_ATTRIBUTE_NAME,
+				"3",
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_SUBSCRIPTION_ATTRIBUTE_NAME,
+				_SOURCE_SUBSCRIPTION),
+			"{\"a\":\"<script>alert(1)</script>\"}", "test-topic");
+
+		_subscriber.receive(message);
+
+		ArgumentCaptor<String> bodyArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			bodyArgumentCaptor.capture()
+		);
+
+		String body = bodyArgumentCaptor.getValue();
+
+		Assertions.assertFalse(body.contains("<script>"));
+		Assertions.assertTrue(body.contains("&lt;script&gt;"));
+	}
+
+	@Test
+	public void testOnDeadLetterIncludesEscapedAttributesInNotificationBody()
+		throws Exception {
+
+		Message message = new Message(
+			Map.of(
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_DELIVERY_COUNT_ATTRIBUTE_NAME,
+				"3",
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_SUBSCRIPTION_ATTRIBUTE_NAME,
+				_SOURCE_SUBSCRIPTION, "customAttribute", "<bold>"),
+			"{\"a\":\"value\"}", "test-topic");
+
+		_subscriber.receive(message);
+
+		ArgumentCaptor<String> bodyArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			bodyArgumentCaptor.capture()
+		);
+
+		String body = bodyArgumentCaptor.getValue();
+
+		Assertions.assertTrue(body.contains("customAttribute=&lt;bold&gt;"));
+		Assertions.assertFalse(body.contains("<bold>"));
+	}
+
+	@Test
+	public void testOnDeadLetterSendsNotificationEmailWithAttemptCountAndSourceSubscription()
+		throws Exception {
+
+		_subscriber.receive(_createMessage("3", _SOURCE_SUBSCRIPTION));
+
+		ArgumentCaptor<String> bodyArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.eq(_EMAIL_ADDRESS_GLOBAL), Mockito.eq("Liferay One"),
+			Mockito.eq(_NOTIFICATION_RECIPIENT),
+			Mockito.eq("Liferay One Dead Letter Notification"),
+			bodyArgumentCaptor.capture()
+		);
+
+		String body = bodyArgumentCaptor.getValue();
+
+		Assertions.assertTrue(body.contains("3 delivery attempts"));
+		Assertions.assertTrue(body.contains(_SOURCE_SUBSCRIPTION));
+	}
+
+	@Test
+	public void testOnDeadLetterSwallowsNotificationFailure() throws Exception {
+		Mockito.doThrow(
+			new RuntimeException("Unable to add notification queue entry")
+		).when(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _subscriber.receive(
+				_createMessage("3", _SOURCE_SUBSCRIPTION)));
+	}
+
+	private Message _createMessage(
+		String deliveryCount, String sourceSubscription) {
+
+		return new Message(
+			Map.of(
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_DELIVERY_COUNT_ATTRIBUTE_NAME,
+				deliveryCount,
+				BaseDeadLetterPubsubSubscriber.
+					SOURCE_SUBSCRIPTION_ATTRIBUTE_NAME,
+				sourceSubscription),
+			"{\"a\":\"value\"}", "test-topic");
+	}
+
+	private static final String _EMAIL_ADDRESS_GLOBAL = "global@example.com";
+
+	private static final String _NOTIFICATION_RECIPIENT = "oncall@example.com";
+
+	private static final String _SOURCE_SUBSCRIPTION =
+		"projects/test-project/subscriptions/source-subscription";
+
+	private NotificationQueueEntryService _notificationQueueEntryService;
+	private DeadLetterPubsubSubscriber _subscriber;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/model/SalesforceModelTestUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/model/SalesforceModelTestUtil.java
@@ -1,0 +1,227 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.model;
+
+import com.liferay.headless.commerce.admin.order.client.custom.field.CustomField;
+import com.liferay.headless.commerce.admin.order.client.custom.field.CustomValue;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * @author Felipe Franca
+ */
+public class SalesforceModelTestUtil {
+
+	public static JSONObject createAccountJSONObject(
+		boolean activeSubscription, String billingCountry, String id,
+		String name) {
+
+		return new JSONObject(
+		).put(
+			"Active_Subscription__c", activeSubscription
+		).put(
+			"BillingCountry", billingCountry
+		).put(
+			"Id", id
+		).put(
+			"Name", name
+		);
+	}
+
+	public static JSONObject createAccountJSONObject(String id, String name) {
+		return createAccountJSONObject(true, "", id, name);
+	}
+
+	public static JSONObject createAccountJSONObject(
+		String billingCountry, String id, String name) {
+
+		return createAccountJSONObject(true, billingCountry, id, name);
+	}
+
+	public static JSONObject createObjectMessagePayload(
+		String action, String salesforceObjectName,
+		JSONObject... recordJSONObjects) {
+
+		JSONArray recordsJSONArray = new JSONArray();
+
+		for (JSONObject recordJSONObject : recordJSONObjects) {
+			recordsJSONArray.put(recordJSONObject);
+		}
+
+		return new JSONObject(
+		).put(
+			"action", action
+		).put(
+			"records", recordsJSONArray
+		).put(
+			"salesforceObjectName", salesforceObjectName
+		);
+	}
+
+	public static JSONObject createOpportunityJSONObject(
+		String accountId, String amendedContractOpportunityId,
+		boolean hasRenewal, String id, String ownerEmail, String productFamily,
+		String projectId, String soldBy, String stageName, String type) {
+
+		return new JSONObject(
+		).put(
+			"AccountId", accountId
+		).put(
+			"Has_Renewal__c", hasRenewal ? 1 : 0
+		).put(
+			"Id", id
+		).put(
+			"Owner.Email", ownerEmail
+		).put(
+			"Product_Family__c", productFamily
+		).put(
+			"Project__c", projectId
+		).put(
+			"SBQQ__AmendedContract__r.SBQQ__Opportunity__c",
+			amendedContractOpportunityId
+		).put(
+			"Sold_By__c", soldBy
+		).put(
+			"StageName", stageName
+		).put(
+			"Type", type
+		);
+	}
+
+	public static JSONObject createOpportunityLineItemJSONObject(
+		String currencyIsoCode, String endDate, String id, String product2Id,
+		String productName, String productType, double quantity,
+		String serviceDate) {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"CurrencyIsoCode", currencyIsoCode
+		).put(
+			"Id", id
+		).put(
+			"Product_Type__c", productType
+		).put(
+			"Product2.Name", productName
+		).put(
+			"Product2Id", product2Id
+		).put(
+			"Quantity", quantity
+		);
+
+		if (endDate != null) {
+			jsonObject.put("End_Date__c", endDate);
+		}
+
+		if (serviceDate != null) {
+			jsonObject.put("ServiceDate", serviceDate);
+		}
+
+		return jsonObject;
+	}
+
+	public static JSONObject createOpportunityMessagePayload(
+		JSONObject... recordJSONObjects) {
+
+		JSONArray recordsJSONArray = new JSONArray();
+
+		for (JSONObject recordJSONObject : recordJSONObjects) {
+			recordsJSONArray.put(recordJSONObject);
+		}
+
+		return new JSONObject(
+		).put(
+			"records", recordsJSONArray
+		);
+	}
+
+	public static JSONObject createOpportunityRecordJSONObject(
+		JSONObject accountJSONObject, JSONObject opportunityJSONObject,
+		JSONArray opportunityLineItemsJSONArray,
+		JSONArray projectContactRolesJSONArray, JSONObject projectJSONObject) {
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"account", accountJSONObject
+		).put(
+			"opportunity", opportunityJSONObject
+		).put(
+			"opportunityLineItems", opportunityLineItemsJSONArray
+		).put(
+			"projectContactRoles", projectContactRolesJSONArray
+		);
+
+		if (projectJSONObject != null) {
+			jsonObject.put("project", projectJSONObject);
+		}
+
+		return jsonObject;
+	}
+
+	public static OrderItem createOrderItem(
+		String customStatus, String effectiveEndDate, String endDate,
+		String externalReferenceCode, Long id, String skuExternalReferenceCode,
+		String startDate) {
+
+		List<CustomField> customFields = new ArrayList<>();
+
+		_addCustomField(customFields, "customStatus", customStatus);
+		_addCustomField(customFields, "effectiveEndDate", effectiveEndDate);
+		_addCustomField(customFields, "endDate", endDate);
+		_addCustomField(customFields, "startDate", startDate);
+
+		OrderItem orderItem = new OrderItem();
+
+		orderItem.setCustomFields(customFields.toArray(new CustomField[0]));
+		orderItem.setExternalReferenceCode(externalReferenceCode);
+		orderItem.setId(id);
+		orderItem.setSkuExternalReferenceCode(skuExternalReferenceCode);
+
+		return orderItem;
+	}
+
+	public static JSONObject createProjectContactRoleJSONObject(
+		String contactRole, String emailAddress, String firstName,
+		String lastName, String projectId) {
+
+		return new JSONObject(
+		).put(
+			"Contact__r.Email", emailAddress
+		).put(
+			"Contact__r.FirstName", firstName
+		).put(
+			"Contact__r.LastName", lastName
+		).put(
+			"Contact_Role__c", contactRole
+		).put(
+			"Project__c", projectId
+		);
+	}
+
+	private static void _addCustomField(
+		List<CustomField> customFields, String name, String value) {
+
+		if (value == null) {
+			return;
+		}
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(value);
+
+		CustomField customField = new CustomField();
+
+		customField.setCustomValue(customValue);
+		customField.setName(name);
+
+		customFields.add(customField);
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/pubsub/SalesforceObjectPubsubSubscriberTest.java
@@ -1,0 +1,613 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.pubsub;
+
+import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Sku;
+import com.liferay.headless.commerce.admin.pricing.client.dto.v2_0.PriceList;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.salesforce.model.SalesforceAccount;
+import com.liferay.one.salesforce.model.SalesforceContract;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceProject;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommercePriceEntryService;
+import com.liferay.one.service.CommercePriceListService;
+import com.liferay.one.service.CommerceProductService;
+import com.liferay.one.service.CommerceSkuService;
+import com.liferay.one.service.ContractService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Collections;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class SalesforceObjectPubsubSubscriberTest {
+
+	@BeforeEach
+	public void setUp() {
+		_subscriber = new SalesforceObjectPubsubSubscriber();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_commercePriceEntryService = Mockito.mock(
+			CommercePriceEntryService.class);
+		_commercePriceListService = Mockito.mock(
+			CommercePriceListService.class);
+		_commerceProductService = Mockito.mock(CommerceProductService.class);
+		_commerceSkuService = Mockito.mock(CommerceSkuService.class);
+		_contractService = Mockito.mock(ContractService.class);
+		_projectService = Mockito.mock(ProjectService.class);
+
+		ReflectionTestUtils.setField(
+			_subscriber, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commercePriceEntryService",
+			_commercePriceEntryService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commercePriceListService",
+			_commercePriceListService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commerceProductService", _commerceProductService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commerceSkuService", _commerceSkuService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_contractService", _contractService);
+		ReflectionTestUtils.setField(_subscriber, "_projectId", "test-project");
+		ReflectionTestUtils.setField(
+			_subscriber, "_projectService", _projectService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_subscription", "test-subscription");
+		ReflectionTestUtils.setField(_subscriber, "_topic", "test-topic");
+	}
+
+	@Test
+	public void testIsAutoCreateTopicReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isAutoCreateTopic());
+	}
+
+	@Test
+	public void testReceiveDeactivatesProduct2OnDelete() throws Exception {
+		_receiveMessage(
+			"delete", "Product2", _createProduct2JSONObject("Widget"));
+
+		Mockito.verify(
+			_commerceProductService
+		).deactivateProduct(
+			_PRODUCT_2_ID
+		);
+
+		Mockito.verify(
+			_commerceProductService, Mockito.never()
+		).addOrUpdateProduct(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveDeletesPricebookEntryOnDelete() throws Exception {
+		_receiveMessage(
+			"delete", "PricebookEntry",
+			_createPricebookEntryJSONObject("USD", 100.0));
+
+		Mockito.verify(
+			_commercePriceEntryService
+		).deletePriceEntry(
+			_PRICEBOOK_ENTRY_ID
+		);
+
+		Mockito.verify(
+			_commerceSkuService, Mockito.never()
+		).fetchSku(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_commercePriceEntryService, Mockito.never()
+		).addOrUpdatePriceEntry(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.anyDouble(),
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveDoesNothingWhenRecordsArrayIsEmpty()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createObjectMessagePayload(
+				"update", "Account"
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verifyNoInteractions(
+			_accountService, _commercePriceEntryService,
+			_commercePriceListService, _commerceProductService,
+			_commerceSkuService, _contractService, _projectService);
+	}
+
+	@Test
+	public void testReceiveIgnoresUnknownSalesforceObjectName()
+		throws Exception {
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveMessage(
+				"update", "Widget__c",
+				new JSONObject(
+				).put(
+					"Id", "W-1"
+				)));
+
+		Mockito.verifyNoInteractions(
+			_accountService, _commercePriceEntryService,
+			_commercePriceListService, _commerceProductService,
+			_commerceSkuService, _contractService, _projectService);
+	}
+
+	@Test
+	public void testReceiveProcessesRemainingRecordsAfterFailure()
+		throws Exception {
+
+		Mockito.doThrow(
+			new Exception("Unable to add or update product")
+		).doNothing(
+		).when(
+			_commerceProductService
+		).addOrUpdateProduct(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createObjectMessagePayload(
+				"update", "Product2", _createProduct2JSONObject("Widget"),
+				_createProduct2JSONObject("Gadget")
+			).toString(),
+			"test-topic");
+
+		Exception exception = Assertions.assertThrows(
+			Exception.class, () -> _subscriber.receive(message));
+
+		Assertions.assertTrue(
+			exception.getMessage(
+			).contains(
+				"1 of 2"
+			));
+
+		Mockito.verify(
+			_commerceProductService, Mockito.times(2)
+		).addOrUpdateProduct(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_commerceProductService
+		).addOrUpdateProduct(
+			Mockito.any(), Mockito.any(), Mockito.eq("Gadget")
+		);
+	}
+
+	@Test
+	public void testReceiveRethrowsOnMalformedPayload() {
+		Message message = new Message(
+			Collections.emptyMap(), "not json", "test-topic");
+
+		Assertions.assertThrows(
+			JSONException.class, () -> _subscriber.receive(message));
+	}
+
+	@Test
+	public void testReceiveRethrowsWhenSalesforceObjectNameIsAbsent() {
+		Message message = new Message(
+			Collections.emptyMap(),
+			new JSONObject(
+			).put(
+				"action", "update"
+			).put(
+				"records", new JSONArray()
+			).toString(),
+			"test-topic");
+
+		Assertions.assertThrows(
+			JSONException.class, () -> _subscriber.receive(message));
+	}
+
+	@Test
+	public void testReceiveSkipsInactiveAccount() throws Exception {
+		_receiveMessage(
+			"update", "Account",
+			SalesforceModelTestUtil.createAccountJSONObject(
+				false, "", "SF-ACCOUNT-1", "Test Account"));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).upsertAccount(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsPricebookEntryWhenPriceListNotFound()
+		throws Exception {
+
+		Sku sku = new Sku();
+
+		sku.setId(_SKU_ID);
+
+		Mockito.when(
+			_commerceSkuService.fetchSku(_PRODUCT_2_ID)
+		).thenReturn(
+			sku
+		);
+
+		Mockito.when(
+			_commercePriceListService.fetchOrAddPriceList(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			null
+		);
+
+		_receiveMessage(
+			"update", "PricebookEntry",
+			_createPricebookEntryJSONObject("USD", 100.0));
+
+		Mockito.verify(
+			_commercePriceEntryService, Mockito.never()
+		).addOrUpdatePriceEntry(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.anyDouble(),
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsPricebookEntryWithBlankPricebook2Id()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createPricebookEntryJSONObject(
+			"USD", 100.0);
+
+		recordJSONObject.put("Pricebook2Id", "");
+
+		_receiveMessage("update", "PricebookEntry", recordJSONObject);
+
+		Mockito.verify(
+			_commerceSkuService, Mockito.never()
+		).fetchSku(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_commercePriceEntryService, Mockito.never()
+		).addOrUpdatePriceEntry(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.anyDouble(),
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsPricebookEntryWithoutSku() throws Exception {
+		Mockito.when(
+			_commerceSkuService.fetchSku(_PRODUCT_2_ID)
+		).thenReturn(
+			null
+		);
+
+		_receiveMessage(
+			"update", "PricebookEntry",
+			_createPricebookEntryJSONObject("USD", 100.0));
+
+		Mockito.verify(
+			_commercePriceEntryService, Mockito.never()
+		).addOrUpdatePriceEntry(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.anyDouble(),
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsPricebookEntryWithUnsupportedCurrency()
+		throws Exception {
+
+		_receiveMessage(
+			"update", "PricebookEntry",
+			_createPricebookEntryJSONObject("CHF", 100.0));
+
+		Mockito.verify(
+			_commerceSkuService, Mockito.never()
+		).fetchSku(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_commercePriceEntryService, Mockito.never()
+		).addOrUpdatePriceEntry(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.anyDouble(),
+			Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	@Test
+	public void testReceiveThrowsWhenAllRecordsFail() throws Exception {
+		Mockito.doThrow(
+			new Exception("Unable to add or update product")
+		).when(
+			_commerceProductService
+		).addOrUpdateProduct(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createObjectMessagePayload(
+				"update", "Product2", _createProduct2JSONObject("Widget"),
+				_createProduct2JSONObject("Gadget")
+			).toString(),
+			"test-topic");
+
+		Exception exception = Assertions.assertThrows(
+			Exception.class, () -> _subscriber.receive(message));
+
+		Assertions.assertTrue(
+			exception.getMessage(
+			).contains(
+				"2 of 2"
+			));
+	}
+
+	@Test
+	public void testReceiveUpsertsActiveAccount() throws Exception {
+		_receiveMessage(
+			"update", "Account",
+			SalesforceModelTestUtil.createAccountJSONObject(
+				true, "", "SF-ACCOUNT-1", "Test Account"));
+
+		ArgumentCaptor<SalesforceAccount> salesforceAccountArgumentCaptor =
+			ArgumentCaptor.forClass(SalesforceAccount.class);
+
+		Mockito.verify(
+			_accountService
+		).upsertAccount(
+			salesforceAccountArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals(
+			"SF-ACCOUNT-1",
+			salesforceAccountArgumentCaptor.getValue(
+			).getId());
+	}
+
+	@Test
+	public void testReceiveUpsertsContract() throws Exception {
+		JSONObject recordJSONObject = new JSONObject(
+		).put(
+			"Id", "SF-CONTRACT-1"
+		).put(
+			"SBQQ__Opportunity__c", "OPP-1"
+		);
+
+		_receiveMessage("update", "Contract", recordJSONObject);
+
+		ArgumentCaptor<SalesforceContract> salesforceContractArgumentCaptor =
+			ArgumentCaptor.forClass(SalesforceContract.class);
+
+		Mockito.verify(
+			_contractService
+		).upsertContract(
+			Mockito.eq("update"), salesforceContractArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals(
+			"SF-CONTRACT-1",
+			salesforceContractArgumentCaptor.getValue(
+			).getId());
+	}
+
+	@Test
+	public void testReceiveUpsertsInactivePricebookEntry() throws Exception {
+		Sku sku = new Sku();
+
+		sku.setId(_SKU_ID);
+
+		Mockito.when(
+			_commerceSkuService.fetchSku(_PRODUCT_2_ID)
+		).thenReturn(
+			sku
+		);
+
+		PriceList priceList = new PriceList();
+
+		priceList.setId(_PRICE_LIST_ID);
+
+		Mockito.when(
+			_commercePriceListService.fetchOrAddPriceList(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			priceList
+		);
+
+		_receiveMessage(
+			"update", "PricebookEntry",
+			_createPricebookEntryJSONObject(false, "USD", 100.0));
+
+		Mockito.verify(
+			_commercePriceEntryService
+		).addOrUpdatePriceEntry(
+			false, _PRICEBOOK_ENTRY_ID, 100.0, _PRICE_LIST_ID, _SKU_ID
+		);
+	}
+
+	@Test
+	public void testReceiveUpsertsPricebookEntry() throws Exception {
+		Sku sku = new Sku();
+
+		sku.setId(_SKU_ID);
+
+		Mockito.when(
+			_commerceSkuService.fetchSku(_PRODUCT_2_ID)
+		).thenReturn(
+			sku
+		);
+
+		PriceList priceList = new PriceList();
+
+		priceList.setId(_PRICE_LIST_ID);
+
+		Mockito.when(
+			_commercePriceListService.fetchOrAddPriceList(
+				"USD",
+				StringBundler.concat(
+					"SALESFORCE_PRICE_LIST_", _PRICEBOOK_2_ID, "_USD"),
+				StringBundler.concat("Salesforce ", _PRICEBOOK_2_ID, " USD"))
+		).thenReturn(
+			priceList
+		);
+
+		_receiveMessage(
+			"update", "PricebookEntry",
+			_createPricebookEntryJSONObject("USD", 100.0));
+
+		Mockito.verify(
+			_commercePriceListService
+		).fetchOrAddPriceList(
+			"USD",
+			StringBundler.concat(
+				"SALESFORCE_PRICE_LIST_", _PRICEBOOK_2_ID, "_USD"),
+			StringBundler.concat("Salesforce ", _PRICEBOOK_2_ID, " USD")
+		);
+
+		Mockito.verify(
+			_commercePriceEntryService
+		).addOrUpdatePriceEntry(
+			true, _PRICEBOOK_ENTRY_ID, 100.0, _PRICE_LIST_ID, _SKU_ID
+		);
+	}
+
+	@Test
+	public void testReceiveUpsertsProduct2() throws Exception {
+		_receiveMessage(
+			"update", "Product2", _createProduct2JSONObject("Widget"));
+
+		Mockito.verify(
+			_commerceProductService
+		).addOrUpdateProduct(
+			"A description", _PRODUCT_2_ID, "Widget"
+		);
+	}
+
+	@Test
+	public void testReceiveUpsertsProject() throws Exception {
+		JSONObject recordJSONObject = new JSONObject(
+		).put(
+			"Id", "SF-PROJ-1"
+		).put(
+			"Name", "My Project"
+		);
+
+		_receiveMessage("update", "Project__c", recordJSONObject);
+
+		ArgumentCaptor<SalesforceProject> salesforceProjectArgumentCaptor =
+			ArgumentCaptor.forClass(SalesforceProject.class);
+
+		Mockito.verify(
+			_projectService
+		).upsertProject(
+			salesforceProjectArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals(
+			"SF-PROJ-1",
+			salesforceProjectArgumentCaptor.getValue(
+			).getId());
+	}
+
+	private JSONObject _createPricebookEntryJSONObject(
+		boolean active, String currencyIsoCode, double unitPrice) {
+
+		return new JSONObject(
+		).put(
+			"CurrencyIsoCode", currencyIsoCode
+		).put(
+			"Id", _PRICEBOOK_ENTRY_ID
+		).put(
+			"IsActive", active
+		).put(
+			"Pricebook2Id", _PRICEBOOK_2_ID
+		).put(
+			"Product2Id", _PRODUCT_2_ID
+		).put(
+			"UnitPrice", unitPrice
+		);
+	}
+
+	private JSONObject _createPricebookEntryJSONObject(
+		String currencyIsoCode, double unitPrice) {
+
+		return _createPricebookEntryJSONObject(
+			true, currencyIsoCode, unitPrice);
+	}
+
+	private JSONObject _createProduct2JSONObject(String name) {
+		return new JSONObject(
+		).put(
+			"Description", "A description"
+		).put(
+			"Id", _PRODUCT_2_ID
+		).put(
+			"Name", name
+		);
+	}
+
+	private void _receiveMessage(
+			String action, String salesforceObjectName,
+			JSONObject... recordJSONObjects)
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createObjectMessagePayload(
+				action, salesforceObjectName, recordJSONObjects
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+	}
+
+	private static final long _PRICE_LIST_ID = 3000L;
+
+	private static final String _PRICEBOOK_2_ID = "PB-1";
+
+	private static final String _PRICEBOOK_ENTRY_ID = "PBE-1";
+
+	private static final String _PRODUCT_2_ID = "PROD-1";
+
+	private static final long _SKU_ID = 2000L;
+
+	private AccountService _accountService;
+	private CommercePriceEntryService _commercePriceEntryService;
+	private CommercePriceListService _commercePriceListService;
+	private CommerceProductService _commerceProductService;
+	private CommerceSkuService _commerceSkuService;
+	private ContractService _contractService;
+	private ProjectService _projectService;
+	private SalesforceObjectPubsubSubscriber _subscriber;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriberTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/salesforce/pubsub/SalesforceOpportunityPubsubSubscriberTest.java
@@ -1,0 +1,2067 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.salesforce.pubsub;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.commerce.admin.catalog.client.dto.v1_0.Sku;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.constants.OpportunityConstants;
+import com.liferay.one.model.Contract;
+import com.liferay.one.model.Project;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceOpportunity;
+import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
+import com.liferay.one.salesforce.model.SalesforceProject;
+import com.liferay.one.salesforce.model.SalesforceProjectContactRole;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommerceOrderItemService;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.CommerceSkuService;
+import com.liferay.one.service.ContractService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.one.service.ProjectService;
+import com.liferay.one.service.ProvisioningContactService;
+import com.liferay.one.service.ProvisioningEmailService;
+import com.liferay.one.service.ProvisioningIssueService;
+import com.liferay.one.service.ProvisioningOrderService;
+import com.liferay.one.service.ProvisioningSubdomainService;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class SalesforceOpportunityPubsubSubscriberTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_subscriber = new SalesforceOpportunityPubsubSubscriber();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_commerceOrderItemService = Mockito.mock(
+			CommerceOrderItemService.class);
+		_commerceOrderService = Mockito.mock(CommerceOrderService.class);
+		_commerceSkuService = Mockito.mock(CommerceSkuService.class);
+		_contractService = Mockito.mock(ContractService.class);
+		_entitlementService = Mockito.mock(EntitlementService.class);
+		_projectService = Mockito.mock(ProjectService.class);
+		_provisioningContactService = Mockito.mock(
+			ProvisioningContactService.class);
+		_provisioningEmailService = Mockito.mock(
+			ProvisioningEmailService.class);
+		_provisioningIssueService = Mockito.mock(
+			ProvisioningIssueService.class);
+		_provisioningOrderService = Mockito.mock(
+			ProvisioningOrderService.class);
+		_provisioningSubdomainService = Mockito.mock(
+			ProvisioningSubdomainService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
+
+		_account = new Account();
+
+		_account.setExternalReferenceCode(_ACCOUNT_ID_SF);
+		_account.setId(_ACCOUNT_ID);
+		_account.setName("Test Account");
+
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(
+				Mockito.anyString())
+		).thenReturn(
+			_account
+		);
+
+		Sku sku = new Sku();
+
+		sku.setId(_SKU_ID);
+
+		Mockito.when(
+			_commerceSkuService.fetchSku(Mockito.anyString())
+		).thenReturn(
+			sku
+		);
+
+		Order newOrder = new Order();
+
+		newOrder.setId(_NEW_ORDER_ID);
+
+		Mockito.when(
+			_commerceOrderService.upsertOrder(
+				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.anyList(), Mockito.any())
+		).thenReturn(
+			newOrder
+		);
+
+		OrderItem upsertedOrderItem = new OrderItem();
+
+		upsertedOrderItem.setId(_ORDER_ITEM_ID);
+
+		Mockito.when(
+			_commerceOrderItemService.upsertOrderItem(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			upsertedOrderItem
+		);
+
+		ReflectionTestUtils.setField(
+			_subscriber, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commerceOrderItemService",
+			_commerceOrderItemService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commerceOrderService", _commerceOrderService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_commerceSkuService", _commerceSkuService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_contractService", _contractService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_entitlementService", _entitlementService);
+		ReflectionTestUtils.setField(_subscriber, "_projectId", "test-project");
+		ReflectionTestUtils.setField(
+			_subscriber, "_projectService", _projectService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningContactService",
+			_provisioningContactService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningEmailService",
+			_provisioningEmailService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningIssueService",
+			_provisioningIssueService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningOrderService",
+			_provisioningOrderService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_provisioningSubdomainService",
+			_provisioningSubdomainService);
+		ReflectionTestUtils.setField(
+			_subscriber, "_subscription", "test-subscription");
+		ReflectionTestUtils.setField(_subscriber, "_topic", "test-topic");
+		ReflectionTestUtils.setField(
+			_subscriber, "_userAccountService", _userAccountService);
+	}
+
+	@Test
+	public void testIsAutoCreateTopicReturnsFalse() {
+		Assertions.assertFalse(_subscriber.isAutoCreateTopic());
+	}
+
+	@Test
+	public void testReceiveAddsErrorIssueForEveryFailedRecord()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to upsert account")
+		).when(
+			_accountService
+		).upsertAccount(
+			Mockito.any(), Mockito.any()
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				_createNewBusinessRecordJSONObject("OPP-FAIL-1"),
+				_createNewBusinessRecordJSONObject("OPP-FAIL-2")
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.times(2)
+		).addErrorIssue(
+			Mockito.eq(message), Mockito.any(JSONObject.class),
+			Mockito.any(Exception.class)
+		);
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.never()
+		).addErrorIssue(
+			Mockito.any(Message.class), Mockito.any(Exception.class)
+		);
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveAddsErrorIssueForMalformedPayload()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(), "not json", "test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addErrorIssue(
+			Mockito.eq(message), Mockito.any(Exception.class)
+		);
+	}
+
+	@Test
+	public void testReceiveAddsErrorIssueWhenRecordHasNoOpportunityKey()
+		throws Exception {
+
+		JSONObject recordJSONObject = new JSONObject(
+		).put(
+			"someOtherKey", "x"
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				recordJSONObject
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		ArgumentCaptor<JSONObject> recordJSONObjectArgumentCaptor =
+			ArgumentCaptor.forClass(JSONObject.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addErrorIssue(
+			Mockito.eq(message), recordJSONObjectArgumentCaptor.capture(),
+			Mockito.any(Exception.class)
+		);
+
+		Assertions.assertTrue(
+			recordJSONObjectArgumentCaptor.getValue(
+			).has(
+				"someOtherKey"
+			));
+	}
+
+	@Test
+	public void testReceiveAddsErrorIssueWhenRecordProcessingThrows()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to upsert account")
+		).when(
+			_accountService
+		).upsertAccount(
+			Mockito.any(), Mockito.any()
+		);
+
+		JSONObject recordJSONObject = _createNewBusinessRecordJSONObject();
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				recordJSONObject
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addErrorIssue(
+			Mockito.eq(message), Mockito.any(JSONObject.class),
+			Mockito.any(Exception.class)
+		);
+	}
+
+	@Test
+	public void testReceiveAttachesContractToProjectWhenProjectExternalReferenceCodeBlank()
+		throws Exception {
+
+		Mockito.when(
+			_contractService.fetchLatestContractByOpportunityId(
+				Mockito.anyString())
+		).thenReturn(
+			new Contract(
+				new JSONObject(
+				).put(
+					"id", 888L
+				))
+		);
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject projectJSONObject = new JSONObject(
+		).put(
+			"Id", "SF-PROJ-2"
+		).put(
+			"Name", "My Project"
+		);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), projectJSONObject);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_contractService
+		).attachContractToProject(
+			888L, "SF-PROJ-2"
+		);
+	}
+
+	@Test
+	public void testReceiveCompletesOrderBeforeProvisioningSubdomain()
+		throws Exception {
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		InOrder inOrder = Mockito.inOrder(
+			_commerceOrderItemService, _commerceOrderService,
+			_provisioningEmailService, _provisioningSubdomainService);
+
+		inOrder.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+
+		inOrder.verify(
+			_commerceOrderItemService
+		).upsertOrderItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		inOrder.verify(
+			_commerceOrderService
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+
+		inOrder.verify(
+			_provisioningSubdomainService
+		).provisionSubdomain(
+			Mockito.any(), Mockito.anyList()
+		);
+
+		inOrder.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.any(), Mockito.any(), Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveCompletesOrderOnFirstDelivery() throws Exception {
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_commerceOrderService
+		).completeOrder(
+			_NEW_ORDER_ID,
+			CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account),
+			Mockito.eq(OpportunityConstants.TYPE_NEW_BUSINESS),
+			Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.never()
+		).sendAssignedWelcomeEmails(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveCompletesOrderOnReprocessWhenNotYetCompleted()
+		throws Exception {
+
+		OrderItem existingOrderItem = SalesforceModelTestUtil.createOrderItem(
+			null, null, null, "LINE-1", _EXISTING_ORDER_ITEM_ID, "PROD-1",
+			null);
+
+		Order existingOrder = new Order();
+
+		existingOrder.setExternalReferenceCode(_OPPORTUNITY_ID);
+		existingOrder.setOrderItems(new OrderItem[] {existingOrderItem});
+		existingOrder.setOrderStatus(
+			CommerceOrderConstants.ORDER_STATUS_PROCESSING);
+
+		Mockito.when(
+			_commerceOrderService.fetchOrderByExternalReferenceCode(
+				_OPPORTUNITY_ID)
+		).thenReturn(
+			existingOrder
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_commerceOrderService
+		).completeOrder(
+			_NEW_ORDER_ID,
+			CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmails(
+			Mockito.eq(_account), Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveContinuesWhenUpdateEntitlementsThrows()
+		throws Exception {
+
+		OrderItem existingOrderItem = SalesforceModelTestUtil.createOrderItem(
+			null, null, null, "LINE-1", _EXISTING_ORDER_ITEM_ID, "PROD-1",
+			null);
+
+		Order existingOrder = new Order();
+
+		existingOrder.setExternalReferenceCode(_OPPORTUNITY_ID);
+		existingOrder.setOrderItems(new OrderItem[] {existingOrderItem});
+		existingOrder.setOrderStatus(
+			CommerceOrderConstants.ORDER_STATUS_COMPLETED);
+
+		Mockito.when(
+			_commerceOrderService.fetchOrderByExternalReferenceCode(
+				_OPPORTUNITY_ID)
+		).thenReturn(
+			existingOrder
+		);
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to update entitlements")
+		).when(
+			_entitlementService
+		).updateEntitlements(
+			_EXISTING_ORDER_ITEM_ID
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveOpportunityMessage(
+				_createNewBusinessRecordJSONObject()));
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmails(
+			Mockito.eq(_account), Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveDefaultsToUsdWhenLineCurrenciesAreBlank()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<String> currencyCodeArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), currencyCodeArgumentCaptor.capture(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals("USD", currencyCodeArgumentCaptor.getValue());
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertFalse(
+			_containsSubstring(
+				"reconcile mixed currencies",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveDoesNotAttachContractToProjectWhenProjectAlreadyAttached()
+		throws Exception {
+
+		Mockito.when(
+			_contractService.fetchLatestContractByOpportunityId(
+				Mockito.anyString())
+		).thenReturn(
+			new Contract(
+				new JSONObject(
+				).put(
+					"id", 888L
+				).put(
+					"r_projectToContract_c_projectERC", "SF-PROJ-EXISTING"
+				))
+		);
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject projectJSONObject = new JSONObject(
+		).put(
+			"Id", "SF-PROJ-2"
+		).put(
+			"Name", "My Project"
+		);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), projectJSONObject);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_contractService, Mockito.never()
+		).attachContractToProject(
+			Mockito.anyLong(), Mockito.anyString()
+		);
+
+		ArgumentCaptor<Long> contractIdArgumentCaptor = ArgumentCaptor.forClass(
+			Long.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), contractIdArgumentCaptor.capture(), Mockito.any(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals(888L, contractIdArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testReceiveDoesNothingWhenRecordsArrayIsEmpty()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+			).toString(),
+			"test-topic");
+
+		Assertions.assertDoesNotThrow(() -> _subscriber.receive(message));
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveForwardsProjectContactRolesToAddProjectContacts()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject contactRoleJSONObject =
+			SalesforceModelTestUtil.createProjectContactRoleJSONObject(
+				"Member", "contact@example.com", "Jane", "Doe", _PROJECT_ID);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(
+				).put(
+					contactRoleJSONObject
+				),
+				null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<SalesforceProjectContactRole>>
+			contactRolesArgumentCaptor = ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningContactService
+		).addProjectContacts(
+			Mockito.any(), contactRolesArgumentCaptor.capture(), Mockito.any(),
+			Mockito.any()
+		);
+
+		List<SalesforceProjectContactRole> contactRoles =
+			contactRolesArgumentCaptor.getValue();
+
+		Assertions.assertEquals(1, contactRoles.size());
+		Assertions.assertEquals(
+			"contact@example.com",
+			contactRoles.get(
+				0
+			).getEmailAddress());
+	}
+
+	@Test
+	public void testReceiveProcessesEveryRecordWhenAllRecordsSucceed()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				_createNewBusinessRecordJSONObject("OPP-1"),
+				_createNewBusinessRecordJSONObject("OPP-2")
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.times(2)
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.times(2)
+		).sendWelcomeEmails(
+			Mockito.any(), Mockito.any(), Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.times(2)
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.never()
+		).addErrorIssue(
+			Mockito.any(Message.class), Mockito.any(JSONObject.class),
+			Mockito.any(Exception.class)
+		);
+	}
+
+	@Test
+	public void testReceiveProcessesRemainingRecordAfterOneRecordFails()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to upsert account")
+		).doNothing(
+		).when(
+			_accountService
+		).upsertAccount(
+			Mockito.any(), Mockito.any()
+		);
+
+		JSONObject firstRecordJSONObject = _createNewBusinessRecordJSONObject(
+			"OPP-FAIL");
+		JSONObject secondRecordJSONObject = _createNewBusinessRecordJSONObject(
+			_OPPORTUNITY_ID);
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				firstRecordJSONObject, secondRecordJSONObject
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addErrorIssue(
+			Mockito.eq(message), Mockito.any(JSONObject.class),
+			Mockito.any(Exception.class)
+		);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveProvisionsExistingBusinessOpportunity()
+		throws Exception {
+
+		Mockito.when(
+			_projectService.fetchProject(_PROJECT_ID)
+		).thenReturn(
+			new Project(new JSONObject())
+		);
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", _PROJECT_ID, "Closed Won",
+			OpportunityConstants.TYPE_EXISTING_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account),
+			Mockito.eq(OpportunityConstants.TYPE_EXISTING_BUSINESS),
+			Mockito.anyList()
+		);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		for (String warningMessage : warningMessagesArgumentCaptor.getValue()) {
+			Assertions.assertFalse(
+				warningMessage.contains("project does not exist"));
+		}
+	}
+
+	@Test
+	public void testReceiveProvisionsNewBusinessOpportunity() throws Exception {
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		ArgumentCaptor<String> currencyCodeArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), currencyCodeArgumentCaptor.capture(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals("USD", currencyCodeArgumentCaptor.getValue());
+
+		Mockito.verify(
+			_provisioningSubdomainService
+		).provisionSubdomain(
+			Mockito.eq(_account), Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_commerceOrderItemService
+		).upsertOrderItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_commerceOrderService
+		).completeOrder(
+			_NEW_ORDER_ID,
+			CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account),
+			Mockito.eq(OpportunityConstants.TYPE_NEW_BUSINESS),
+			Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningOrderService, Mockito.never()
+		).trimRealignedOrderItems(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyString(),
+			Mockito.anyList(), Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningOrderService, Mockito.never()
+		).trimRenewedOrderItems(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyList(),
+			Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveProvisionsOpportunityWithSupportProductFamily()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "S", "", "Closed Won",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_commerceOrderService
+		).completeOrder(
+			_NEW_ORDER_ID,
+			CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED
+		);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveProvisionsRenewalOpportunity() throws Exception {
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", "", "Closed Lost",
+			OpportunityConstants.TYPE_RENEWAL);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_provisioningOrderService
+		).trimRenewedOrderItems(
+			Mockito.eq(_ACCOUNT_ID), Mockito.eq(_OPPORTUNITY_ID),
+			Mockito.anyList(), Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningContactService, Mockito.never()
+		).addProjectContacts(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account), Mockito.eq(OpportunityConstants.TYPE_RENEWAL),
+			Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveReprocessesRedeliveredMessageWithoutDuplicating()
+		throws Exception {
+
+		OrderItem existingOrderItem = SalesforceModelTestUtil.createOrderItem(
+			null, null, null, "LINE-1", _EXISTING_ORDER_ITEM_ID, "PROD-1",
+			null);
+
+		Order existingOrder = new Order();
+
+		existingOrder.setExternalReferenceCode(_OPPORTUNITY_ID);
+		existingOrder.setOrderItems(new OrderItem[] {existingOrderItem});
+		existingOrder.setOrderStatus(
+			CommerceOrderConstants.ORDER_STATUS_COMPLETED);
+
+		Mockito.when(
+			_commerceOrderService.fetchOrderByExternalReferenceCode(
+				_OPPORTUNITY_ID)
+		).thenReturn(
+			existingOrder
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.never()
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmails(
+			Mockito.eq(_account), Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.never()
+		).sendWelcomeEmails(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_entitlementService
+		).updateEntitlements(
+			_EXISTING_ORDER_ITEM_ID
+		);
+
+		ArgumentCaptor<SalesforceOpportunity>
+			salesforceOpportunityArgumentCaptor = ArgumentCaptor.forClass(
+				SalesforceOpportunity.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(),
+			salesforceOpportunityArgumentCaptor.capture(), Mockito.anyList(),
+			Mockito.any()
+		);
+
+		Assertions.assertEquals(
+			_OPPORTUNITY_ID,
+			salesforceOpportunityArgumentCaptor.getValue(
+			).getId());
+	}
+
+	@Test
+	public void testReceiveResolvesSingleLineCurrency() throws Exception {
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"EUR", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<String> currencyCodeArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), currencyCodeArgumentCaptor.capture(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals("EUR", currencyCodeArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testReceiveSkipsLineItemWithoutMatchingSku() throws Exception {
+		Mockito.when(
+			_commerceSkuService.fetchSku(Mockito.anyString())
+		).thenReturn(
+			null
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_commerceOrderItemService, Mockito.never()
+		).upsertOrderItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Unable to find SKU",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveSkipsOpportunityInvoicedIssueForProductFamilyP()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "P", "", "Closed Won",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_commerceOrderService
+		).completeOrder(
+			_NEW_ORDER_ID,
+			CommerceOrderConstants.ORDER_PAYMENT_STATUS_NOT_REQUIRED
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account),
+			Mockito.eq(OpportunityConstants.TYPE_NEW_BUSINESS),
+			Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService, Mockito.never()
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsOpportunityThatIsNotClosedWon()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", "", "Negotiation",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveSkipsOpportunityWithoutLineItems() throws Exception {
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject, new JSONArray(), new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveSkipsOpportunityWithoutProductFamily()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "", "", "Closed Won",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveSkipsOpportunityWithUnmatchedProductFamily()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "X", "", "Closed Won",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveSkipsRenewalOpportunityThatIsClosedWon()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", "", "Closed Won",
+			OpportunityConstants.TYPE_RENEWAL);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		_verifyNoProvisioningInteractions();
+	}
+
+	@Test
+	public void testReceiveSkipsWhenAccountNotFoundAfterUpsert()
+		throws Exception {
+
+		Mockito.when(
+			_accountService.fetchAccountByExternalReferenceCode(
+				Mockito.anyString())
+		).thenReturn(
+			null
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveSkipsWhenSalesforceAccountIdIsBlank()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					"", "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).upsertAccount(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveTreatsOrderWithoutOrderItemsAsFirstDelivery()
+		throws Exception {
+
+		Order existingOrder = new Order();
+
+		existingOrder.setExternalReferenceCode(_OPPORTUNITY_ID);
+		existingOrder.setOrderStatus(
+			CommerceOrderConstants.ORDER_STATUS_COMPLETED);
+
+		Mockito.when(
+			_commerceOrderService.fetchOrderByExternalReferenceCode(
+				_OPPORTUNITY_ID)
+		).thenReturn(
+			existingOrder
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendWelcomeEmails(
+			Mockito.eq(_account),
+			Mockito.eq(OpportunityConstants.TYPE_NEW_BUSINESS),
+			Mockito.anyList()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.never()
+		).sendAssignedWelcomeEmails(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+	}
+
+	@Test
+	public void testReceiveTrimsRealignedOrderItemsForAmendment()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, _PARENT_OPPORTUNITY_ID, false, _OPPORTUNITY_ID,
+				"", "E", "", "", "Closed Won", "Amendment");
+
+		JSONObject realignmentLineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-R", "PROD-R", "Widget", "Subscription", 0,
+				null);
+		JSONObject provisionableLineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-P", "PROD-P", "Gadget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					realignmentLineItemJSONObject
+				).put(
+					provisionableLineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<SalesforceOpportunityLineItem>>
+			realignedLinesArgumentCaptor = ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningOrderService
+		).trimRealignedOrderItems(
+			Mockito.eq(_ACCOUNT_ID), Mockito.eq(_OPPORTUNITY_ID),
+			Mockito.eq(_PARENT_OPPORTUNITY_ID),
+			realignedLinesArgumentCaptor.capture(), Mockito.anyList()
+		);
+
+		List<SalesforceOpportunityLineItem> realignedLines =
+			realignedLinesArgumentCaptor.getValue();
+
+		Assertions.assertEquals(1, realignedLines.size());
+
+		ArgumentCaptor<List<SalesforceOpportunityLineItem>>
+			provisionableLinesArgumentCaptor = ArgumentCaptor.forClass(
+				List.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			provisionableLinesArgumentCaptor.capture(), Mockito.any()
+		);
+
+		Assertions.assertEquals(
+			1,
+			provisionableLinesArgumentCaptor.getValue(
+			).size());
+	}
+
+	@Test
+	public void testReceiveTrimsRenewedOrderItemsWhenHasRenewalFlagSet()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", true, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_provisioningOrderService
+		).trimRenewedOrderItems(
+			Mockito.eq(_ACCOUNT_ID), Mockito.eq(_OPPORTUNITY_ID),
+			Mockito.anyList(), Mockito.anyList()
+		);
+	}
+
+	@Test
+	public void testReceiveUpsertsAccountWithSoldByFromOpportunity()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "",
+				"SALES-REP-1", "Closed Won",
+				OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<String> soldByArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_accountService
+		).upsertAccount(
+			Mockito.any(), soldByArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals("SALES-REP-1", soldByArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testReceiveUpsertsProjectWhenProjectNodePresent()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject projectJSONObject = new JSONObject(
+		).put(
+			"Id", "SF-PROJ-1"
+		).put(
+			"Name", "My Project"
+		);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), projectJSONObject);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_projectService
+		).upsertProject(
+			Mockito.eq(_ACCOUNT_ID_SF), Mockito.any()
+		);
+
+		ArgumentCaptor<SalesforceProject> salesforceProjectArgumentCaptor =
+			ArgumentCaptor.forClass(SalesforceProject.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), salesforceProjectArgumentCaptor.capture()
+		);
+
+		Assertions.assertNotNull(salesforceProjectArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testReceiveUsesContractIdFromFoundContract() throws Exception {
+		Mockito.when(
+			_contractService.fetchLatestContractByOpportunityId(
+				Mockito.anyString())
+		).thenReturn(
+			new Contract(
+				new JSONObject(
+				).put(
+					"id", 777L
+				))
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		ArgumentCaptor<Long> contractIdArgumentCaptor = ArgumentCaptor.forClass(
+			Long.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), contractIdArgumentCaptor.capture(), Mockito.any(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals(777L, contractIdArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testReceiveWarnsAndContinuesWhenCompleteOrderThrows()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to complete order")
+		).when(
+			_commerceOrderService
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveOpportunityMessage(
+				_createNewBusinessRecordJSONObject()));
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Unable to complete order",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsAndContinuesWhenUpsertOrderItemThrows()
+		throws Exception {
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to upsert order item")
+		).when(
+			_commerceOrderItemService
+		).upsertOrderItem(
+			Mockito.any(), Mockito.any(), Mockito.any()
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _receiveOpportunityMessage(
+				_createNewBusinessRecordJSONObject()));
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.never()
+		).completeOrder(
+			Mockito.anyLong(), Mockito.anyInt()
+		);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Unable to provision line",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsOnMixedLineCurrenciesAndDefaultsToUsd()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject firstLineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+		JSONObject secondLineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"EUR", null, "LINE-2", "PROD-2", "Gadget", "Subscription", 3,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					firstLineItemJSONObject
+				).put(
+					secondLineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<String> currencyCodeArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), currencyCodeArgumentCaptor.capture(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertEquals("USD", currencyCodeArgumentCaptor.getValue());
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"reconcile mixed currencies",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsWhenAmendmentHasNoParentOpportunity()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", "Amendment");
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-R", "PROD-R", "Widget", "Subscription", 0,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		Mockito.verify(
+			_provisioningOrderService, Mockito.never()
+		).trimRealignedOrderItems(
+			Mockito.anyLong(), Mockito.anyString(), Mockito.anyString(),
+			Mockito.anyList(), Mockito.anyList()
+		);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		boolean hasProductWarning = false;
+
+		for (String warningMessage : warningMessagesArgumentCaptor.getValue()) {
+			if (warningMessage.contains("Widget")) {
+				hasProductWarning = true;
+			}
+		}
+
+		Assertions.assertTrue(hasProductWarning);
+	}
+
+	@Test
+	public void testReceiveWarnsWhenContractNotFound() throws Exception {
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		ArgumentCaptor<Long> contractIdArgumentCaptor = ArgumentCaptor.forClass(
+			Long.class);
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), contractIdArgumentCaptor.capture(), Mockito.any(),
+			Mockito.any(), Mockito.anyList(), Mockito.any()
+		);
+
+		Assertions.assertNull(contractIdArgumentCaptor.getValue());
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Unable to find a contract for opportunity " + _OPPORTUNITY_ID,
+				warningMessagesArgumentCaptor.getValue()));
+
+		Mockito.verify(
+			_contractService, Mockito.never()
+		).attachContractToProject(
+			Mockito.anyLong(), Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testReceiveWarnsWhenDuplicateAccountName() throws Exception {
+		Mockito.when(
+			_accountService.hasDuplicateAccountName(
+				Mockito.any(), Mockito.any())
+		).thenReturn(
+			true
+		);
+
+		_receiveOpportunityMessage(_createNewBusinessRecordJSONObject());
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Another account already uses the name",
+				warningMessagesArgumentCaptor.getValue()));
+
+		Mockito.verify(
+			_commerceOrderService
+		).upsertOrder(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			Mockito.anyList(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testReceiveWarnsWhenLineEndDateDiffersFromContractEndDate()
+		throws Exception {
+
+		Mockito.when(
+			_contractService.fetchLatestContractByOpportunityId(
+				Mockito.anyString())
+		).thenReturn(
+			new Contract(
+				new JSONObject(
+				).put(
+					"endDate", "2026-01-01T00:00:00Z"
+				).put(
+					"id", 999L
+				))
+		);
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "", "E", "", "",
+				"Closed Won", OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", "2025-06-01", "LINE-1", "PROD-1", "Widget",
+				"Subscription", 5, null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"differs from the end date of contract",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsWhenOpportunityOwnerNotFound()
+		throws Exception {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, _OPPORTUNITY_ID, "owner@example.com",
+				"E", "", "", "Closed Won",
+				OpportunityConstants.TYPE_NEW_BUSINESS);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		JSONObject recordJSONObject =
+			SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+				SalesforceModelTestUtil.createAccountJSONObject(
+					_ACCOUNT_ID_SF, "Test Salesforce Account"),
+				opportunityJSONObject,
+				new JSONArray(
+				).put(
+					lineItemJSONObject
+				),
+				new JSONArray(), null);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"Unable to find portal user",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsWhenProjectAlreadyExistsForNewBusiness()
+		throws Exception {
+
+		Mockito.when(
+			_projectService.fetchProject(_PROJECT_ID)
+		).thenReturn(
+			new Project(new JSONObject())
+		);
+
+		_receiveOpportunityMessage(
+			_createOpportunityRecordJSONObject(
+				_OPPORTUNITY_ID, "E", _PROJECT_ID, "Closed Won",
+				OpportunityConstants.TYPE_NEW_BUSINESS));
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"project already exists",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsWhenProjectAlreadyExistsForNewProjectExistingBusiness()
+		throws Exception {
+
+		Mockito.when(
+			_projectService.fetchProject(Mockito.anyString())
+		).thenReturn(
+			new Project(new JSONObject())
+		);
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", _PROJECT_ID, "Closed Won",
+			OpportunityConstants.TYPE_NEW_PROJECT_EXISTING_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				StringBundler.concat(
+					"The opportunity type is ",
+					OpportunityConstants.TYPE_NEW_PROJECT_EXISTING_BUSINESS,
+					" and the project already exists"),
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	@Test
+	public void testReceiveWarnsWhenProjectDoesNotExistForExistingBusiness()
+		throws Exception {
+
+		JSONObject recordJSONObject = _createOpportunityRecordJSONObject(
+			_OPPORTUNITY_ID, "E", _PROJECT_ID, "Closed Won",
+			OpportunityConstants.TYPE_EXISTING_BUSINESS);
+
+		_receiveOpportunityMessage(recordJSONObject);
+
+		ArgumentCaptor<List<String>> warningMessagesArgumentCaptor =
+			ArgumentCaptor.forClass(List.class);
+
+		Mockito.verify(
+			_provisioningIssueService
+		).addOpportunityInvoicedIssue(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+			warningMessagesArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			_containsSubstring(
+				"project does not exist",
+				warningMessagesArgumentCaptor.getValue()));
+	}
+
+	private boolean _containsSubstring(
+		String substring, List<String> warningMessages) {
+
+		for (String warningMessage : warningMessages) {
+			if (warningMessage.contains(substring)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private JSONObject _createNewBusinessRecordJSONObject() {
+		return _createNewBusinessRecordJSONObject(_OPPORTUNITY_ID);
+	}
+
+	private JSONObject _createNewBusinessRecordJSONObject(
+		String opportunityId) {
+
+		return _createOpportunityRecordJSONObject(
+			opportunityId, "E", "", "Closed Won",
+			OpportunityConstants.TYPE_NEW_BUSINESS);
+	}
+
+	private JSONObject _createOpportunityRecordJSONObject(
+		String opportunityId, String productFamily, String projectId,
+		String stageName, String type) {
+
+		JSONObject opportunityJSONObject =
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ID_SF, "", false, opportunityId, "", productFamily,
+				projectId, "", stageName, type);
+
+		JSONObject lineItemJSONObject =
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "Widget", "Subscription", 5,
+				null);
+
+		return SalesforceModelTestUtil.createOpportunityRecordJSONObject(
+			SalesforceModelTestUtil.createAccountJSONObject(
+				_ACCOUNT_ID_SF, "Test Salesforce Account"),
+			opportunityJSONObject,
+			new JSONArray(
+			).put(
+				lineItemJSONObject
+			),
+			new JSONArray(), null);
+	}
+
+	private void _receiveOpportunityMessage(JSONObject recordJSONObject)
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(),
+			SalesforceModelTestUtil.createOpportunityMessagePayload(
+				recordJSONObject
+			).toString(),
+			"test-topic");
+
+		_subscriber.receive(message);
+	}
+
+	private void _verifyNoProvisioningInteractions() {
+		Mockito.verifyNoInteractions(
+			_accountService, _commerceOrderItemService, _commerceOrderService,
+			_commerceSkuService, _contractService, _entitlementService,
+			_projectService, _provisioningContactService,
+			_provisioningEmailService, _provisioningIssueService,
+			_provisioningOrderService, _provisioningSubdomainService,
+			_userAccountService);
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final String _ACCOUNT_ID_SF = "SF-ACCOUNT-1";
+
+	private static final long _EXISTING_ORDER_ITEM_ID = 555L;
+
+	private static final long _NEW_ORDER_ID = 4000L;
+
+	private static final String _OPPORTUNITY_ID = "OPP-1";
+
+	private static final long _ORDER_ITEM_ID = 3000L;
+
+	private static final String _PARENT_OPPORTUNITY_ID = "OPP-PARENT";
+
+	private static final String _PROJECT_ID = "PROJECT-1";
+
+	private static final long _SKU_ID = 2000L;
+
+	private Account _account;
+	private AccountService _accountService;
+	private CommerceOrderItemService _commerceOrderItemService;
+	private CommerceOrderService _commerceOrderService;
+	private CommerceSkuService _commerceSkuService;
+	private ContractService _contractService;
+	private EntitlementService _entitlementService;
+	private ProjectService _projectService;
+	private ProvisioningContactService _provisioningContactService;
+	private ProvisioningEmailService _provisioningEmailService;
+	private ProvisioningIssueService _provisioningIssueService;
+	private ProvisioningOrderService _provisioningOrderService;
+	private ProvisioningSubdomainService _provisioningSubdomainService;
+	private SalesforceOpportunityPubsubSubscriber _subscriber;
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningAssignmentServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningAssignmentServiceTest.java
@@ -1,0 +1,371 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningAssignmentServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_provisioningAssignmentService = new ProvisioningAssignmentService();
+
+		_oktaService = Mockito.mock(OktaService.class);
+		_propertyService = Mockito.mock(PropertyService.class);
+		_provisioningEmailService = Mockito.mock(
+			ProvisioningEmailService.class);
+		_subscriptionEntryService = Mockito.mock(
+			SubscriptionEntryService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
+
+		_account = new Account();
+
+		_account.setId(_ACCOUNT_ID);
+
+		_userAccount = new UserAccount();
+
+		_userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		_userAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			_userAccount
+		);
+
+		Mockito.when(
+			_oktaService.fetchContactStatusByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			WorkflowConstants.STATUS_APPROVED
+		);
+
+		ReflectionTestUtils.setField(
+			_provisioningAssignmentService, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			_provisioningAssignmentService, "_propertyService",
+			_propertyService);
+		ReflectionTestUtils.setField(
+			_provisioningAssignmentService, "_provisioningEmailService",
+			_provisioningEmailService);
+		ReflectionTestUtils.setField(
+			_provisioningAssignmentService, "_subscriptionEntryService",
+			_subscriptionEntryService);
+		ReflectionTestUtils.setField(
+			_provisioningAssignmentService, "_userAccountService",
+			_userAccountService);
+	}
+
+	@Test
+	public void testAssignAccountRoleActivatesInactiveContact()
+		throws Exception {
+
+		Mockito.when(
+			_oktaService.fetchContactStatusByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			WorkflowConstants.STATUS_INACTIVE
+		);
+
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_ACCOUNT_MEMBER);
+
+		Mockito.verify(
+			_oktaService
+		).activateUser(
+			_EMAIL_ADDRESS
+		);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).addMembership(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAssignAccountRoleAddsCustomerMembership() throws Exception {
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_ACCOUNT_MEMBER);
+
+		Mockito.verify(
+			_oktaService
+		).addMembership(
+			"Customers", _EMAIL_ADDRESS
+		);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).addMembership(
+			Mockito.eq("Partners"), Mockito.any()
+		);
+
+		Mockito.verifyNoInteractions(_provisioningEmailService);
+	}
+
+	@Test
+	public void testAssignAccountRoleAddsPartnerMembershipAndSendsEmail()
+		throws Exception {
+
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_PARTNER_MEMBER);
+
+		Mockito.verify(
+			_oktaService
+		).addMembership(
+			"Customers", _EMAIL_ADDRESS
+		);
+
+		Mockito.verify(
+			_oktaService
+		).addMembership(
+			"Partners", _EMAIL_ADDRESS
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendPartnerUserUpdateEmail(
+			_account, _userAccount, RoleConstants.NAME_PARTNER_MEMBER,
+			"Assigned"
+		);
+	}
+
+	@Test
+	public void testAssignAccountRoleAssignsCloudNativeContactToApplication()
+		throws Exception {
+
+		Mockito.when(
+			_propertyService.getPropertyValue(
+				_ACCOUNT_ID, PropertyConstants.NAME_OKTA_APPLICATION)
+		).thenReturn(
+			_OKTA_APPLICATION_ID
+		);
+
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_CLOUD_NATIVE_CONTACT);
+
+		Mockito.verify(
+			_oktaService
+		).assignUserToApplication(
+			_OKTA_APPLICATION_ID, _EMAIL_ADDRESS
+		);
+	}
+
+	@Test
+	public void testAssignAccountRoleSkipsCloudNativeContactWithoutApplication()
+		throws Exception {
+
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_CLOUD_NATIVE_CONTACT);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).assignUserToApplication(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAssignAccountRoleSkipsMembershipWhenContactStatusIsNull()
+		throws Exception {
+
+		Mockito.when(
+			_oktaService.fetchContactStatusByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			null
+		);
+
+		_provisioningAssignmentService.assignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_ACCOUNT_MEMBER);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).addMembership(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).activateUser(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAssignCustomerGroupAddsCustomerMembership()
+		throws Exception {
+
+		_provisioningAssignmentService.assignCustomerGroup(_USER_ID);
+
+		Mockito.verify(
+			_oktaService
+		).addMembership(
+			"Customers", _EMAIL_ADDRESS
+		);
+	}
+
+	@Test
+	public void testUnassignAccountMembershipAlwaysDeletesSubscriptionEntries()
+		throws Exception {
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			_ACCOUNT_ID, _USER_ID);
+
+		Mockito.verify(
+			_subscriptionEntryService
+		).deleteAccountLicenseKeySubscriptionEntries(
+			_ACCOUNT_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testUnassignAccountMembershipKeepsCustomerMembershipWhenStillAMember()
+		throws Exception {
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setId(_ACCOUNT_ID);
+
+		_userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			_ACCOUNT_ID, _USER_ID);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).removeMembership(
+			Mockito.eq("Customers"), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testUnassignAccountMembershipRemovesCustomerMembershipWhenNoAccountBriefs()
+		throws Exception {
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			_ACCOUNT_ID, _USER_ID);
+
+		Mockito.verify(
+			_oktaService
+		).removeMembership(
+			"Customers", _EMAIL_ADDRESS
+		);
+	}
+
+	@Test
+	public void testUnassignAccountMembershipRemovesPartnerMembershipWhenNoPartnerRoleRemains()
+		throws Exception {
+
+		_provisioningAssignmentService.unassignAccountMembership(
+			_ACCOUNT_ID, _USER_ID);
+
+		Mockito.verify(
+			_oktaService
+		).removeMembership(
+			"Partners", _EMAIL_ADDRESS
+		);
+	}
+
+	@Test
+	public void testUnassignAccountRoleRemovesPartnerMembershipAndSendsEmail()
+		throws Exception {
+
+		_provisioningAssignmentService.unassignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_PARTNER_MEMBER);
+
+		Mockito.verify(
+			_oktaService
+		).removeMembership(
+			"Partners", _EMAIL_ADDRESS
+		);
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendPartnerUserUpdateEmail(
+			_account, _userAccount, RoleConstants.NAME_PARTNER_MEMBER,
+			"Unassigned"
+		);
+	}
+
+	@Test
+	public void testUnassignAccountRoleSkipsRemovalWhenStillPartnerElsewhere()
+		throws Exception {
+
+		RoleBrief partnerRoleBrief = new RoleBrief();
+
+		partnerRoleBrief.setName(RoleConstants.NAME_PARTNER_MANAGER);
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setId(_ACCOUNT_ID + 1);
+		accountBrief.setRoleBriefs(new RoleBrief[] {partnerRoleBrief});
+
+		_userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
+
+		_provisioningAssignmentService.unassignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_PARTNER_MEMBER);
+
+		Mockito.verify(
+			_oktaService, Mockito.never()
+		).removeMembership(
+			Mockito.eq("Partners"), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testUnassignAccountRoleUnassignsCloudNativeContactFromApplication()
+		throws Exception {
+
+		Mockito.when(
+			_propertyService.getPropertyValue(
+				_ACCOUNT_ID, PropertyConstants.NAME_OKTA_APPLICATION)
+		).thenReturn(
+			_OKTA_APPLICATION_ID
+		);
+
+		_provisioningAssignmentService.unassignAccountRole(
+			_account, _USER_ID, RoleConstants.NAME_CLOUD_NATIVE_CONTACT);
+
+		Mockito.verify(
+			_oktaService
+		).unassignUserFromApplication(
+			_OKTA_APPLICATION_ID, _EMAIL_ADDRESS
+		);
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final String _EMAIL_ADDRESS = "contact@example.com";
+
+	private static final String _OKTA_APPLICATION_ID = "APP-1";
+
+	private static final long _USER_ID = 100L;
+
+	private Account _account;
+	private OktaService _oktaService;
+	private PropertyService _propertyService;
+	private ProvisioningAssignmentService _provisioningAssignmentService;
+	private ProvisioningEmailService _provisioningEmailService;
+	private SubscriptionEntryService _subscriptionEntryService;
+	private UserAccount _userAccount;
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningContactServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningContactServiceTest.java
@@ -1,0 +1,597 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceProject;
+import com.liferay.one.salesforce.model.SalesforceProjectContactRole;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningContactServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_provisioningContactService = new ProvisioningContactService();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_emailAddressValidatorService = Mockito.mock(
+			EmailAddressValidatorService.class);
+		_oktaService = Mockito.mock(OktaService.class);
+		_projectMembershipService = Mockito.mock(
+			ProjectMembershipService.class);
+		_provisioningAssignmentService = Mockito.mock(
+			ProvisioningAssignmentService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
+
+		_account = new Account();
+
+		_account.setId(_ACCOUNT_ID);
+
+		Mockito.when(
+			_userAccountService.hasUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			true
+		);
+
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_emailAddressValidatorService",
+			_emailAddressValidatorService);
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_projectMembershipService",
+			_projectMembershipService);
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_provisioningAssignmentService",
+			_provisioningAssignmentService);
+		ReflectionTestUtils.setField(
+			_provisioningContactService, "_userAccountService",
+			_userAccountService);
+	}
+
+	@Test
+	public void testAddProjectContactsAddsProjectMembershipWhenProjectPresent()
+		throws Exception {
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		SalesforceProject salesforceProject = new SalesforceProject(
+			new JSONObject(
+			).put(
+				"Id", "SF-PROJ-1"
+			));
+
+		_provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)),
+			salesforceProject, new ArrayList<>());
+
+		Mockito.verify(
+			_projectMembershipService
+		).addProjectMembership(
+			"SF-PROJ-1", _USER_ID
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsCreatesNewContact() throws Exception {
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			warningMessages);
+
+		Mockito.verify(
+			_userAccountService
+		).addUserAccount(
+			_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME
+		);
+
+		Mockito.verify(
+			_oktaService
+		).createContact(
+			_EMAIL_ADDRESS, _FIRST_NAME, null, _LAST_NAME
+		);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccount(
+			_ACCOUNT_ID, _ACCOUNT_ROLE_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService
+		).assignAccountRole(
+			_account, _USER_ID, _CONTACT_ROLE
+		);
+
+		Assertions.assertEquals(List.of(_USER_ID), userIds);
+	}
+
+	@Test
+	public void testAddProjectContactsIsolatesPerContactFailures()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenThrow(
+			new RuntimeException("Unable to fetch user account")
+		);
+
+		UserAccount secondUserAccount = new UserAccount();
+
+		secondUserAccount.setId(_SECOND_USER_ID);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(
+				_SECOND_EMAIL_ADDRESS)
+		).thenReturn(
+			secondUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account,
+			List.of(
+				_createContactRole(_CONTACT_ROLE),
+				_createContactRole(
+					_CONTACT_ROLE, _SECOND_EMAIL_ADDRESS, _FIRST_NAME,
+					_LAST_NAME)),
+			null, warningMessages);
+
+		Assertions.assertEquals(List.of(_SECOND_USER_ID), userIds);
+
+		Assertions.assertEquals(1, warningMessages.size());
+	}
+
+	@Test
+	public void testAddProjectContactsPromotesFirstUserToAdministrator()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.hasUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			false
+		);
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(
+				_ACCOUNT_ID, RoleConstants.NAME_ACCOUNT_ADMINISTRATOR)
+		).thenReturn(
+			_ADMINISTRATOR_ROLE_ID
+		);
+
+		_provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			new ArrayList<>());
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccountRole(
+			_ACCOUNT_ID, _ADMINISTRATOR_ROLE_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsSkipsAutoPromotionWhenDesignatedAdministratorPresent()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.hasUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		UserAccount firstUserAccount = new UserAccount();
+
+		firstUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			firstUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(
+				_ACCOUNT_ID, RoleConstants.NAME_ACCOUNT_ADMINISTRATOR)
+		).thenReturn(
+			_ADMINISTRATOR_ROLE_ID
+		);
+
+		UserAccount secondUserAccount = new UserAccount();
+
+		secondUserAccount.setId(_SECOND_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_SECOND_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			secondUserAccount
+		);
+
+		_provisioningContactService.addProjectContacts(
+			_account,
+			List.of(
+				_createContactRole(RoleConstants.NAME_ACCOUNT_ADMINISTRATOR),
+				_createContactRole(
+					_CONTACT_ROLE, _SECOND_EMAIL_ADDRESS, _FIRST_NAME,
+					_LAST_NAME)),
+			null, new ArrayList<>());
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).addAccountUserAccountRole(
+			_ACCOUNT_ID, _ADMINISTRATOR_ROLE_ID, _SECOND_USER_ID
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsSkipsExistingMember() throws Exception {
+		UserAccount existingUserAccount = new UserAccount();
+
+		existingUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.fetchUserAccountByEmailAddress(_EMAIL_ADDRESS)
+		).thenReturn(
+			existingUserAccount
+		);
+
+		Mockito.when(
+			_userAccountService.hasAccountUserAccount(_ACCOUNT_ID, _USER_ID)
+		).thenReturn(
+			true
+		);
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			new ArrayList<>());
+
+		Assertions.assertTrue(userIds.isEmpty());
+
+		Mockito.verify(
+			_provisioningAssignmentService, Mockito.never()
+		).assignAccountRole(
+			Mockito.any(), Mockito.anyLong(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsSkipsLiferayDomainEmail()
+		throws Exception {
+
+		Mockito.when(
+			_emailAddressValidatorService.isLiferayDomain(_EMAIL_ADDRESS)
+		).thenReturn(
+			true
+		);
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			new ArrayList<>());
+
+		Assertions.assertTrue(userIds.isEmpty());
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testAddProjectContactsSwallowsAssignmentSideEffectFailure()
+		throws Exception {
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to assign account role")
+		).when(
+			_provisioningAssignmentService
+		).assignAccountRole(
+			Mockito.any(), Mockito.anyLong(), Mockito.any()
+		);
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			new ArrayList<>());
+
+		Assertions.assertEquals(List.of(_USER_ID), userIds);
+	}
+
+	@Test
+	public void testAddProjectContactsSwallowsOktaContactCreationFailure()
+		throws Exception {
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to create Okta contact")
+		).when(
+			_oktaService
+		).createContact(
+			_EMAIL_ADDRESS, _FIRST_NAME, null, _LAST_NAME
+		);
+
+		List<Long> userIds = _provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			new ArrayList<>());
+
+		Assertions.assertEquals(List.of(_USER_ID), userIds);
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccount(
+			_ACCOUNT_ID, _ACCOUNT_ROLE_ID, _USER_ID
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsWarnsOnUnknownContactRole()
+		throws Exception {
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			null
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			warningMessages);
+
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"Unable to find account role"
+			));
+
+		Mockito.verify(
+			_accountService
+		).addAccountUserAccount(
+			_ACCOUNT_ID, _USER_ID
+		);
+
+		Mockito.verify(
+			_provisioningAssignmentService, Mockito.never()
+		).assignAccountRole(
+			Mockito.any(), Mockito.anyLong(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testAddProjectContactsWarnsWhenAdministratorRoleIsMissing()
+		throws Exception {
+
+		Mockito.when(
+			_userAccountService.hasUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			false
+		);
+
+		UserAccount newUserAccount = new UserAccount();
+
+		newUserAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.addUserAccount(
+				_EMAIL_ADDRESS, _LAST_NAME, _FIRST_NAME)
+		).thenReturn(
+			newUserAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(_ACCOUNT_ID, _CONTACT_ROLE)
+		).thenReturn(
+			_ACCOUNT_ROLE_ID
+		);
+
+		Mockito.when(
+			_accountService.fetchAccountRoleId(
+				_ACCOUNT_ID, RoleConstants.NAME_ACCOUNT_ADMINISTRATOR)
+		).thenReturn(
+			null
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningContactService.addProjectContacts(
+			_account, List.of(_createContactRole(_CONTACT_ROLE)), null,
+			warningMessages);
+
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"Unable to find account role " +
+					RoleConstants.NAME_ACCOUNT_ADMINISTRATOR
+			));
+
+		Mockito.verify(
+			_accountService, Mockito.never()
+		).addAccountUserAccountRole(
+			Mockito.anyLong(), Mockito.anyLong(), Mockito.anyLong()
+		);
+	}
+
+	private SalesforceProjectContactRole _createContactRole(
+		String contactRole) {
+
+		return _createContactRole(
+			contactRole, _EMAIL_ADDRESS, _FIRST_NAME, _LAST_NAME);
+	}
+
+	private SalesforceProjectContactRole _createContactRole(
+		String contactRole, String emailAddress, String firstName,
+		String lastName) {
+
+		JSONObject jsonObject =
+			SalesforceModelTestUtil.createProjectContactRoleJSONObject(
+				contactRole, emailAddress, firstName, lastName, _PROJECT_ID);
+
+		return new SalesforceProjectContactRole(jsonObject);
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final long _ACCOUNT_ROLE_ID = 500L;
+
+	private static final long _ADMINISTRATOR_ROLE_ID = 600L;
+
+	private static final String _CONTACT_ROLE = "Member";
+
+	private static final String _EMAIL_ADDRESS = "contact@example.com";
+
+	private static final String _FIRST_NAME = "Jane";
+
+	private static final String _LAST_NAME = "Doe";
+
+	private static final String _PROJECT_ID = "PROJECT-1";
+
+	private static final String _SECOND_EMAIL_ADDRESS =
+		"other-contact@example.com";
+
+	private static final long _SECOND_USER_ID = 200L;
+
+	private static final long _USER_ID = 100L;
+
+	private Account _account;
+	private AccountService _accountService;
+	private EmailAddressValidatorService _emailAddressValidatorService;
+	private OktaService _oktaService;
+	private ProjectMembershipService _projectMembershipService;
+	private ProvisioningAssignmentService _provisioningAssignmentService;
+	private ProvisioningContactService _provisioningContactService;
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningEmailServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningEmailServiceTest.java
@@ -1,0 +1,952 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.EntitlementConstants;
+import com.liferay.one.constants.OpportunityConstants;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.constants.SupportRegionConstants;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.model.Project;
+import com.liferay.one.model.ProjectMembership;
+
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.context.MessageSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningEmailServiceTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_provisioningEmailService = Mockito.spy(new ProvisioningEmailService());
+
+		_accountService = Mockito.mock(AccountService.class);
+		_commerceOrderService = Mockito.mock(CommerceOrderService.class);
+		_entitlementService = Mockito.mock(EntitlementService.class);
+		_messageSource = Mockito.mock(MessageSource.class);
+		_notificationQueueEntryService = Mockito.mock(
+			NotificationQueueEntryService.class);
+		_notificationTemplateService = Mockito.mock(
+			NotificationTemplateService.class);
+		_projectMembershipService = Mockito.mock(
+			ProjectMembershipService.class);
+		_projectService = Mockito.mock(ProjectService.class);
+		_userAccountService = Mockito.mock(UserAccountService.class);
+
+		JSONObject templateJSONObject = new JSONObject(
+		).put(
+			"body", "Body"
+		).put(
+			"subject", "Subject"
+		);
+
+		Mockito.when(
+			_notificationTemplateService.getAndProcessTemplateJSONObject(
+				Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			templateJSONObject
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(
+				Mockito.anyLong(), Mockito.any())
+		).thenReturn(
+			new AccountSupportInfo(
+				"en_US", SupportRegionConstants.UNITED_STATES)
+		);
+
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_commerceOrderService",
+			_commerceOrderService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressAustralia",
+			"australia@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressBrazil",
+			"brazil@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressChina",
+			"china@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressGlobal",
+			_EMAIL_ADDRESS_GLOBAL);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressHungary",
+			"hungary@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressIndia",
+			"india@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressJapan",
+			"japan@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressSpain",
+			"spain@example.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_emailAddressUS", _EMAIL_ADDRESS_US);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_entitlementService",
+			_entitlementService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_messageSource", _messageSource);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_notificationQueueEntryService",
+			_notificationQueueEntryService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_notificationTemplateService",
+			_notificationTemplateService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_partnerUserUpdateRecipient",
+			_PARTNER_USER_UPDATE_RECIPIENT);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_portalURL", "https://one.liferay.com");
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_projectMembershipService",
+			_projectMembershipService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_projectService", _projectService);
+		ReflectionTestUtils.setField(
+			_provisioningEmailService, "_userAccountService",
+			_userAccountService);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailFallsBackToDefaultLanguageForUnsupportedId()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		userAccount.setLanguageId("de_DE");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verify(
+			_notificationTemplateService
+		).getAndProcessTemplateJSONObject(
+			Mockito.eq("PROVISIONING-WELCOME"), Mockito.eq("en_US"),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailIncludesSingleProjectInvitation()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_projectMembershipService.getProjectMemberships(
+				_ACCOUNT_ID, _USER_ID)
+		).thenReturn(
+			List.of(_createProjectMembership("PROJECT-ERC-1"))
+		);
+
+		Mockito.when(
+			_projectService.fetchProject("PROJECT-ERC-1")
+		).thenReturn(
+			_createProject("PROJECT-ERC-1", "My Project")
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		ArgumentCaptor<Map<String, String>> placeholdersArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_notificationTemplateService
+		).getAndProcessTemplateJSONObject(
+			Mockito.eq("PROVISIONING-WELCOME"), Mockito.any(),
+			placeholdersArgumentCaptor.capture()
+		);
+
+		Map<String, String> placeholders =
+			placeholdersArgumentCaptor.getValue();
+
+		Assertions.assertEquals(
+			"PROJECT-ERC-1", placeholders.get("PROJECT_KEY"));
+		Assertions.assertTrue(
+			placeholders.get(
+				"PROJECT_NAME_SUFFIX"
+			).contains(
+				"My Project"
+			));
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailsIsolatesPerUserFailures()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenThrow(
+			new RuntimeException("Unable to fetch user account")
+		);
+
+		UserAccount secondUserAccount = _createVerifiedUserAccount(
+			_SECOND_USER_ID);
+
+		secondUserAccount.setEmailAddress("second@example.com");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_SECOND_USER_ID)
+		).thenReturn(
+			secondUserAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmails(
+			account, List.of(_USER_ID, _SECOND_USER_ID));
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq("second@example.com"),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailSkipsUnverifiedUser()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setId(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verifyNoInteractions(_entitlementService);
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailSkipsWithoutSupportOrPartnerEntitlement()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailUsesPartnerEntitlement()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAME_PARTNER)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq(_EMAIL_ADDRESS),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailUsesSupportedLanguageId()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		userAccount.setLanguageId("pt_BR");
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verify(
+			_notificationTemplateService
+		).getAndProcessTemplateJSONObject(
+			Mockito.eq("PROVISIONING-WELCOME"), Mockito.eq("pt_BR"),
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendAssignedWelcomeEmailUsesUnitedStatesRegionAddress()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendAssignedWelcomeEmail(account, _USER_ID);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			_EMAIL_ADDRESS_US, "Liferay Provisioning", _EMAIL_ADDRESS,
+			"Subject", "Body"
+		);
+	}
+
+	@Test
+	public void testSendAutoProvisionedWelcomeEmailSendsOnlyToEligibleMembers()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount eligibleUserAccount = _createMemberUserAccount(
+			_ACCOUNT_ID, _EMAIL_ADDRESS, _USER_ID,
+			RoleConstants.NAME_ACCOUNT_MEMBER, true);
+		UserAccount unverifiedUserAccount = _createMemberUserAccount(
+			_ACCOUNT_ID, "unverified@example.com", _SECOND_USER_ID,
+			RoleConstants.NAME_ACCOUNT_MEMBER, false);
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(eligibleUserAccount, unverifiedUserAccount)
+		);
+
+		_provisioningEmailService.sendAutoProvisionedWelcomeEmail(account);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq(_EMAIL_ADDRESS),
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_notificationQueueEntryService, Mockito.never()
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq("unverified@example.com"),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendPartnerUserUpdateEmailUsesGlobalRecipientTemplate()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		account.setName("Test Account");
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		userAccount.setFamilyName("Doe");
+		userAccount.setGivenName("Jane");
+
+		_provisioningEmailService.sendPartnerUserUpdateEmail(
+			account, userAccount, RoleConstants.NAME_PARTNER_MEMBER,
+			"Assigned");
+
+		ArgumentCaptor<Map<String, String>> placeholdersArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_notificationTemplateService
+		).getAndProcessTemplateJSONObject(
+			Mockito.eq("PROVISIONING-PARTNER-USER-UPDATE"), Mockito.any(),
+			placeholdersArgumentCaptor.capture()
+		);
+
+		Map<String, String> placeholders =
+			placeholdersArgumentCaptor.getValue();
+
+		Assertions.assertTrue(placeholders.containsKey("ACCOUNT_NAME"));
+		Assertions.assertTrue(placeholders.containsKey("ACCOUNT_ROLE"));
+		Assertions.assertTrue(placeholders.containsKey("ACCOUNT_ROLE_ACTION"));
+		Assertions.assertTrue(placeholders.containsKey("USER_EMAIL_ADDRESS"));
+		Assertions.assertTrue(placeholders.containsKey("USER_FIRST_NAME"));
+		Assertions.assertTrue(placeholders.containsKey("USER_LAST_NAME"));
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			_EMAIL_ADDRESS_GLOBAL, "Liferay Provisioning",
+			_PARTNER_USER_UPDATE_RECIPIENT, "Subject", "Body"
+		);
+	}
+
+	@Test
+	public void testSendVerifiedWelcomeEmailFallsBackToGlobalForMixedRegions()
+		throws Exception {
+
+		Account usAccount = _createAccount(_ACCOUNT_ID);
+		Account brazilAccount = _createAccount(_SECOND_ACCOUNT_ID);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ID)
+		).thenReturn(
+			usAccount
+		);
+
+		Mockito.when(
+			_accountService.fetchAccount(_SECOND_ACCOUNT_ID)
+		).thenReturn(
+			brazilAccount
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(
+				_SECOND_ACCOUNT_ID, null)
+		).thenReturn(
+			new AccountSupportInfo("pt_BR", SupportRegionConstants.BRAZIL)
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_SECOND_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		UserAccount userAccount = _createUserAccountWithAccountBriefs(
+			_EMAIL_ADDRESS, _USER_ID, RoleConstants.NAME_ACCOUNT_MEMBER,
+			_ACCOUNT_ID, _SECOND_ACCOUNT_ID);
+
+		_provisioningEmailService.sendVerifiedWelcomeEmail(userAccount);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			_EMAIL_ADDRESS_GLOBAL, "Liferay Provisioning", _EMAIL_ADDRESS,
+			"Subject", "Body"
+		);
+	}
+
+	@Test
+	public void testSendVerifiedWelcomeEmailIncludesInvitationForMultipleProjects()
+		throws Exception {
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ID)
+		).thenReturn(
+			_createAccount(_ACCOUNT_ID)
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_projectMembershipService.getProjectMemberships(
+				_ACCOUNT_ID, _USER_ID)
+		).thenReturn(
+			List.of(
+				_createProjectMembership("PROJECT-ERC-1"),
+				_createProjectMembership("PROJECT-ERC-2"))
+		);
+
+		Mockito.when(
+			_projectService.fetchProject("PROJECT-ERC-1")
+		).thenReturn(
+			_createProject("PROJECT-ERC-1", "First Project")
+		);
+
+		Mockito.when(
+			_projectService.fetchProject("PROJECT-ERC-2")
+		).thenReturn(
+			_createProject("PROJECT-ERC-2", "Second Project")
+		);
+
+		UserAccount userAccount = _createUserAccountWithAccountBriefs(
+			_EMAIL_ADDRESS, _USER_ID, RoleConstants.NAME_ACCOUNT_MEMBER,
+			_ACCOUNT_ID);
+
+		_provisioningEmailService.sendVerifiedWelcomeEmail(userAccount);
+
+		ArgumentCaptor<Map<String, String>> placeholdersArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_notificationTemplateService
+		).getAndProcessTemplateJSONObject(
+			Mockito.eq("PROVISIONING-WELCOME"), Mockito.any(),
+			placeholdersArgumentCaptor.capture()
+		);
+
+		Map<String, String> placeholders =
+			placeholdersArgumentCaptor.getValue();
+
+		Assertions.assertEquals("", placeholders.get("PROJECT_KEY"));
+		Assertions.assertEquals("", placeholders.get("PROJECT_NAME_SUFFIX"));
+		Assertions.assertTrue(
+			placeholders.get(
+				"PROJECT_INVITATION_MESSAGE"
+			).contains(
+				"First Project"
+			));
+		Assertions.assertTrue(
+			placeholders.get(
+				"PROJECT_INVITATION_MESSAGE"
+			).contains(
+				"Second Project"
+			));
+	}
+
+	@Test
+	public void testSendVerifiedWelcomeEmailIncludesPartnerAccount()
+		throws Exception {
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ID)
+		).thenReturn(
+			_createAccount(_ACCOUNT_ID)
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAME_PARTNER)
+		).thenReturn(
+			true
+		);
+
+		UserAccount userAccount = _createUserAccountWithAccountBriefs(
+			_EMAIL_ADDRESS, _USER_ID, RoleConstants.NAME_PARTNER_MEMBER,
+			_ACCOUNT_ID);
+
+		_provisioningEmailService.sendVerifiedWelcomeEmail(userAccount);
+
+		Mockito.verify(
+			_accountService
+		).fetchAccount(
+			_ACCOUNT_ID
+		);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq(_EMAIL_ADDRESS),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendVerifiedWelcomeEmailSkipsWhenNoEligibleAccounts()
+		throws Exception {
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		userAccount.setId(_USER_ID);
+
+		_provisioningEmailService.sendVerifiedWelcomeEmail(userAccount);
+
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	@Test
+	public void testSendWelcomeEmailsRoutesExistingBusinessToAssigned()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount userAccount = _createVerifiedUserAccount(_USER_ID);
+
+		Mockito.when(
+			_userAccountService.getUserAccount(_USER_ID)
+		).thenReturn(
+			userAccount
+		);
+
+		Mockito.when(
+			_entitlementService.hasEntitlement(
+				_ACCOUNT_ID, EntitlementConstants.NAMES_SLAS)
+		).thenReturn(
+			true
+		);
+
+		_provisioningEmailService.sendWelcomeEmails(
+			account, OpportunityConstants.TYPE_EXISTING_BUSINESS,
+			List.of(_USER_ID));
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAssignedWelcomeEmails(
+			account, List.of(_USER_ID)
+		);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			_EMAIL_ADDRESS_US, "Liferay Provisioning", _EMAIL_ADDRESS,
+			"Subject", "Body"
+		);
+	}
+
+	@Test
+	public void testSendWelcomeEmailsRoutesNewBusinessToAutoProvisioned()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount eligibleUserAccount = _createMemberUserAccount(
+			_ACCOUNT_ID, _EMAIL_ADDRESS, _USER_ID,
+			RoleConstants.NAME_ACCOUNT_MEMBER, true);
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(eligibleUserAccount)
+		);
+
+		_provisioningEmailService.sendWelcomeEmails(
+			account, OpportunityConstants.TYPE_NEW_BUSINESS, List.of());
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAutoProvisionedWelcomeEmail(
+			account
+		);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq(_EMAIL_ADDRESS),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendWelcomeEmailsRoutesNewProjectExistingBusinessToAutoProvisioned()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		UserAccount eligibleUserAccount = _createMemberUserAccount(
+			_ACCOUNT_ID, _EMAIL_ADDRESS, _USER_ID,
+			RoleConstants.NAME_ACCOUNT_MEMBER, true);
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(eligibleUserAccount)
+		);
+
+		_provisioningEmailService.sendWelcomeEmails(
+			account, OpportunityConstants.TYPE_NEW_PROJECT_EXISTING_BUSINESS,
+			List.of());
+
+		Mockito.verify(
+			_provisioningEmailService
+		).sendAutoProvisionedWelcomeEmail(
+			account
+		);
+
+		Mockito.verify(
+			_notificationQueueEntryService
+		).addNotificationQueueEntry(
+			Mockito.any(), Mockito.any(), Mockito.eq(_EMAIL_ADDRESS),
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSendWelcomeEmailsRoutesRenewalToNoOp() throws Exception {
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		_provisioningEmailService.sendWelcomeEmails(
+			account, OpportunityConstants.TYPE_RENEWAL, List.of());
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.never()
+		).sendAutoProvisionedWelcomeEmail(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_provisioningEmailService, Mockito.never()
+		).sendAssignedWelcomeEmails(
+			Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	@Test
+	public void testSendWelcomeEmailsSwallowsAutoProvisionedFailure()
+		throws Exception {
+
+		Account account = _createAccount(_ACCOUNT_ID);
+
+		Mockito.when(
+			_userAccountService.getAccountUserAccounts(_ACCOUNT_ID)
+		).thenThrow(
+			new RuntimeException("Unable to fetch account user accounts")
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _provisioningEmailService.sendWelcomeEmails(
+				account, OpportunityConstants.TYPE_NEW_BUSINESS, List.of()));
+
+		Mockito.verifyNoInteractions(_notificationQueueEntryService);
+	}
+
+	private Account _createAccount(long id) {
+		Account account = new Account();
+
+		account.setId(id);
+
+		return account;
+	}
+
+	private UserAccount _createMemberUserAccount(
+		long accountId, String emailAddress, long id, String roleName,
+		boolean verified) {
+
+		RoleBrief roleBrief = new RoleBrief();
+
+		roleBrief.setName(roleName);
+
+		AccountBrief accountBrief = new AccountBrief();
+
+		accountBrief.setId(accountId);
+		accountBrief.setRoleBriefs(new RoleBrief[] {roleBrief});
+
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setAccountBriefs(new AccountBrief[] {accountBrief});
+		userAccount.setEmailAddress(emailAddress);
+		userAccount.setId(id);
+
+		if (verified) {
+			CustomValue customValue = new CustomValue();
+
+			customValue.setData(true);
+
+			CustomField customField = new CustomField();
+
+			customField.setCustomValue(customValue);
+			customField.setName("verified");
+
+			userAccount.setCustomFields(new CustomField[] {customField});
+		}
+
+		return userAccount;
+	}
+
+	private Project _createProject(String externalReferenceCode, String name) {
+		return new Project(
+			new JSONObject(
+			).put(
+				"externalReferenceCode", externalReferenceCode
+			).put(
+				"name", name
+			));
+	}
+
+	private ProjectMembership _createProjectMembership(
+		String projectExternalReferenceCode) {
+
+		return new ProjectMembership(
+			new JSONObject(
+			).put(
+				"r_projectToProjectMembership_c_projectERC",
+				projectExternalReferenceCode
+			));
+	}
+
+	private UserAccount _createUserAccountWithAccountBriefs(
+		String emailAddress, long id, String roleName, long... accountIds) {
+
+		AccountBrief[] accountBriefs = new AccountBrief[accountIds.length];
+
+		for (int i = 0; i < accountIds.length; i++) {
+			RoleBrief roleBrief = new RoleBrief();
+
+			roleBrief.setName(roleName);
+
+			AccountBrief accountBrief = new AccountBrief();
+
+			accountBrief.setId(accountIds[i]);
+			accountBrief.setRoleBriefs(new RoleBrief[] {roleBrief});
+
+			accountBriefs[i] = accountBrief;
+		}
+
+		UserAccount userAccount = _createVerifiedUserAccount(id);
+
+		userAccount.setAccountBriefs(accountBriefs);
+		userAccount.setEmailAddress(emailAddress);
+
+		return userAccount;
+	}
+
+	private UserAccount _createVerifiedUserAccount(long id) {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setEmailAddress(_EMAIL_ADDRESS);
+		userAccount.setId(id);
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(true);
+
+		CustomField customField = new CustomField();
+
+		customField.setCustomValue(customValue);
+		customField.setName("verified");
+
+		userAccount.setCustomFields(new CustomField[] {customField});
+
+		return userAccount;
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final String _EMAIL_ADDRESS = "contact@example.com";
+
+	private static final String _EMAIL_ADDRESS_GLOBAL = "global@example.com";
+
+	private static final String _EMAIL_ADDRESS_US = "us@example.com";
+
+	private static final String _PARTNER_USER_UPDATE_RECIPIENT =
+		"partner-update@example.com";
+
+	private static final long _SECOND_ACCOUNT_ID = 2000L;
+
+	private static final long _SECOND_USER_ID = 200L;
+
+	private static final long _USER_ID = 100L;
+
+	private AccountService _accountService;
+	private CommerceOrderService _commerceOrderService;
+	private EntitlementService _entitlementService;
+	private MessageSource _messageSource;
+	private NotificationQueueEntryService _notificationQueueEntryService;
+	private NotificationTemplateService _notificationTemplateService;
+	private ProjectMembershipService _projectMembershipService;
+	private ProjectService _projectService;
+	private ProvisioningEmailService _provisioningEmailService;
+	private UserAccountService _userAccountService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningIssueServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningIssueServiceTest.java
@@ -1,0 +1,417 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.jira.service.JiraIssueService;
+import com.liferay.one.pubsub.Message;
+import com.liferay.one.salesforce.model.SalesforceAccount;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceOpportunity;
+import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
+import com.liferay.portal.kernel.util.ListUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningIssueServiceTest {
+
+	@BeforeEach
+	public void setUp() {
+		_provisioningIssueService = new ProvisioningIssueService();
+
+		_jiraIssueService = Mockito.mock(JiraIssueService.class);
+
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueProvisioningFieldCountry",
+			"customfield_country");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueProvisioningFieldOffering",
+			"customfield_offering");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService,
+			"_jiraIssueProvisioningFieldOrganization",
+			"customfield_organization");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueProvisioningFieldOwner",
+			"customfield_owner");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService,
+			"_jiraIssueProvisioningFieldProvisioningComponent",
+			"customfield_provisioning_component");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService,
+			"_jiraIssueProvisioningFieldSupportRegion",
+			"customfield_support_region");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueProvisioningId", "10001");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueProvisioningOfferingId",
+			"20001");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueService", _jiraIssueService);
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraIssueSupportHCFieldRequestType",
+			"customfield_request_type");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraOrganizationProvisioningId",
+			"30001");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraProjectSupportHC", "SUPPORTHC");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraRequestProvisioningId", "40001");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_jiraWorkspaceId", "WORKSPACE-1");
+		ReflectionTestUtils.setField(
+			_provisioningIssueService, "_portalURL", "https://one.liferay.com");
+	}
+
+	@Test
+	public void testAddErrorIssueSwallowsFailure() throws Exception {
+		Mockito.when(
+			_jiraIssueService.addIssue(
+				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.any())
+		).thenThrow(
+			new RuntimeException("Unable to add issue")
+		);
+
+		Message message = new Message(
+			Collections.emptyMap(), "{}", "test-topic");
+
+		Assertions.assertDoesNotThrow(
+			() -> _provisioningIssueService.addErrorIssue(
+				message, new RuntimeException("boom")));
+	}
+
+	@Test
+	public void testAddErrorIssueUsesGenericSummary() throws Exception {
+		Message message = new Message(
+			Collections.emptyMap(), "{}", "test-topic");
+
+		_provisioningIssueService.addErrorIssue(
+			message, new RuntimeException("boom"));
+
+		ArgumentCaptor<Map<String, Object>> customFieldsArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+		ArgumentCaptor<String> summaryArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			customFieldsArgumentCaptor.capture(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC),
+			summaryArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals(
+			"Auto-Provisioning Error", summaryArgumentCaptor.getValue());
+
+		JSONArray labelsJSONArray =
+			(JSONArray)customFieldsArgumentCaptor.getValue(
+			).get(
+				"labels"
+			);
+
+		Assertions.assertTrue(
+			labelsJSONArray.toList(
+			).contains(
+				"auto-generated"
+			));
+		Assertions.assertTrue(
+			labelsJSONArray.toList(
+			).contains(
+				"provisioning-error"
+			));
+	}
+
+	@Test
+	public void testAddErrorIssueWithRecordIncludesOpportunityId()
+		throws Exception {
+
+		Message message = new Message(
+			Collections.emptyMap(), "{}", "test-topic");
+
+		JSONObject recordJSONObject = new JSONObject(
+		).put(
+			"opportunity",
+			new JSONObject(
+			).put(
+				"Id", _OPPORTUNITY_ID
+			)
+		);
+
+		_provisioningIssueService.addErrorIssue(
+			message, recordJSONObject, new RuntimeException("boom"));
+
+		ArgumentCaptor<String> summaryArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			Mockito.any(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC),
+			summaryArgumentCaptor.capture()
+		);
+
+		Assertions.assertEquals(
+			"Auto-Provisioning Error for opportunity " + _OPPORTUNITY_ID,
+			summaryArgumentCaptor.getValue());
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssueIncludesCountryAndOwnerWhenPresent()
+		throws Exception {
+
+		_invokeAddOpportunityInvoicedIssue(
+			"US", "owner@example.com", Collections.emptyList());
+
+		ArgumentCaptor<Map<String, Object>> customFieldsArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			customFieldsArgumentCaptor.capture(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC), Mockito.any()
+		);
+
+		Map<String, Object> customFields =
+			customFieldsArgumentCaptor.getValue();
+
+		Assertions.assertEquals("US", customFields.get("customfield_country"));
+		Assertions.assertEquals(
+			"owner@example.com", customFields.get("customfield_owner"));
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssueOmitsCountryAndOwnerWhenBlank()
+		throws Exception {
+
+		_invokeAddOpportunityInvoicedIssue("", "", Collections.emptyList());
+
+		ArgumentCaptor<Map<String, Object>> customFieldsArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			customFieldsArgumentCaptor.capture(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC), Mockito.any()
+		);
+
+		Map<String, Object> customFields =
+			customFieldsArgumentCaptor.getValue();
+
+		Assertions.assertFalse(customFields.containsKey("customfield_country"));
+		Assertions.assertFalse(customFields.containsKey("customfield_owner"));
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssuePinsSupportRegionAndOrganizationFields()
+		throws Exception {
+
+		_invokeAddOpportunityInvoicedIssue(
+			"US", "", "Subscription", "Liferay Brazil",
+			Collections.emptyList());
+
+		ArgumentCaptor<Map<String, Object>> customFieldsArgumentCaptor =
+			ArgumentCaptor.forClass(Map.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			customFieldsArgumentCaptor.capture(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC), Mockito.any()
+		);
+
+		Map<String, Object> customFields =
+			customFieldsArgumentCaptor.getValue();
+
+		JSONObject supportRegionJSONObject = (JSONObject)customFields.get(
+			"customfield_support_region");
+
+		Assertions.assertEquals(
+			"Brazil", supportRegionJSONObject.getString("value"));
+
+		JSONArray offeringJSONArray = (JSONArray)customFields.get(
+			"customfield_offering");
+
+		Assertions.assertEquals(
+			"WORKSPACE-1:20001",
+			offeringJSONArray.getJSONObject(
+				0
+			).getString(
+				"id"
+			));
+
+		JSONArray organizationJSONArray = (JSONArray)customFields.get(
+			"customfield_organization");
+
+		Assertions.assertEquals(
+			"WORKSPACE-1:30001",
+			organizationJSONArray.getJSONObject(
+				0
+			).getString(
+				"id"
+			));
+
+		Assertions.assertEquals(
+			"40001", customFields.get("customfield_request_type"));
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssuePrefixesWarningIndicator()
+		throws Exception {
+
+		_invokeAddOpportunityInvoicedIssue(
+			"US", "", List.of("Something went wrong"));
+
+		ArgumentCaptor<String> summaryArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			Mockito.any(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC),
+			summaryArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			summaryArgumentCaptor.getValue(
+			).startsWith(
+				"[Warning] "
+			));
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssueSummaryContainsAccountNameAndProductType()
+		throws Exception {
+
+		_invokeAddOpportunityInvoicedIssue(
+			"US", "", "License", Collections.emptyList());
+
+		ArgumentCaptor<String> summaryArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_jiraIssueService
+		).addIssue(
+			Mockito.any(), Mockito.any(),
+			Mockito.eq(_JIRA_ISSUE_PROVISIONING_ID),
+			Mockito.eq(_JIRA_PROJECT_SUPPORT_HC),
+			summaryArgumentCaptor.capture()
+		);
+
+		String summary = summaryArgumentCaptor.getValue();
+
+		Assertions.assertFalse(summary.startsWith("[Warning] "));
+		Assertions.assertTrue(summary.contains(_ACCOUNT_NAME));
+		Assertions.assertTrue(summary.contains("License"));
+	}
+
+	@Test
+	public void testAddOpportunityInvoicedIssueSwallowsFailure()
+		throws Exception {
+
+		Mockito.when(
+			_jiraIssueService.addIssue(
+				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.any())
+		).thenThrow(
+			new RuntimeException("Unable to add issue")
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _invokeAddOpportunityInvoicedIssue(
+				"US", "", Collections.emptyList()));
+	}
+
+	private void _invokeAddOpportunityInvoicedIssue(
+		String billingCountry, String ownerEmail,
+		List<String> warningMessages) {
+
+		_invokeAddOpportunityInvoicedIssue(
+			billingCountry, ownerEmail, "Subscription", warningMessages);
+	}
+
+	private void _invokeAddOpportunityInvoicedIssue(
+		String billingCountry, String ownerEmail, String productType,
+		List<String> warningMessages) {
+
+		_invokeAddOpportunityInvoicedIssue(
+			billingCountry, ownerEmail, productType, "", warningMessages);
+	}
+
+	private void _invokeAddOpportunityInvoicedIssue(
+		String billingCountry, String ownerEmail, String productType,
+		String soldBy, List<String> warningMessages) {
+
+		Account account = new Account();
+
+		account.setExternalReferenceCode(_ACCOUNT_ERC);
+		account.setName(_ACCOUNT_NAME);
+
+		SalesforceAccount salesforceAccount = new SalesforceAccount(
+			SalesforceModelTestUtil.createAccountJSONObject(
+				billingCountry, _ACCOUNT_ERC, _ACCOUNT_NAME));
+
+		SalesforceOpportunity salesforceOpportunity = new SalesforceOpportunity(
+			SalesforceModelTestUtil.createOpportunityJSONObject(
+				_ACCOUNT_ERC, "", false, _OPPORTUNITY_ID, ownerEmail, "E", "",
+				soldBy, "Closed Won", "New Business"));
+
+		List<SalesforceOpportunityLineItem> salesforceOpportunityLineItems =
+			ListUtil.fromArray(
+				new SalesforceOpportunityLineItem(
+					SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+						"USD", null, "LINE-1", "PROD-1", "Widget", productType,
+						5, null)));
+
+		_provisioningIssueService.addOpportunityInvoicedIssue(
+			account, salesforceAccount, salesforceOpportunity,
+			salesforceOpportunityLineItems, warningMessages);
+	}
+
+	private static final String _ACCOUNT_ERC = "ACCOUNT-1";
+
+	private static final String _ACCOUNT_NAME = "Test Account";
+
+	private static final String _JIRA_ISSUE_PROVISIONING_ID = "10001";
+
+	private static final String _JIRA_PROJECT_SUPPORT_HC = "SUPPORTHC";
+
+	private static final String _OPPORTUNITY_ID = "OPP-1";
+
+	private JiraIssueService _jiraIssueService;
+	private ProvisioningIssueService _provisioningIssueService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningOrderServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningOrderServiceTest.java
@@ -1,0 +1,445 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
+import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningOrderServiceTest {
+
+	@BeforeEach
+	public void setUp() {
+		_provisioningOrderService = new ProvisioningOrderService();
+
+		_commerceOrderItemService = Mockito.mock(
+			CommerceOrderItemService.class);
+		_commerceOrderService = Mockito.mock(CommerceOrderService.class);
+		_entitlementService = Mockito.mock(EntitlementService.class);
+
+		ReflectionTestUtils.setField(
+			_provisioningOrderService, "_commerceOrderItemService",
+			_commerceOrderItemService);
+		ReflectionTestUtils.setField(
+			_provisioningOrderService, "_commerceOrderService",
+			_commerceOrderService);
+		ReflectionTestUtils.setField(
+			_provisioningOrderService, "_entitlementService",
+			_entitlementService);
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsExcludesTheCurrentOrder()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		Order currentOrder = new Order();
+
+		currentOrder.setCustomFields(
+			Map.of("parentOpportunityId", _PARENT_OPPORTUNITY_ID));
+		currentOrder.setExternalReferenceCode(_OPPORTUNITY_ID);
+		currentOrder.setOrderItems(new OrderItem[] {orderItem});
+
+		Mockito.when(
+			_commerceOrderService.getAccountOrders(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(currentOrder)
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Mockito.verifyNoInteractions(_entitlementService);
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"Unable to find an order item for amended line"
+			));
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsMatchesFamilyOrderViaCustomFields()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		Order order = new Order();
+
+		order.setCustomFields(
+			Map.of("parentOpportunityId", _PARENT_OPPORTUNITY_ID));
+		order.setExternalReferenceCode("OPP-FAMILY-CHILD");
+		order.setOrderItems(new OrderItem[] {orderItem});
+
+		Mockito.when(
+			_commerceOrderService.getAccountOrders(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(order)
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verify(
+			_commerceOrderItemService
+		).patchOrderItemCustomFields(
+			5001L, Map.of("effectiveEndDate", "2026-01-01T00:00:00Z")
+		);
+
+		Mockito.verify(
+			_entitlementService
+		).trimEntitlements(
+			5001L, "2026-01-01T00:00:00Z"
+		);
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsPatchesApprovedOrderItem()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verify(
+			_commerceOrderItemService
+		).patchOrderItemCustomFields(
+			5001L, Map.of("effectiveEndDate", "2026-01-01T00:00:00Z")
+		);
+
+		Mockito.verify(
+			_entitlementService
+		).trimEntitlements(
+			5001L, "2026-01-01T00:00:00Z"
+		);
+
+		boolean hasMismatchWarning = false;
+
+		for (String warningMessage : warningMessages) {
+			if (warningMessage.contains("End date mismatch")) {
+				hasMismatchWarning = true;
+			}
+		}
+
+		Assertions.assertTrue(hasMismatchWarning);
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsPatchesWhenExistingEffectiveEndDateIsAfterAmendedDate()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", "2027-01-01T00:00:00Z", "2025-01-01T00:00:00Z",
+			"ORDER-ITEM-1", 5001L, _PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verify(
+			_commerceOrderItemService
+		).patchOrderItemCustomFields(
+			5001L, Map.of("effectiveEndDate", "2026-01-01T00:00:00Z")
+		);
+
+		Mockito.verify(
+			_entitlementService
+		).trimEntitlements(
+			5001L, "2026-01-01T00:00:00Z"
+		);
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsSkipsMatchingDates()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-06-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2025-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Mockito.verifyNoInteractions(_entitlementService);
+		Assertions.assertEquals(0, warningMessages.size());
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsSkipsOrderOutsideFamily()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		Order otherOrder = new Order();
+
+		otherOrder.setCustomFields(
+			Map.of("parentOpportunityId", "OPP-UNRELATED"));
+		otherOrder.setExternalReferenceCode("OPP-OTHER");
+		otherOrder.setOrderItems(new OrderItem[] {orderItem});
+
+		Mockito.when(
+			_commerceOrderService.getAccountOrders(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(otherOrder)
+		);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Mockito.verifyNoInteractions(_entitlementService);
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"Unable to find an order item for amended line"
+			));
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsSkipsPatchWhenExistingEffectiveEndDateIsNotAfterAmendedDate()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", "2025-06-01T00:00:00Z", "2025-01-01T00:00:00Z",
+			"ORDER-ITEM-1", 5001L, _PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+
+		Mockito.verify(
+			_entitlementService
+		).trimEntitlements(
+			5001L, "2026-01-01T00:00:00Z"
+		);
+
+		Assertions.assertEquals(0, warningMessages.size());
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsSkipsUnapprovedOrderItem()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Pending", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, "2024-01-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Mockito.verifyNoInteractions(_entitlementService);
+		Assertions.assertEquals(0, warningMessages.size());
+	}
+
+	@Test
+	public void testTrimRealignedOrderItemsWarnsWhenNoOrderItemMatches()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			"OTHER-SKU", "2024-01-01T00:00:00Z");
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRealignedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID, _PARENT_OPPORTUNITY_ID,
+			List.of(_createRealignmentLineItem("2026-01-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Mockito.verifyNoInteractions(_entitlementService);
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"Unable to find an order item for amended line"
+			));
+	}
+
+	@Test
+	public void testTrimRenewedOrderItemsPatchesEffectiveEndDate()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", "2025-06-01T00:00:00Z", "2025-01-01T00:00:00Z",
+			"ORDER-ITEM-1", 5001L, _PRODUCT_2_ID, null);
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRenewedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID,
+			List.of(_createRenewalLineItem("2025-02-01")), warningMessages);
+
+		Mockito.verify(
+			_commerceOrderItemService
+		).patchOrderItemCustomFields(
+			5001L, Map.of("effectiveEndDate", "2025-02-01T00:00:00Z")
+		);
+
+		Assertions.assertEquals(0, warningMessages.size());
+	}
+
+	@Test
+	public void testTrimRenewedOrderItemsSkipsWhenEffectiveEndDateIsAbsent()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", null, "2025-01-01T00:00:00Z", "ORDER-ITEM-1", 5001L,
+			_PRODUCT_2_ID, null);
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRenewedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID,
+			List.of(_createRenewalLineItem("2025-02-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Assertions.assertEquals(0, warningMessages.size());
+	}
+
+	@Test
+	public void testTrimRenewedOrderItemsWarnsWhenStartIsBeforeEndDate()
+		throws Exception {
+
+		OrderItem orderItem = SalesforceModelTestUtil.createOrderItem(
+			"Approved", "2025-06-01T00:00:00Z", "2025-01-01T00:00:00Z",
+			"ORDER-ITEM-1", 5001L, _PRODUCT_2_ID, null);
+
+		_stubFamilyOrder(orderItem);
+
+		List<String> warningMessages = new ArrayList<>();
+
+		_provisioningOrderService.trimRenewedOrderItems(
+			_ACCOUNT_ID, _OPPORTUNITY_ID,
+			List.of(_createRenewalLineItem("2024-12-01")), warningMessages);
+
+		Mockito.verifyNoInteractions(_commerceOrderItemService);
+		Assertions.assertEquals(1, warningMessages.size());
+		Assertions.assertTrue(
+			warningMessages.get(
+				0
+			).contains(
+				"is before the end date"
+			));
+	}
+
+	private SalesforceOpportunityLineItem _createRealignmentLineItem(
+		String endDate) {
+
+		return new SalesforceOpportunityLineItem(
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", endDate, "LINE-1", _PRODUCT_2_ID, "Widget",
+				"Subscription", 0, "2024-06-01"));
+	}
+
+	private SalesforceOpportunityLineItem _createRenewalLineItem(
+		String serviceDate) {
+
+		return new SalesforceOpportunityLineItem(
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", _PRODUCT_2_ID, "Widget", "Subscription",
+				5, serviceDate));
+	}
+
+	private void _stubFamilyOrder(OrderItem orderItem) throws Exception {
+		Order order = new Order();
+
+		order.setExternalReferenceCode(_PARENT_OPPORTUNITY_ID);
+		order.setOrderItems(new OrderItem[] {orderItem});
+
+		Mockito.when(
+			_commerceOrderService.getAccountOrders(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(order)
+		);
+	}
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private static final String _OPPORTUNITY_ID = "OPP-1";
+
+	private static final String _PARENT_OPPORTUNITY_ID = "OPP-PARENT";
+
+	private static final String _PRODUCT_2_ID = "PROD-1";
+
+	private CommerceOrderItemService _commerceOrderItemService;
+	private CommerceOrderService _commerceOrderService;
+	private EntitlementService _entitlementService;
+	private ProvisioningOrderService _provisioningOrderService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningSubdomainServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/ProvisioningSubdomainServiceTest.java
@@ -1,0 +1,282 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.service;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.constants.PropertyConstants;
+import com.liferay.one.model.Property;
+import com.liferay.one.okta.service.OktaService;
+import com.liferay.one.salesforce.model.SalesforceModelTestUtil;
+import com.liferay.one.salesforce.model.SalesforceOpportunityLineItem;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Felipe Franca
+ */
+public class ProvisioningSubdomainServiceTest {
+
+	@BeforeEach
+	public void setUp() {
+		_provisioningSubdomainService = new ProvisioningSubdomainService();
+
+		_oktaService = Mockito.mock(OktaService.class);
+		_propertyService = Mockito.mock(PropertyService.class);
+
+		_account = new Account();
+
+		_account.setExternalReferenceCode(_ACCOUNT_ERC);
+		_account.setId(_ACCOUNT_ID);
+
+		ReflectionTestUtils.setField(
+			_provisioningSubdomainService, "_oktaService", _oktaService);
+		ReflectionTestUtils.setField(
+			_provisioningSubdomainService, "_propertyService",
+			_propertyService);
+	}
+
+	@Test
+	public void testProvisionSubdomainGeneratesAndAssignsSubdomain()
+		throws Exception {
+
+		Mockito.when(
+			_propertyService.getProperties(Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_provisioningSubdomainService.provisionSubdomain(
+			_account, List.of(_createPaasExperienceLineItem()));
+
+		ArgumentCaptor<String> subdomainArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.verify(
+			_propertyService
+		).addProperty(
+			Mockito.eq(_ACCOUNT_ID),
+			Mockito.eq(PropertyConstants.NAME_CLOUD_NATIVE_SUBDOMAIN),
+			subdomainArgumentCaptor.capture()
+		);
+
+		String subdomain = subdomainArgumentCaptor.getValue();
+
+		Assertions.assertEquals(8, subdomain.length());
+		Assertions.assertTrue(subdomain.matches("[a-z]{8}"));
+
+		ArgumentCaptor<String> filterArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_propertyService
+		).getProperties(
+			filterArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			filterArgumentCaptor.getValue(
+			).contains(
+				"value eq '" + subdomain + "'"
+			));
+		Assertions.assertTrue(
+			filterArgumentCaptor.getValue(
+			).contains(
+				"name eq '" + PropertyConstants.NAME_CLOUD_NATIVE_SUBDOMAIN +
+					"'"
+			));
+
+		Mockito.verify(
+			_oktaService
+		).createApplication(
+			_ACCOUNT_ERC, subdomain
+		);
+	}
+
+	@Test
+	public void testProvisionSubdomainRetriesOnCollisionThenSucceeds()
+		throws Exception {
+
+		Property existingProperty = new Property(
+			new JSONObject(
+			).put(
+				"id", 1L
+			));
+
+		Mockito.when(
+			_propertyService.getProperties(Mockito.anyString())
+		).thenReturn(
+			List.of(existingProperty)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		_provisioningSubdomainService.provisionSubdomain(
+			_account, List.of(_createPaasExperienceLineItem()));
+
+		ArgumentCaptor<String> filterArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			_propertyService, Mockito.times(2)
+		).getProperties(
+			filterArgumentCaptor.capture()
+		);
+
+		List<String> filters = filterArgumentCaptor.getAllValues();
+
+		Assertions.assertNotEquals(filters.get(0), filters.get(1));
+
+		ArgumentCaptor<String> subdomainArgumentCaptor =
+			ArgumentCaptor.forClass(String.class);
+
+		Mockito.verify(
+			_propertyService
+		).addProperty(
+			Mockito.eq(_ACCOUNT_ID),
+			Mockito.eq(PropertyConstants.NAME_CLOUD_NATIVE_SUBDOMAIN),
+			subdomainArgumentCaptor.capture()
+		);
+
+		Assertions.assertTrue(
+			filters.get(
+				1
+			).contains(
+				"value eq '" + subdomainArgumentCaptor.getValue() + "'"
+			));
+	}
+
+	@Test
+	public void testProvisionSubdomainSkipsWhenNoPaasExperienceLine()
+		throws Exception {
+
+		SalesforceOpportunityLineItem lineItem =
+			new SalesforceOpportunityLineItem(
+				SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+					"USD", null, "LINE-1", "PROD-1", "Other Product",
+					"Subscription", 5, null));
+
+		_provisioningSubdomainService.provisionSubdomain(
+			_account, List.of(lineItem));
+
+		Mockito.verifyNoInteractions(_propertyService);
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testProvisionSubdomainSkipsWhenSubdomainAlreadyExists()
+		throws Exception {
+
+		Mockito.when(
+			_propertyService.getPropertyValue(
+				_ACCOUNT_ID, PropertyConstants.NAME_CLOUD_NATIVE_SUBDOMAIN)
+		).thenReturn(
+			"existing-subdomain"
+		);
+
+		_provisioningSubdomainService.provisionSubdomain(
+			_account, List.of(_createPaasExperienceLineItem()));
+
+		Mockito.verify(
+			_propertyService, Mockito.never()
+		).addProperty(
+			Mockito.anyLong(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testProvisionSubdomainStopsAfterExhaustingAttempts()
+		throws Exception {
+
+		Property existingProperty = new Property(
+			new JSONObject(
+			).put(
+				"id", 1L
+			));
+
+		Mockito.when(
+			_propertyService.getProperties(Mockito.anyString())
+		).thenReturn(
+			List.of(existingProperty)
+		);
+
+		_provisioningSubdomainService.provisionSubdomain(
+			_account, List.of(_createPaasExperienceLineItem()));
+
+		Mockito.verify(
+			_propertyService, Mockito.times(20)
+		).getProperties(
+			Mockito.anyString()
+		);
+
+		Mockito.verify(
+			_propertyService, Mockito.never()
+		).addProperty(
+			Mockito.anyLong(), Mockito.any(), Mockito.any()
+		);
+
+		Mockito.verifyNoInteractions(_oktaService);
+	}
+
+	@Test
+	public void testProvisionSubdomainSwallowsOktaFailure() throws Exception {
+		Mockito.when(
+			_propertyService.getProperties(Mockito.anyString())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		Mockito.doThrow(
+			new RuntimeException("Unable to create Okta application")
+		).when(
+			_oktaService
+		).createApplication(
+			Mockito.any(), Mockito.any()
+		);
+
+		Assertions.assertDoesNotThrow(
+			() -> _provisioningSubdomainService.provisionSubdomain(
+				_account, List.of(_createPaasExperienceLineItem())));
+
+		Mockito.verify(
+			_propertyService
+		).addProperty(
+			Mockito.eq(_ACCOUNT_ID),
+			Mockito.eq(PropertyConstants.NAME_CLOUD_NATIVE_SUBDOMAIN),
+			Mockito.any()
+		);
+	}
+
+	private SalesforceOpportunityLineItem _createPaasExperienceLineItem() {
+		return new SalesforceOpportunityLineItem(
+			SalesforceModelTestUtil.createOpportunityLineItemJSONObject(
+				"USD", null, "LINE-1", "PROD-1", "PaaS Experience",
+				"Subscription", 1, null));
+	}
+
+	private static final String _ACCOUNT_ERC = "ACCOUNT-1";
+
+	private static final long _ACCOUNT_ID = 1000L;
+
+	private Account _account;
+	private OktaService _oktaService;
+	private PropertyService _propertyService;
+	private ProvisioningSubdomainService _provisioningSubdomainService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99435

## What is being fixed

The Pub/Sub subscribers and the provisioning services they drive had no automated test coverage. A regression in the auto provisioning flow — a subdomain never provisioned, an ineligible opportunity provisioned anyway, a localized welcome email silently falling back to English — could only surface in a running environment.

## How it is being fixed

This adds 188 tests across 14 new test classes covering the five Pub/Sub subscribers and the provisioning services they invoke. Each subscriber is exercised through its happy path, its early return guards, partial and total record failures, malformed and absent-field payloads, and every event type and object name it dispatches on.

Every test was written so that it fails if the behavior it covers regresses, and that property was checked by reasoning about the production line under test rather than by trusting a passing suite. Coverage is bounded to what is reachable and can occur in practice: the topic and subscription bootstrap helpers are unreachable because every subscriber disables auto creation, and the ack and nack contract inside the message receiver cannot be reached without extracting it from its anonymous class, so both are left untested rather than covered by tests that would assert nothing.

No production code is changed.
