### PR TITLE
LPD-89437 LPD-99655 Add test coverage for com.liferay.one.jira

### DIFF
--- a/workspaces/liferay-one-workspace/.agents/skills/one-pr/SKILL.md
+++ b/workspaces/liferay-one-workspace/.agents/skills/one-pr/SKILL.md
@@ -60,6 +60,7 @@ Name the state in a sentence or two — a note, not a report:
 In every case but the first, **do not push, do not open the pull request, and do not transition the Jira ticket yet.** Ask once, with `AskUserQuestion`, offering these two in this order:
 
 1. **Run `/one-review` first** — the recommendation, and the first option every time. Stop the run here, and hand it back so they can invoke `/one-review` themselves.
+
 1. **Open the pull request anyway** — proceed to everything below, Jira transition included.
 
 Nothing goes out on a default or a shrug. The pull request is opened only when the author picks it, either at that question or by saying so afterward.

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -19,6 +19,7 @@ import com.liferay.one.model.Project;
 import com.liferay.one.okta.model.OktaUser;
 import com.liferay.one.okta.service.OktaService;
 import com.liferay.one.permission.AccountPermission;
+import com.liferay.one.permission.AdminPermission;
 import com.liferay.one.permission.LicenseKeyPermission;
 import com.liferay.one.permission.ProjectMembershipPermission;
 import com.liferay.one.service.AccountInvitationEmailService;
@@ -33,6 +34,7 @@ import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.KeyedLock;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.lang.reflect.Field;
@@ -871,6 +873,63 @@ public class AccountsRestControllerTest {
 	}
 
 	@Test
+	public void testPostSyncToJSMRejectsNonadministrator() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.doThrow(
+			PrincipalException.class
+		).when(
+			_adminPermission
+		).check(
+			Mockito.any()
+		);
+
+		Assertions.assertThrows(
+			PrincipalException.class,
+			() -> accountsRestController.postSyncToJSM(
+				null, _EXTERNAL_REFERENCE_CODE));
+
+		Mockito.verify(
+			_accountSynchronizer, Mockito.never()
+		).syncAccount(
+			Mockito.any()
+		);
+	}
+
+	@Test
+	public void testPostSyncToJSMSyncsAccountForAdministrator()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Account account = _createAccount();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE)
+		).thenReturn(
+			account
+		);
+
+		ResponseEntity<Void> responseEntity =
+			accountsRestController.postSyncToJSM(
+				null, _EXTERNAL_REFERENCE_CODE);
+
+		Assertions.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+		Mockito.verify(
+			_adminPermission
+		).check(
+			Mockito.any()
+		);
+
+		Mockito.verify(
+			_accountSynchronizer
+		).syncAccount(
+			account
+		);
+	}
+
+	@Test
 	public void testPostUserAccountsAccountRoleAssignsAccountRole()
 		throws Exception {
 
@@ -1438,6 +1497,8 @@ public class AccountsRestControllerTest {
 			accountsRestController, "_accountUserAccountSynchronizer",
 			_accountUserAccountSynchronizer);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_adminPermission", _adminPermission);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_emailAddressValidatorService",
 			_emailAddressValidatorService);
 		ReflectionTestUtils.setField(
@@ -1583,6 +1644,8 @@ public class AccountsRestControllerTest {
 	private final AccountUserAccountSynchronizer
 		_accountUserAccountSynchronizer = Mockito.mock(
 			AccountUserAccountSynchronizer.class);
+	private final AdminPermission _adminPermission = Mockito.mock(
+		AdminPermission.class);
 	private final EmailAddressValidatorService _emailAddressValidatorService =
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountContactRoleAssignmentConverterTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.AccountContactRoleAssignmentConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountContactRoleAssignmentConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_accountContactRoleAssignmentConverter =
+			JiraAssetObjectConverterTestUtil.prepare(
+				new AccountContactRoleAssignmentConverter());
+	}
+
+	@Test
+	public void testGetDeletedAttributeNameIsDeleted() {
+		Assertions.assertEquals(
+			AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED,
+			_accountContactRoleAssignmentConverter.getDeletedAttributeName());
+	}
+
+	@Test
+	public void testGetExternalKeyAttributeNameIsName() {
+		Assertions.assertEquals(
+			AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME,
+			_accountContactRoleAssignmentConverter.
+				getExternalKeyAttributeName());
+	}
+
+	@Test
+	public void testGetNameJoinsExternalKeys() {
+		Assertions.assertEquals(
+			"contact-role-erc;contact-erc;account-erc",
+			_accountContactRoleAssignmentConverter.getName(
+				"account-erc", "contact-erc", "contact-role-erc"));
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		JiraAssetObject jiraAssetObject =
+			_accountContactRoleAssignmentConverter.toAssetObject(
+				"contact-role-erc", "contact-erc", "account-erc", false,
+				new Date(0));
+
+		Assertions.assertEquals(
+			"account-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"contact-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"contact-role-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"false",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"contact-role-erc;contact-erc;account-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	@Test
+	public void testToAssetObjectMapsDeleted() {
+		JiraAssetObject jiraAssetObject =
+			_accountContactRoleAssignmentConverter.toAssetObject(
+				"contact-role-erc", "contact-erc", "account-erc", true,
+				new Date(0));
+
+		Assertions.assertEquals(
+			"true",
+			jiraAssetObject.getAttributeValue(
+				AccountContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+	}
+
+	private AccountContactRoleAssignmentConverter
+		_accountContactRoleAssignmentConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountConverterTest.java
@@ -1,0 +1,290 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.headless.admin.user.client.dto.v1_0.AccountContactInformation;
+import com.liferay.headless.admin.user.client.dto.v1_0.EmailAddress;
+import com.liferay.headless.admin.user.client.dto.v1_0.Phone;
+import com.liferay.headless.admin.user.client.dto.v1_0.WebUrl;
+import com.liferay.one.jira.constants.AccountConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_accountConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new AccountConverter());
+	}
+
+	@Test
+	public void testToAssetObjectFallsBackToFirstContactInformation() {
+		AccountContactInformation accountContactInformation =
+			new AccountContactInformation();
+
+		accountContactInformation.setEmailAddresses(
+			new EmailAddress[] {
+				_emailAddress("first@liferay.com", false),
+				_emailAddress("second@liferay.com", false)
+			});
+		accountContactInformation.setTelephones(
+			new Phone[] {
+				_phone("111", "local", false), _phone("222", "local", false)
+			});
+		accountContactInformation.setWebUrls(
+			new WebUrl[] {
+				_webUrl("https://first.example.com", false),
+				_webUrl("https://second.example.com", false)
+			});
+
+		Account account = new Account();
+
+		account.setAccountContactInformation(accountContactInformation);
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account);
+
+		Assertions.assertEquals(
+			"first@liferay.com",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS));
+		Assertions.assertEquals(
+			"111",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_PHONE_NUMBER));
+		Assertions.assertEquals(
+			"https://first.example.com",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_WEBSITE));
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		Account account = new Account();
+
+		account.setCustomFields(
+			new CustomField[] {
+				_customField("accountCode", "test-account-code"),
+				_customField("accountTier", "Gold")
+			});
+		account.setDateCreated(new Date(0));
+		account.setDateModified(new Date(86400000));
+		account.setDescription("Test description");
+		account.setExternalReferenceCode("test-erc");
+		account.setName("Test Account");
+		account.setStatus(0);
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account);
+
+		Assertions.assertEquals(
+			"test-account-code",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CODE));
+		Assertions.assertEquals(
+			"Test description",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_DESCRIPTION));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"test-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"1970-01-02T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"Test Account",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			"Active",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_STATUS));
+		Assertions.assertEquals(
+			"Gold",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_TIER));
+	}
+
+	@Test
+	public void testToAssetObjectMapsClosedStatusForNonzeroStatus() {
+		Account account = new Account();
+
+		account.setStatus(5);
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account);
+
+		Assertions.assertEquals(
+			"Closed",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_STATUS));
+	}
+
+	@Test
+	public void testToAssetObjectPrefersExplicitExternalKeyAndName() {
+		Account account = new Account();
+
+		account.setExternalReferenceCode("test-erc");
+		account.setName("Test Account");
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account, "explicit-erc", "Explicit Name");
+
+		Assertions.assertEquals(
+			"explicit-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"Explicit Name",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	@Test
+	public void testToAssetObjectPrefersPrimaryContactInformation() {
+		AccountContactInformation accountContactInformation =
+			new AccountContactInformation();
+
+		accountContactInformation.setEmailAddresses(
+			new EmailAddress[] {
+				_emailAddress("first@liferay.com", false),
+				_emailAddress("primary@liferay.com", true)
+			});
+		accountContactInformation.setTelephones(
+			new Phone[] {
+				_phone("111", "local", false), _phone("222", "fax", true),
+				_phone("333", "local", true)
+			});
+		accountContactInformation.setWebUrls(
+			new WebUrl[] {
+				_webUrl("https://first.example.com", false),
+				_webUrl("https://primary.example.com", true)
+			});
+
+		Account account = new Account();
+
+		account.setAccountContactInformation(accountContactInformation);
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account);
+
+		Assertions.assertEquals(
+			"primary@liferay.com",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS));
+		Assertions.assertEquals(
+			"222",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_FAX_NUMBER));
+		Assertions.assertEquals(
+			"333",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_PHONE_NUMBER));
+		Assertions.assertEquals(
+			"https://primary.example.com",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_WEBSITE));
+	}
+
+	@Test
+	public void testToAssetObjectSkipsMissingValues() {
+		Account account = new Account();
+
+		account.setCustomFields(
+			new CustomField[] {_customField("accountCode", null)});
+
+		JiraAssetObject jiraAssetObject = _accountConverter.toAssetObject(
+			account);
+
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CODE));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_CONTACT_EMAIL_ADDRESS));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_STATUS));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				AccountConstants.ATTRIBUTE_NAME_TIER));
+	}
+
+	private CustomField _customField(String name, Object data) {
+		CustomField customField = new CustomField();
+
+		customField.setName(name);
+
+		if (data != null) {
+			CustomValue customValue = new CustomValue();
+
+			customValue.setData(data);
+
+			customField.setCustomValue(customValue);
+		}
+
+		return customField;
+	}
+
+	private EmailAddress _emailAddress(String emailAddress, boolean primary) {
+		EmailAddress emailAddressDTO = new EmailAddress();
+
+		emailAddressDTO.setEmailAddress(emailAddress);
+		emailAddressDTO.setPrimary(primary);
+
+		return emailAddressDTO;
+	}
+
+	private Phone _phone(
+		String phoneNumber, String phoneType, boolean primary) {
+
+		Phone phone = new Phone();
+
+		phone.setPhoneNumber(phoneNumber);
+		phone.setPhoneType(phoneType);
+		phone.setPrimary(primary);
+
+		return phone;
+	}
+
+	private WebUrl _webUrl(String url, boolean primary) {
+		WebUrl webUrl = new WebUrl();
+
+		webUrl.setPrimary(primary);
+		webUrl.setUrl(url);
+
+		return webUrl;
+	}
+
+	private AccountConverter _accountConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountTeamRoleAssignmentConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/AccountTeamRoleAssignmentConverterTest.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.AccountTeamRoleAssignmentConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class AccountTeamRoleAssignmentConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_accountTeamRoleAssignmentConverter =
+			JiraAssetObjectConverterTestUtil.prepare(
+				new AccountTeamRoleAssignmentConverter());
+	}
+
+	@Test
+	public void testGetDeletedAttributeNameIsDeleted() {
+		Assertions.assertEquals(
+			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED,
+			_accountTeamRoleAssignmentConverter.getDeletedAttributeName());
+	}
+
+	@Test
+	public void testGetExternalKeyAttributeNameIsName() {
+		Assertions.assertEquals(
+			AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_NAME,
+			_accountTeamRoleAssignmentConverter.getExternalKeyAttributeName());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		JiraAssetObject jiraAssetObject =
+			_accountTeamRoleAssignmentConverter.toAssetObject(
+				"team-role-erc", "team-erc", "account-erc", false, new Date(0));
+
+		Assertions.assertEquals(
+			"account-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_ACCOUNT_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"false",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"team-role-erc;team-erc;account-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			"team-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"team-role-erc",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_ROLE_EXTERNAL_KEY));
+	}
+
+	@Test
+	public void testToAssetObjectMapsDeleted() {
+		JiraAssetObject jiraAssetObject =
+			_accountTeamRoleAssignmentConverter.toAssetObject(
+				"team-role-erc", "team-erc", "account-erc", true, new Date(0));
+
+		Assertions.assertEquals(
+			"true",
+			jiraAssetObject.getAttributeValue(
+				AccountTeamRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+	}
+
+	private AccountTeamRoleAssignmentConverter
+		_accountTeamRoleAssignmentConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/ContactConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/ContactConverterTest.java
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.custom.field.CustomField;
+import com.liferay.headless.admin.user.client.custom.field.CustomValue;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.jira.constants.ContactConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class ContactConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_contactConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new ContactConverter());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setAdditionalName("Middle");
+		userAccount.setCustomFields(
+			new CustomField[] {_verifiedCustomField(true)});
+		userAccount.setDateCreated(new Date(0));
+		userAccount.setDateModified(new Date(86400000));
+		userAccount.setEmailAddress("test@liferay.com");
+		userAccount.setExternalReferenceCode("test-erc");
+		userAccount.setFamilyName("Last");
+		userAccount.setGivenName("First");
+		userAccount.setLanguageId("en_US");
+		userAccount.setName("First Middle Last");
+
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		Assertions.assertEquals(
+			"test@liferay.com",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS));
+		Assertions.assertEquals(
+			"true",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS_VERIFIED));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"test-erc",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"1970-01-02T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"First",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_FIRST_NAME));
+		Assertions.assertEquals(
+			"en_US",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_LANGUAGE_ID));
+		Assertions.assertEquals(
+			"Last",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_LAST_NAME));
+		Assertions.assertEquals(
+			"Middle",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_MIDDLE_NAME));
+		Assertions.assertEquals(
+			"First Middle Last",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	@Test
+	public void testToAssetObjectMapsUnverifiedEmailAddress() {
+		UserAccount userAccount = new UserAccount();
+
+		userAccount.setCustomFields(
+			new CustomField[] {_verifiedCustomField(false)});
+
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			userAccount);
+
+		Assertions.assertEquals(
+			"false",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS_VERIFIED));
+	}
+
+	@Test
+	public void testToAssetObjectSkipsMissingValues() {
+		JiraAssetObject jiraAssetObject = _contactConverter.toAssetObject(
+			new UserAccount());
+
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS));
+		Assertions.assertEquals(
+			"false",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EMAIL_ADDRESS_VERIFIED));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	private CustomField _verifiedCustomField(boolean verified) {
+		CustomField customField = new CustomField();
+
+		customField.setName("verified");
+
+		CustomValue customValue = new CustomValue();
+
+		customValue.setData(verified);
+
+		customField.setCustomValue(customValue);
+
+		return customField;
+	}
+
+	private ContactConverter _contactConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/ContactRoleConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/ContactRoleConverterTest.java
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Role;
+import com.liferay.one.jira.constants.ContactRoleConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.util.role.EmployeeRoles;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class ContactRoleConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_contactRoleConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new ContactRoleConverter());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAccountWorkerTypeForEmployeeRole() {
+		Role role = new Role();
+
+		role.setName(EmployeeRoles.LIFERAY_SALES.getName());
+		role.setRoleType("account");
+
+		JiraAssetObject jiraAssetObject = _contactRoleConverter.toAssetObject(
+			role);
+
+		Assertions.assertEquals(
+			ContactRoleConstants.ATTRIBUTE_VALUE_TYPE_ACCOUNT_WORKER,
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_TYPE));
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		Role role = new Role();
+
+		role.setDateCreated(new Date(0));
+		role.setDateModified(new Date(86400000));
+		role.setDescription("Test description");
+		role.setExternalReferenceCode("test-erc");
+		role.setName("Test Role");
+		role.setRoleType("account");
+
+		JiraAssetObject jiraAssetObject = _contactRoleConverter.toAssetObject(
+			role);
+
+		Assertions.assertEquals(
+			"Test description",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_DESCRIPTION));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"test-erc",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"1970-01-02T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"Test Role",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			ContactRoleConstants.ATTRIBUTE_VALUE_TYPE_ACCOUNT_CUSTOMER,
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_TYPE));
+	}
+
+	@Test
+	public void testToAssetObjectMapsTeamTypeForOrganizationRole() {
+		Role role = new Role();
+
+		role.setName("Test Role");
+		role.setRoleType("organization");
+
+		JiraAssetObject jiraAssetObject = _contactRoleConverter.toAssetObject(
+			role);
+
+		Assertions.assertEquals(
+			ContactRoleConstants.ATTRIBUTE_VALUE_TYPE_TEAM,
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_TYPE));
+	}
+
+	@Test
+	public void testToAssetObjectSkipsMissingValues() {
+		JiraAssetObject jiraAssetObject = _contactRoleConverter.toAssetObject(
+			new Role());
+
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_DESCRIPTION));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			ContactRoleConstants.ATTRIBUTE_VALUE_TYPE_ACCOUNT_CUSTOMER,
+			jiraAssetObject.getAttributeValue(
+				ContactRoleConstants.ATTRIBUTE_NAME_TYPE));
+	}
+
+	private ContactRoleConverter _contactRoleConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/EntitlementConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/EntitlementConverterTest.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.EntitlementConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+import com.liferay.one.model.EntitlementDefinition;
+
+import org.json.JSONObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class EntitlementConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_entitlementConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new EntitlementConverter());
+	}
+
+	@Test
+	public void testGetExternalKeyAttributeNameIsName() {
+		Assertions.assertEquals(
+			EntitlementConstants.ATTRIBUTE_NAME_NAME,
+			_entitlementConverter.getExternalKeyAttributeName());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		EntitlementDefinition entitlementDefinition = new EntitlementDefinition(
+			new JSONObject(
+			).put(
+				"displayName", "Test Entitlement"
+			).put(
+				"externalReferenceCode", "test-erc"
+			).put(
+				"id", 12345L
+			));
+
+		JiraAssetObject jiraAssetObject = _entitlementConverter.toAssetObject(
+			entitlementDefinition);
+
+		Assertions.assertEquals(
+			"test-erc",
+			jiraAssetObject.getAttributeValue(
+				EntitlementConstants.
+					ATTRIBUTE_NAME_ENTITLEMENT_DEFINITION_KEY));
+		Assertions.assertEquals(
+			"Test Entitlement",
+			jiraAssetObject.getAttributeValue(
+				EntitlementConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	private EntitlementConverter _entitlementConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/JiraAssetObjectConverterTestUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/JiraAssetObjectConverterTestUtil.java
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.service.JiraAssetSchemaService;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class JiraAssetObjectConverterTestUtil {
+
+	public static <T extends BaseJiraAssetObjectConverter> T prepare(
+		T converter) {
+
+		JiraAssetSchemaService jiraAssetSchemaService = Mockito.mock(
+			JiraAssetSchemaService.class);
+
+		Mockito.when(
+			jiraAssetSchemaService.getAttributeIds(Mockito.any(), Mockito.any())
+		).thenReturn(
+			new PassthroughAttributeIdMap()
+		);
+
+		Mockito.when(
+			jiraAssetSchemaService.getAttributeOptions(
+				Mockito.any(), Mockito.any())
+		).thenReturn(
+			Collections.emptyMap()
+		);
+
+		ReflectionTestUtils.setField(
+			converter, "_jiraAssetSchemaService", jiraAssetSchemaService);
+
+		return converter;
+	}
+
+	/**
+	 * Maps every attribute name to itself so that converted attribute values
+	 * can be read back by name without loading a real schema.
+	 */
+	private static class PassthroughAttributeIdMap
+		extends AbstractMap<String, String> {
+
+		@Override
+		public Set<Map.Entry<String, String>> entrySet() {
+			return Collections.emptySet();
+		}
+
+		@Override
+		public String get(Object key) {
+			return (String)key;
+		}
+
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamContactRoleAssignmentConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamContactRoleAssignmentConverterTest.java
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.TeamContactRoleAssignmentConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class TeamContactRoleAssignmentConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_teamContactRoleAssignmentConverter =
+			JiraAssetObjectConverterTestUtil.prepare(
+				new TeamContactRoleAssignmentConverter());
+	}
+
+	@Test
+	public void testGetDeletedAttributeNameIsDeleted() {
+		Assertions.assertEquals(
+			TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED,
+			_teamContactRoleAssignmentConverter.getDeletedAttributeName());
+	}
+
+	@Test
+	public void testGetExternalKeyAttributeNameIsName() {
+		Assertions.assertEquals(
+			TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME,
+			_teamContactRoleAssignmentConverter.getExternalKeyAttributeName());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		JiraAssetObject jiraAssetObject =
+			_teamContactRoleAssignmentConverter.toAssetObject(
+				"contact-role-erc", "contact-erc", "team-erc", false,
+				new Date(0));
+
+		Assertions.assertEquals(
+			"contact-erc",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"contact-role-erc",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_CONTACT_ROLE_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"false",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"contact-role-erc;contact-erc;team-erc",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			"team-erc",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.
+					ATTRIBUTE_NAME_TEAM_EXTERNAL_KEY));
+	}
+
+	@Test
+	public void testToAssetObjectMapsDeleted() {
+		JiraAssetObject jiraAssetObject =
+			_teamContactRoleAssignmentConverter.toAssetObject(
+				"contact-role-erc", "contact-erc", "team-erc", true,
+				new Date(0));
+
+		Assertions.assertEquals(
+			"true",
+			jiraAssetObject.getAttributeValue(
+				TeamContactRoleAssignmentConstants.ATTRIBUTE_NAME_DELETED));
+	}
+
+	private TeamContactRoleAssignmentConverter
+		_teamContactRoleAssignmentConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamConverterTest.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Organization;
+import com.liferay.one.jira.constants.TeamConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class TeamConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_teamConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new TeamConverter());
+	}
+
+	@Test
+	public void testToAssetObjectMapsAttributes() {
+		Organization organization = new Organization();
+
+		organization.setDateCreated(new Date(0));
+		organization.setDateModified(new Date(86400000));
+		organization.setExternalReferenceCode("test-erc");
+		organization.setName("Test Team");
+
+		JiraAssetObject jiraAssetObject = _teamConverter.toAssetObject(
+			organization);
+
+		Assertions.assertEquals(
+			"1970-01-01T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"test-erc",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"1970-01-02T00:00:00Z",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"Test Team",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	@Test
+	public void testToAssetObjectSkipsMissingValues() {
+		JiraAssetObject jiraAssetObject = _teamConverter.toAssetObject(
+			new Organization());
+
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_CREATED_AT));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_EXTERNAL_UPDATED_AT));
+		Assertions.assertEquals(
+			"",
+			jiraAssetObject.getAttributeValue(
+				TeamConstants.ATTRIBUTE_NAME_NAME));
+	}
+
+	private TeamConverter _teamConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamRoleConverterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/converter/TeamRoleConverterTest.java
@@ -1,0 +1,47 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.jira.converter;
+
+import com.liferay.one.jira.constants.TeamRoleConstants;
+import com.liferay.one.jira.model.JiraAssetObject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Drew Brokke
+ */
+public class TeamRoleConverterTest {
+
+	@BeforeEach
+	public void setUp() {
+		_teamRoleConverter = JiraAssetObjectConverterTestUtil.prepare(
+			new TeamRoleConverter());
+	}
+
+	@Test
+	public void testToFirstLineSupportAssetObjectMapsAttributes() {
+		JiraAssetObject jiraAssetObject =
+			_teamRoleConverter.toFirstLineSupportAssetObject();
+
+		Assertions.assertEquals(
+			TeamRoleConstants.EXTERNAL_KEY_FIRST_LINE_SUPPORT,
+			jiraAssetObject.getAttributeValue(
+				TeamRoleConstants.ATTRIBUTE_NAME_EXTERNAL_KEY));
+		Assertions.assertEquals(
+			TeamRoleConstants.NAME_FIRST_LINE_SUPPORT,
+			jiraAssetObject.getAttributeValue(
+				TeamRoleConstants.ATTRIBUTE_NAME_NAME));
+		Assertions.assertEquals(
+			"Account",
+			jiraAssetObject.getAttributeValue(
+				TeamRoleConstants.ATTRIBUTE_NAME_TYPE));
+	}
+
+	private TeamRoleConverter _teamRoleConverter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/service/JiraAssetServiceTest.java
@@ -199,6 +199,66 @@ public class JiraAssetServiceTest {
 	}
 
 	@Test
+	public void testGetOrCreateReferenceObjectIdsCreatesMissingObjects() {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.singletonList(_existingJiraAssetObject)
+		);
+
+		Mockito.when(
+			_jiraAssetPersistence.createObject(Mockito.any(), Mockito.any())
+		).thenReturn(
+			new JSONObject(
+			).put(
+				"id", "created-object-id"
+			)
+		);
+
+		JiraAssetObject createdJiraAssetObject = Mockito.mock(
+			JiraAssetObject.class);
+
+		List<String> objectIds =
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_converter, Arrays.asList(_EXTERNAL_KEY, "unresolved-key"),
+				externalKey -> externalKey,
+				externalKey -> createdJiraAssetObject);
+
+		Assertions.assertEquals(
+			Arrays.asList(_OBJECT_ID, "created-object-id"), objectIds);
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).createObject(
+			"objectTypeId", createdJiraAssetObject
+		);
+	}
+
+	@Test
+	public void testGetOrCreateReferenceObjectIdsSkipsNullCreatedObjects() {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		List<String> objectIds =
+			_jiraAssetService.getOrCreateReferenceObjectIds(
+				_converter, Collections.singletonList("unresolved-key"),
+				externalKey -> externalKey, externalKey -> null);
+
+		Assertions.assertTrue(objectIds.isEmpty());
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).createObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
 	public void testGetOrCreateReferenceObjectIdsWaitsForUpsert()
 		throws Exception {
 
@@ -264,6 +324,47 @@ public class JiraAssetServiceTest {
 		).createObject(
 			Mockito.any(), Mockito.any()
 		);
+	}
+
+	@Test
+	public void testIsUnchangedByExternalUpdatedAtReturnsFalseForDifferingExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Date date = new Date();
+
+		Assertions.assertFalse(
+			_jiraAssetService.isUnchangedByExternalUpdatedAt(
+				_converter, _mockJiraAssetObjectUpdatedAt(date),
+				_mockJiraAssetObjectUpdatedAt(
+					new Date(date.getTime() + 60000))));
+	}
+
+	@Test
+	public void testIsUnchangedByExternalUpdatedAtReturnsFalseForMissingExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Assertions.assertFalse(
+			_jiraAssetService.isUnchangedByExternalUpdatedAt(
+				_converter, _mockJiraAssetObjectUpdatedAt(new Date()),
+				Mockito.mock(JiraAssetObject.class)));
+	}
+
+	@Test
+	public void testIsUnchangedByExternalUpdatedAtReturnsTrueForSameExternalUpdatedAt()
+		throws Exception {
+
+		_mockExternalUpdatedAt();
+
+		Date date = new Date();
+
+		Assertions.assertTrue(
+			_jiraAssetService.isUnchangedByExternalUpdatedAt(
+				_converter, _mockJiraAssetObjectUpdatedAt(date),
+				_mockJiraAssetObjectUpdatedAt(date)));
 	}
 
 	@Test
@@ -636,6 +737,56 @@ public class JiraAssetServiceTest {
 			() -> _jiraAssetService.softDelete(
 				_converter, _existingJiraAssetObject),
 			"delete", "update");
+	}
+
+	@Test
+	public void testUpsertCreatesMissingObject() throws Exception {
+		Mockito.when(
+			_jiraAssetPersistence.searchObjects(
+				Mockito.anyString(), Mockito.any())
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		JiraAssetObject jiraAssetObject = Mockito.mock(JiraAssetObject.class);
+
+		Mockito.when(
+			jiraAssetObject.getAttributeValue("External Key")
+		).thenReturn(
+			_EXTERNAL_KEY
+		);
+
+		_jiraAssetService.upsert(_converter, jiraAssetObject);
+
+		Mockito.verify(
+			_jiraAssetPersistence
+		).createObject(
+			"objectTypeId", jiraAssetObject
+		);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).updateObject(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testUpsertSkipsMissingExternalKey() throws Exception {
+		_jiraAssetService.upsert(
+			_converter, Mockito.mock(JiraAssetObject.class));
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).searchObjects(
+			Mockito.anyString(), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetPersistence, Mockito.never()
+		).createObject(
+			Mockito.any(), Mockito.any()
+		);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountOrganizationSynchronizerTest.java
@@ -102,6 +102,28 @@ public class AccountOrganizationSynchronizerTest {
 	}
 
 	@Test
+	public void testSyncAssignOrganizationMarksAssignmentUndeleted()
+		throws Exception {
+
+		_accountOrganizationSynchronizer.syncAssignOrganization(
+			_ORGANIZATION_EXTERNAL_KEY, _ACCOUNT_EXTERNAL_KEY);
+
+		Mockito.verify(
+			_accountTeamRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.any(), Mockito.eq(_ORGANIZATION_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(false), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountTeamRoleAssignmentConverter), Mockito.any(),
+			Mockito.isNull()
+		);
+	}
+
+	@Test
 	public void testSyncAssignOrganizationWaitsForSyncAssignOrganization()
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/AccountUserAccountRoleSynchronizerTest.java
@@ -115,6 +115,50 @@ public class AccountUserAccountRoleSynchronizerTest {
 	}
 
 	@Test
+	public void testSyncAssignRoleMarksAssignmentUndeleted() throws Exception {
+		_accountUserAccountRoleSynchronizer.syncAssignRole(
+			_ROLE_EXTERNAL_KEY, _USER_ACCOUNT_EXTERNAL_KEY,
+			_ACCOUNT_EXTERNAL_KEY);
+
+		Mockito.verify(
+			_accountContactRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.eq(_ROLE_EXTERNAL_KEY),
+			Mockito.eq(_USER_ACCOUNT_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(false), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any(),
+			Mockito.isNull()
+		);
+	}
+
+	@Test
+	public void testSyncUnassignRoleMarksAssignmentDeleted() throws Exception {
+		_accountUserAccountRoleSynchronizer.syncUnassignRole(
+			_ROLE_EXTERNAL_KEY, _USER_ACCOUNT_EXTERNAL_KEY,
+			_ACCOUNT_EXTERNAL_KEY);
+
+		Mockito.verify(
+			_accountContactRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.eq(_ROLE_EXTERNAL_KEY),
+			Mockito.eq(_USER_ACCOUNT_EXTERNAL_KEY),
+			Mockito.eq(_ACCOUNT_EXTERNAL_KEY), Mockito.eq(true), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_accountContactRoleAssignmentConverter), Mockito.any(),
+			Mockito.isNull()
+		);
+	}
+
+	@Test
 	public void testSyncUnassignStaleRolesBaseAQL() throws Exception {
 		AtomicReference<String> aqlAtomicReference = _captureAQL();
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/jira/synchronizer/OrganizationUserAccountRoleSynchronizerTest.java
@@ -7,7 +7,9 @@ package com.liferay.one.jira.synchronizer;
 
 import com.liferay.one.jira.constants.TeamContactRoleAssignmentConstants;
 import com.liferay.one.jira.converter.TeamContactRoleAssignmentConverter;
+import com.liferay.one.jira.model.JiraAssetObject;
 import com.liferay.one.jira.service.JiraAssetService;
+import com.liferay.one.util.KeyedLock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,12 +29,24 @@ public class OrganizationUserAccountRoleSynchronizerTest {
 			new OrganizationUserAccountRoleSynchronizer();
 
 		_jiraAssetService = Mockito.mock(JiraAssetService.class);
+
 		_teamContactRoleAssignmentConverter = Mockito.mock(
 			TeamContactRoleAssignmentConverter.class);
+
+		Mockito.when(
+			_teamContactRoleAssignmentConverter.toAssetObject(
+				Mockito.any(), Mockito.any(), Mockito.any(),
+				Mockito.anyBoolean(), Mockito.any())
+		).thenReturn(
+			Mockito.mock(JiraAssetObject.class)
+		);
 
 		ReflectionTestUtils.setField(
 			_organizationUserAccountRoleSynchronizer, "_jiraAssetService",
 			_jiraAssetService);
+		ReflectionTestUtils.setField(
+			_organizationUserAccountRoleSynchronizer, "_keyedLock",
+			new KeyedLock());
 		ReflectionTestUtils.setField(
 			_organizationUserAccountRoleSynchronizer,
 			"_teamContactRoleAssignmentConverter",
@@ -65,6 +79,44 @@ public class OrganizationUserAccountRoleSynchronizerTest {
 			TeamContactRoleAssignmentConstants.
 				ATTRIBUTE_NAME_CONTACT_EXTERNAL_KEY,
 			"user-account-erc"
+		);
+	}
+
+	@Test
+	public void testSyncAssignRoleMarksAssignmentUndeleted() throws Exception {
+		_organizationUserAccountRoleSynchronizer.syncAssignRole(
+			"role-erc", "user-account-erc", "organization-erc");
+
+		Mockito.verify(
+			_teamContactRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.eq("role-erc"), Mockito.eq("user-account-erc"),
+			Mockito.eq("organization-erc"), Mockito.eq(false), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_teamContactRoleAssignmentConverter), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testSyncUnassignRoleMarksAssignmentDeleted() throws Exception {
+		_organizationUserAccountRoleSynchronizer.syncUnassignRole(
+			"role-erc", "user-account-erc", "organization-erc");
+
+		Mockito.verify(
+			_teamContactRoleAssignmentConverter
+		).toAssetObject(
+			Mockito.eq("role-erc"), Mockito.eq("user-account-erc"),
+			Mockito.eq("organization-erc"), Mockito.eq(true), Mockito.any()
+		);
+
+		Mockito.verify(
+			_jiraAssetService
+		).upsert(
+			Mockito.eq(_teamContactRoleAssignmentConverter), Mockito.any()
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/permission/AdminPermissionTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/permission/AdminPermissionTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.permission;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
+import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.RoleConstants;
+import com.liferay.one.service.UserAccountService;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Drew Brokke
+ */
+public class AdminPermissionTest {
+
+	@Test
+	public void testCheckGrantsAdministrator() throws Exception {
+		AdminPermission adminPermission = _createAdminPermission(
+			RoleConstants.NAME_ADMINISTRATOR);
+
+		adminPermission.check(null);
+	}
+
+	@Test
+	public void testCheckGrantsProvisioningAdministrator() throws Exception {
+		AdminPermission adminPermission = _createAdminPermission(
+			RoleConstants.NAME_PROVISIONING_ADMINISTRATOR);
+
+		adminPermission.check(null);
+	}
+
+	@Test
+	public void testCheckThrowsForAccountAdministrator() throws Exception {
+		AdminPermission adminPermission = _createAdminPermission(
+			RoleConstants.NAME_ACCOUNT_ADMINISTRATOR);
+
+		Assertions.assertThrows(
+			PrincipalException.class, () -> adminPermission.check(null));
+	}
+
+	@Test
+	public void testCheckThrowsForUserWithoutRoles() throws Exception {
+		AdminPermission adminPermission = _createAdminPermission();
+
+		Assertions.assertThrows(
+			PrincipalException.class, () -> adminPermission.check(null));
+	}
+
+	private AdminPermission _createAdminPermission(String... roleNames)
+		throws Exception {
+
+		AdminPermission adminPermission = new AdminPermission();
+
+		RoleBrief[] roleBriefs = new RoleBrief[roleNames.length];
+
+		for (int i = 0; i < roleNames.length; i++) {
+			RoleBrief roleBrief = Mockito.mock(RoleBrief.class);
+
+			Mockito.when(
+				roleBrief.getName()
+			).thenReturn(
+				roleNames[i]
+			);
+
+			roleBriefs[i] = roleBrief;
+		}
+
+		UserAccount userAccount = Mockito.mock(UserAccount.class);
+
+		Mockito.when(
+			userAccount.getRoleBriefs()
+		).thenReturn(
+			roleBriefs
+		);
+
+		UserAccountService userAccountService = Mockito.mock(
+			UserAccountService.class);
+
+		Mockito.when(
+			userAccountService.getMyUserAccount(Mockito.any())
+		).thenReturn(
+			userAccount
+		);
+
+		ReflectionTestUtils.setField(
+			adminPermission, "_userAccountService", userAccountService);
+
+		return adminPermission;
+	}
+
+}


### PR DESCRIPTION
Story: [LPD-89437](https://liferay.atlassian.net/browse/LPD-89437)
Technical Task: [LPD-99655](https://liferay.atlassian.net/browse/LPD-99655)

Adds unit test coverage for the `com.liferay.one.jira` package: the asset converters, the deleted attribute in the synchronizers, and the sync-to-jsm endpoint permission gate.


[LPD-89437]: https://liferay.atlassian.net/browse/LPD-89437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-99655]: https://liferay.atlassian.net/browse/LPD-99655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ