### PR TITLE
LPD-99711 Hide the Cloud Native Activation tab for Experience accounts

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/enums/Product.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/enums/Product.ts
@@ -19,6 +19,14 @@ export const ProductEditionOption = {
 export type ProductEditionOption =
 	(typeof ProductEditionOption)[keyof typeof ProductEditionOption];
 
+export const ProductExternalReferenceCode = {
+	PAAS_EXPERIENCE: 'PRDCT-PAAS',
+	SAAS_EXPERIENCE: 'PRDCT-SAAS',
+} as const;
+
+export type ProductExternalReferenceCode =
+	(typeof ProductExternalReferenceCode)[keyof typeof ProductExternalReferenceCode];
+
 export const ProductImageFallbackCategories = {
 	PRODUCT_ICON: 'productIcon',
 	PRODUCT_IMAGE: 'productImage',
@@ -230,6 +238,12 @@ const ALL_OFFERINGS = [
 	ProductOfferingTypes.LIFERAY_SAAS,
 	ProductOfferingTypes.LIFERAY_SELF_HOSTED,
 ];
+
+export const EXPERIENCE_OFFERING_PRODUCT_EXTERNAL_REFERENCE_CODES: readonly ProductExternalReferenceCode[] =
+	[
+		ProductExternalReferenceCode.PAAS_EXPERIENCE,
+		ProductExternalReferenceCode.SAAS_EXPERIENCE,
+	];
 
 const offeringTypes = {
 	'client-extension': ALL_OFFERINGS,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useProjectCommerce.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/hooks/useProjectCommerce.ts
@@ -6,6 +6,7 @@
 import {format} from 'date-fns';
 import {useMemo} from 'react';
 import useSWR from 'swr';
+import {EXPERIENCE_OFFERING_PRODUCT_EXTERNAL_REFERENCE_CODES} from '~/enums/Product';
 import {useFetch} from '~/hooks/useFetch';
 import i18n from '~/i18n';
 import {getProductContactRoleExternalReferenceCodes} from '~/pages/MyAccount/ProjectMembers/projectRoles';
@@ -416,6 +417,47 @@ export function useAccountProducts() {
 	}, [contractsData, productsData]);
 
 	return {loading: contractsLoading || productsLoading, products};
+}
+
+export function useHasActiveExperienceOffering() {
+	const accountId = Liferay.CommerceContext?.account?.accountId;
+
+	const {
+		data,
+		error,
+		isLoading: loading,
+	} = useFetch<APIResponse<ContractNode>>(
+		accountId ? '/o/c/contracts' : null,
+		{
+			params: {
+				filter: `r_accountEntryToContract_accountEntryId eq '${accountId}'`,
+				nestedFields:
+					'commerceOrderItemToEntitlement,contractToEntitlement,entitlementDefinitionToEntitlement',
+				nestedFieldsDepth: 2,
+				pageSize: 100,
+			},
+		}
+	);
+
+	const hasActiveExperienceOffering = useMemo(
+		() =>
+			(data?.items ?? [])
+				.flatMap((contract) =>
+					toProductEntitlements(contract.contractToEntitlement)
+				)
+				.some(
+					(entitlement) =>
+						EXPERIENCE_OFFERING_PRODUCT_EXTERNAL_REFERENCE_CODES.some(
+							(code) =>
+								code ===
+								entitlement.productExternalReferenceCode
+						) &&
+						getEntitlementStatus(entitlement.endDate) === 'active'
+				),
+		[data]
+	);
+
+	return {error, hasActiveExperienceOffering, loading};
 }
 
 export function useAccountProjectContactRoles() {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/ProjectItemDetails/ProjectItemDetails.tsx
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/ProjectItemDetails/ProjectItemDetails.tsx
@@ -12,6 +12,7 @@ import {useDeliveryProduct} from '~/hooks/useDeliveryProduct';
 import {
 	getSpecificationValue,
 	getSpecificationValues,
+	useHasActiveExperienceOffering,
 	useProjectProducts,
 } from '~/hooks/useProjectCommerce';
 import {
@@ -61,6 +62,9 @@ export default function ProjectItemDetails({kind}: ProjectItemDetailsProps) {
 		products,
 	} = useProjectProducts(projectId, selectedContractERC);
 
+	const {hasActiveExperienceOffering, loading: experienceOfferingLoading} =
+		useHasActiveExperienceOffering();
+
 	const productId =
 		products.find((product) => product.externalReferenceCode === itemERC)
 			?.id ?? '';
@@ -75,7 +79,7 @@ export default function ProjectItemDetails({kind}: ProjectItemDetailsProps) {
 		/>
 	);
 
-	if (productsLoading || isLoading) {
+	if (experienceOfferingLoading || productsLoading || isLoading) {
 		return renderMessage('loading');
 	}
 
@@ -98,6 +102,7 @@ export default function ProjectItemDetails({kind}: ProjectItemDetailsProps) {
 		tabKeys,
 		utilizationProfile,
 	} = resolveProductTabConfig({
+		hasActiveExperienceOffering,
 		kind,
 		orderType: orderInfo.orderType,
 		product,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/resolveProductTabConfig.ts
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-custom-element/src/pages/MyAccount/Projects/utils/resolveProductTabConfig.ts
@@ -39,10 +39,12 @@ export type ProductTabConfig = {
 };
 
 export function resolveProductTabConfig({
+	hasActiveExperienceOffering,
 	kind,
 	orderType,
 	product,
 }: {
+	hasActiveExperienceOffering: boolean;
 	kind: ProjectItemKind;
 	orderType?: string;
 	product: DeliveryProduct;
@@ -69,7 +71,11 @@ export function resolveProductTabConfig({
 	const tabPresent: Record<ProjectTabKey, boolean> = {
 		'activation':
 			activationProfile !== 'none' &&
-			!LICENSE_KEY_ACTIVATION_PROFILES.includes(activationProfile),
+			!LICENSE_KEY_ACTIVATION_PROFILES.includes(activationProfile) &&
+			!(
+				activationProfile === 'cloud-native' &&
+				hasActiveExperienceOffering
+			),
 		'details': true,
 		'download': downloadProfile !== 'none',
 		'environment': environmentProfile !== 'none',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99711

## What is being fixed

The Cloud Native product's Activation tab was shown in the One.Liferay Project Management UI even for accounts that already hold an active PaaS Experience or SaaS Experience offering. Those accounts provision Cloud Native environments through the Experience offering itself, so the product's own activation flow does not apply to them and the tab should not appear.

## How it is being fixed

A new `useHasActiveExperienceOffering` hook resolves whether the current account holds an unexpired entitlement for either Experience offering, and `resolveProductTabConfig` takes that as an additional condition on the `activation` tab for the `cloud-native` activation profile. The hook reuses the contracts query the page already issues, with a byte-identical parameter set, so it shares the existing SWR cache entry and adds no network cost on an assigned project.

The check matches on the `PRDCT-PAAS` and `PRDCT-SAAS` product external reference codes rather than on a PaaS/SaaS specification value. The equivalent Customer Portal rule keyed off any PaaS or SaaS purchase, which also hid the tab for accounts holding only legacy or plan-tier products; those siblings share the same profile values, so matching the product code is what keeps the rule narrow enough to avoid repeating that overreach.
