### PR TITLE
LPD-91426 Port the license key download and export endpoints

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -221,7 +221,7 @@ public class AccountsRestController extends OneBaseRestController {
 
 		return ResponseEntity.ok(
 		).contentType(
-			MediaType.parseMediaType("text/csv")
+			_CONTENT_TYPE_CSV
 		).header(
 			HttpHeaders.CONTENT_DISPOSITION,
 			"attachment; filename=\"" + _licenseKeyCSVExporter.getFileName() +
@@ -830,6 +830,9 @@ public class AccountsRestController extends OneBaseRestController {
 			}
 		}
 	}
+
+	private static final MediaType _CONTENT_TYPE_CSV = MediaType.parseMediaType(
+		"text/csv");
 
 	private static final Log _log = LogFactory.getLog(
 		AccountsRestController.class);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -15,6 +15,7 @@ import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
+import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.AccountInvitation;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
@@ -60,7 +61,9 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -203,6 +206,31 @@ public class AccountsRestController extends OneBaseRestController {
 
 		return _licenseKeyService.getLicenseKeysByAccountEntryId(
 			account.getId());
+	}
+
+	@GetMapping("/{externalReferenceCode}/license-keys/export")
+	public ResponseEntity<String> getLicenseKeysExport(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("externalReferenceCode") String externalReferenceCode)
+		throws Exception {
+
+		Account account = _accountService.getAccount(
+			externalReferenceCode, jwt);
+
+		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
+
+		return ResponseEntity.ok(
+		).contentType(
+			MediaType.parseMediaType("text/csv")
+		).header(
+			HttpHeaders.CONTENT_DISPOSITION,
+			"attachment; filename=\"" + _licenseKeyCSVExporter.getFileName() +
+				"\""
+		).body(
+			_licenseKeyCSVExporter.toCSV(
+				_licenseKeyService.getLicenseKeysByAccountEntryId(
+					account.getId()))
+		);
 	}
 
 	@PostMapping("/{externalReferenceCode}/invitations")
@@ -842,6 +870,9 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private KeyedLock _keyedLock;
+
+	@Autowired
+	private LicenseKeyCSVExporter _licenseKeyCSVExporter;
 
 	@Autowired
 	private LicenseKeyPermission _licenseKeyPermission;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -199,12 +199,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		_checkLicenseKeyIds(licenseKeyIds);
 
-		long[] distinctLicenseKeyIds = _toDistinctLicenseKeyIds(licenseKeyIds);
-
-		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
-			jwt, distinctLicenseKeyIds);
-
-		_checkAllFound(licenseKeys, distinctLicenseKeyIds);
+		List<LicenseKey> licenseKeys = _getLicenseKeys(jwt, licenseKeyIds);
 
 		UserAccount userAccount = getMyUserAccount(jwt);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -124,7 +124,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		return ResponseEntity.ok(
 		).contentType(
-			MediaType.APPLICATION_XML
+			MediaType.TEXT_XML
 		).header(
 			HttpHeaders.CONTENT_DISPOSITION,
 			"attachment; filename=\"" + fileName + "\""
@@ -148,7 +148,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		return ResponseEntity.ok(
 		).contentType(
-			MediaType.APPLICATION_XML
+			MediaType.TEXT_XML
 		).header(
 			HttpHeaders.CONTENT_DISPOSITION,
 			"attachment; filename=\"" +

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -204,9 +204,11 @@ public class LicenseKeysRestController extends OneBaseRestController {
 					Arrays.toString(licenseKeyIds));
 		}
 
+		UserAccount userAccount = getMyUserAccount(jwt);
+
 		for (LicenseKey licenseKey : licenseKeys) {
 			_licenseKeyPermission.check(
-				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
+				userAccount, licenseKey.getAccountEntryId(), ActionKeys.VIEW);
 		}
 
 		return ResponseEntity.ok(
@@ -324,13 +326,15 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		List<LicenseKey> licenseKeys = new ArrayList<>();
 
+		UserAccount userAccount = getMyUserAccount(jwt);
+
 		for (LicenseKey licenseKey : _getLicenseKeys(jwt, licenseKeyIds)) {
 			if (!licenseKey.isActive()) {
 				continue;
 			}
 
 			_licenseKeyPermission.check(
-				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
+				userAccount, licenseKey.getAccountEntryId(), ActionKeys.VIEW);
 
 			licenseKeys.add(licenseKey);
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -143,6 +143,8 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
 
+		_checkMaxLicenseKeyIds(licenseKeyIds);
+
 		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
 			jwt, licenseKeyIds);
 
@@ -169,6 +171,8 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
 
+		_checkMaxLicenseKeyIds(licenseKeyIds);
+
 		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
 			jwt, licenseKeyIds);
 
@@ -192,6 +196,8 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@AuthenticationPrincipal Jwt jwt,
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
+
+		_checkMaxLicenseKeyIds(licenseKeyIds);
 
 		if (licenseKeyIds.length == 0) {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
@@ -331,6 +337,15 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		}
 	}
 
+	private void _checkMaxLicenseKeyIds(long[] licenseKeyIds) {
+		if (licenseKeyIds.length > _MAX_LICENSE_KEY_IDS) {
+			throw new ResponseStatusException(
+				HttpStatus.BAD_REQUEST,
+				"No more than " + _MAX_LICENSE_KEY_IDS +
+					" license keys may be requested at once");
+		}
+	}
+
 	private List<LicenseKey> _getActiveLicenseKeys(
 			Jwt jwt, long[] licenseKeyIds)
 		throws Exception {
@@ -386,6 +401,8 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 	private static final MediaType _CONTENT_TYPE_CSV = MediaType.parseMediaType(
 		"text/csv");
+
+	private static final int _MAX_LICENSE_KEY_IDS = 100;
 
 	private static final int _MAX_PAGE_SIZE = 100;
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -143,7 +143,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
 
-		_checkMaxLicenseKeyIds(licenseKeyIds);
+		_checkLicenseKeyIds(licenseKeyIds);
 
 		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
 			jwt, licenseKeyIds);
@@ -171,7 +171,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
 
-		_checkMaxLicenseKeyIds(licenseKeyIds);
+		_checkLicenseKeyIds(licenseKeyIds);
 
 		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
 			jwt, licenseKeyIds);
@@ -197,11 +197,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
 		throws Exception {
 
-		_checkMaxLicenseKeyIds(licenseKeyIds);
-
-		if (licenseKeyIds.length == 0) {
-			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-		}
+		_checkLicenseKeyIds(licenseKeyIds);
 
 		long[] distinctLicenseKeyIds = _toDistinctLicenseKeyIds(licenseKeyIds);
 
@@ -337,7 +333,11 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		}
 	}
 
-	private void _checkMaxLicenseKeyIds(long[] licenseKeyIds) {
+	private void _checkLicenseKeyIds(long[] licenseKeyIds) {
+		if (licenseKeyIds.length == 0) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
 		if (licenseKeyIds.length > _MAX_LICENSE_KEY_IDS) {
 			throw new ResponseStatusException(
 				HttpStatus.BAD_REQUEST,

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -206,7 +206,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		long[] distinctLicenseKeyIds = _toDistinctLicenseKeyIds(licenseKeyIds);
 
 		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
-			distinctLicenseKeyIds);
+			jwt, distinctLicenseKeyIds);
 
 		_checkAllFound(licenseKeys, distinctLicenseKeyIds);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -19,6 +19,9 @@ import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.SubscriptionEntryService;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.json.JSONObject;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,6 +132,56 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		);
 	}
 
+	@GetMapping("/download")
+	public ResponseEntity<String> getLicenseKeysDownload(
+			@AuthenticationPrincipal Jwt jwt,
+			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
+		throws Exception {
+
+		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
+			jwt, licenseKeyIds);
+
+		if (licenseKeys.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		return ResponseEntity.ok(
+		).contentType(
+			MediaType.APPLICATION_XML
+		).header(
+			HttpHeaders.CONTENT_DISPOSITION,
+			"attachment; filename=\"" +
+				_licenseKeyService.getLicenseKeysDownloadFileName(licenseKeys) +
+					"\""
+		).body(
+			_licenseKeyService.getLicenseKeysDownloadXML(licenseKeys)
+		);
+	}
+
+	@GetMapping("/download-zip")
+	public ResponseEntity<byte[]> getLicenseKeysDownloadZip(
+			@AuthenticationPrincipal Jwt jwt,
+			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
+		throws Exception {
+
+		List<LicenseKey> licenseKeys = _getActiveLicenseKeys(
+			jwt, licenseKeyIds);
+
+		if (licenseKeys.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		return ResponseEntity.ok(
+		).contentType(
+			MediaType.parseMediaType("application/zip")
+		).header(
+			HttpHeaders.CONTENT_DISPOSITION,
+			"attachment; filename=\"activation-keys.zip\""
+		).body(
+			_licenseKeyService.getLicenseKeysDownloadZip(licenseKeys)
+		);
+	}
+
 	@GetMapping("/subscriptions")
 	public boolean getSubscriptions(
 			@AuthenticationPrincipal Jwt jwt,
@@ -224,6 +277,29 @@ public class LicenseKeysRestController extends OneBaseRestController {
 				jwt, ClassNameConstants.LICENSE_KEY, licenseKeyId,
 				userAccount.getId());
 		}
+	}
+
+	private List<LicenseKey> _getActiveLicenseKeys(
+			Jwt jwt, long[] licenseKeyIds)
+		throws Exception {
+
+		List<LicenseKey> licenseKeys = new ArrayList<>();
+
+		for (long licenseKeyId : licenseKeyIds) {
+			LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
+				jwt, licenseKeyId);
+
+			if (!licenseKey.isActive()) {
+				continue;
+			}
+
+			_licenseKeyPermission.check(
+				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
+
+			licenseKeys.add(licenseKey);
+		}
+
+		return licenseKeys;
 	}
 
 	private static final int _MAX_PAGE_SIZE = 100;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -340,12 +340,12 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		UserAccount userAccount = getMyUserAccount(jwt);
 
 		for (LicenseKey licenseKey : _getLicenseKeys(jwt, licenseKeyIds)) {
+			_licenseKeyPermission.check(
+				userAccount, licenseKey.getAccountEntryId(), ActionKeys.VIEW);
+
 			if (!licenseKey.isActive()) {
 				continue;
 			}
-
-			_licenseKeyPermission.check(
-				userAccount, licenseKey.getAccountEntryId(), ActionKeys.VIEW);
 
 			licenseKeys.add(licenseKey);
 		}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -342,15 +342,6 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		return licenseKeys;
 	}
 
-	//
-
-	// One filtered read rather than one read per id. Reading each key in turn
-	// cost a round trip to the object API for every id, which the account
-	// scoped export avoids by filtering, and a caller can pass any number of
-	// ids.
-
-	//
-
 	private List<LicenseKey> _getLicenseKeys(Jwt jwt, long[] licenseKeyIds)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -23,7 +23,9 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.json.JSONObject;
 
@@ -195,14 +197,12 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
 		}
 
-		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
-			licenseKeyIds);
+		long[] distinctLicenseKeyIds = _toDistinctLicenseKeyIds(licenseKeyIds);
 
-		if (licenseKeys.size() < licenseKeyIds.length) {
-			throw new NoSuchLicenseKeyException(
-				"Unable to find every license key in " +
-					Arrays.toString(licenseKeyIds));
-		}
+		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
+			distinctLicenseKeyIds);
+
+		_checkAllFound(licenseKeys, distinctLicenseKeyIds);
 
 		UserAccount userAccount = getMyUserAccount(jwt);
 
@@ -320,6 +320,17 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		}
 	}
 
+	private void _checkAllFound(
+			List<LicenseKey> licenseKeys, long[] licenseKeyIds)
+		throws Exception {
+
+		if (licenseKeys.size() < licenseKeyIds.length) {
+			throw new NoSuchLicenseKeyException(
+				"Unable to find every license key in " +
+					Arrays.toString(licenseKeyIds));
+		}
+	}
+
 	private List<LicenseKey> _getActiveLicenseKeys(
 			Jwt jwt, long[] licenseKeyIds)
 		throws Exception {
@@ -345,16 +356,32 @@ public class LicenseKeysRestController extends OneBaseRestController {
 	private List<LicenseKey> _getLicenseKeys(Jwt jwt, long[] licenseKeyIds)
 		throws Exception {
 
-		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
-			jwt, licenseKeyIds);
+		long[] distinctLicenseKeyIds = _toDistinctLicenseKeyIds(licenseKeyIds);
 
-		if (licenseKeys.size() < licenseKeyIds.length) {
-			throw new NoSuchLicenseKeyException(
-				"Unable to find every license key in " +
-					Arrays.toString(licenseKeyIds));
-		}
+		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
+			jwt, distinctLicenseKeyIds);
+
+		_checkAllFound(licenseKeys, distinctLicenseKeyIds);
 
 		return licenseKeys;
+	}
+
+	private long[] _toDistinctLicenseKeyIds(long[] licenseKeyIds) {
+		Set<Long> distinctLicenseKeyIds = new LinkedHashSet<>();
+
+		for (long licenseKeyId : licenseKeyIds) {
+			distinctLicenseKeyIds.add(licenseKeyId);
+		}
+
+		long[] longs = new long[distinctLicenseKeyIds.size()];
+
+		int i = 0;
+
+		for (long licenseKeyId : distinctLicenseKeyIds) {
+			longs[i++] = licenseKeyId;
+		}
+
+		return longs;
 	}
 
 	private static final MediaType _CONTENT_TYPE_CSV = MediaType.parseMediaType(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -10,6 +10,7 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
 import com.liferay.one.permission.AdminPermission;
@@ -182,6 +183,40 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		);
 	}
 
+	@GetMapping("/export")
+	public ResponseEntity<String> getLicenseKeysExport(
+			@AuthenticationPrincipal Jwt jwt,
+			@RequestParam("licenseKeyIds") long[] licenseKeyIds)
+		throws Exception {
+
+		if (licenseKeyIds.length == 0) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		List<LicenseKey> licenseKeys = new ArrayList<>();
+
+		for (long licenseKeyId : licenseKeyIds) {
+			LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
+				licenseKeyId);
+
+			_licenseKeyPermission.check(
+				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
+
+			licenseKeys.add(licenseKey);
+		}
+
+		return ResponseEntity.ok(
+		).contentType(
+			_CONTENT_TYPE_CSV
+		).header(
+			HttpHeaders.CONTENT_DISPOSITION,
+			"attachment; filename=\"" + _licenseKeyCSVExporter.getFileName() +
+				"\""
+		).body(
+			_licenseKeyCSVExporter.toCSV(licenseKeys)
+		);
+	}
+
 	@GetMapping("/subscriptions")
 	public boolean getSubscriptions(
 			@AuthenticationPrincipal Jwt jwt,
@@ -302,6 +337,9 @@ public class LicenseKeysRestController extends OneBaseRestController {
 		return licenseKeys;
 	}
 
+	private static final MediaType _CONTENT_TYPE_CSV = MediaType.parseMediaType(
+		"text/csv");
+
 	private static final int _MAX_PAGE_SIZE = 100;
 
 	@Autowired
@@ -309,6 +347,9 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 	@Autowired
 	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private LicenseKeyCSVExporter _licenseKeyCSVExporter;
 
 	@Autowired
 	private LicenseKeyPermission _licenseKeyPermission;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/LicenseKeysRestController.java
@@ -10,6 +10,7 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.exception.NoSuchLicenseKeyException;
 import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
@@ -21,6 +22,7 @@ import com.liferay.one.service.SubscriptionEntryService;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.json.JSONObject;
@@ -193,16 +195,18 @@ public class LicenseKeysRestController extends OneBaseRestController {
 			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
 		}
 
-		List<LicenseKey> licenseKeys = new ArrayList<>();
+		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
+			licenseKeyIds);
 
-		for (long licenseKeyId : licenseKeyIds) {
-			LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
-				licenseKeyId);
+		if (licenseKeys.size() < licenseKeyIds.length) {
+			throw new NoSuchLicenseKeyException(
+				"Unable to find every license key in " +
+					Arrays.toString(licenseKeyIds));
+		}
 
+		for (LicenseKey licenseKey : licenseKeys) {
 			_licenseKeyPermission.check(
 				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
-
-			licenseKeys.add(licenseKey);
 		}
 
 		return ResponseEntity.ok(
@@ -320,10 +324,7 @@ public class LicenseKeysRestController extends OneBaseRestController {
 
 		List<LicenseKey> licenseKeys = new ArrayList<>();
 
-		for (long licenseKeyId : licenseKeyIds) {
-			LicenseKey licenseKey = _licenseKeyService.getLicenseKey(
-				jwt, licenseKeyId);
-
+		for (LicenseKey licenseKey : _getLicenseKeys(jwt, licenseKeyIds)) {
 			if (!licenseKey.isActive()) {
 				continue;
 			}
@@ -332,6 +333,30 @@ public class LicenseKeysRestController extends OneBaseRestController {
 				licenseKey.getAccountEntryId(), ActionKeys.VIEW, jwt);
 
 			licenseKeys.add(licenseKey);
+		}
+
+		return licenseKeys;
+	}
+
+	//
+
+	// One filtered read rather than one read per id. Reading each key in turn
+	// cost a round trip to the object API for every id, which the account
+	// scoped export avoids by filtering, and a caller can pass any number of
+	// ids.
+
+	//
+
+	private List<LicenseKey> _getLicenseKeys(Jwt jwt, long[] licenseKeyIds)
+		throws Exception {
+
+		List<LicenseKey> licenseKeys = _licenseKeyService.getLicenseKeysByIds(
+			jwt, licenseKeyIds);
+
+		if (licenseKeys.size() < licenseKeyIds.length) {
+			throw new NoSuchLicenseKeyException(
+				"Unable to find every license key in " +
+					Arrays.toString(licenseKeyIds));
 		}
 
 		return licenseKeys;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementConstants.java
@@ -70,4 +70,10 @@ public class EntitlementConstants {
 		NAME_STANDARD_8_5_SUPPORT, NAME_STRATEGIC_24_7_SUPPORT
 	};
 
+	public static final String STATE_ACTIVE = "Active";
+
+	public static final String STATE_EXPIRED = "Expired";
+
+	public static final String STATE_UNACTIVATED = "Unactivated";
+
 }

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.model.LicenseKey;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Collection;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Allen Ziegenfus
+ */
+@Component
+public class LicenseKeyCSVExporter {
+
+	public String getFileName() {
+		return "activation-key-details.csv";
+	}
+
+	public String toCSV(Collection<LicenseKey> licenseKeys) throws Exception {
+		StringBundler sb = new StringBundler(1 + licenseKeys.size());
+
+		sb.append(_HEADER);
+
+		for (LicenseKey licenseKey : licenseKeys) {
+			long accountEntryId = licenseKey.getAccountEntryId();
+
+			Account account = _accountService.fetchAccount(accountEntryId);
+
+			sb.append(
+				_formatCSVFields(
+					licenseKey.getAccountName(),
+					_getExternalReferenceCode(account),
+					_entitlementService.getSubscriptionState(accountEntryId),
+					_getSupportRegion(account),
+					licenseKey.getProductVersionLabel(),
+					licenseKey.getProductName(), licenseKey.getLicenseKeyId(),
+					licenseKey.getIpAddresses(), licenseKey.getMacAddresses(),
+					licenseKey.getHostName(), licenseKey.getSizing(),
+					licenseKey.getStartDateInstant(),
+					licenseKey.getCustomExpirationDateInstant(),
+					_getStatus(licenseKey), _getMaxServersOrNodes(licenseKey),
+					licenseKey.isComplimentary()));
+		}
+
+		return sb.toString();
+	}
+
+	private String _formatCSVFields(Object... objects) {
+		StringBundler sb = new StringBundler((4 * objects.length) + 1);
+
+		for (int i = 0; i < objects.length; i++) {
+			sb.append(StringPool.QUOTE);
+			sb.append(objects[i]);
+			sb.append(StringPool.QUOTE);
+
+			if (i < (objects.length - 1)) {
+				sb.append(StringPool.COMMA);
+			}
+		}
+
+		sb.append(StringPool.NEW_LINE);
+
+		return sb.toString();
+	}
+
+	private String _getExternalReferenceCode(Account account) {
+		if (account == null) {
+			return StringPool.BLANK;
+		}
+
+		return account.getExternalReferenceCode();
+	}
+
+	private int _getMaxServersOrNodes(LicenseKey licenseKey) {
+		if (StringUtil.equals(
+				licenseKey.getLicenseType(),
+				LicenseConstants.TYPE_VIRTUAL_CLUSTER)) {
+
+			return licenseKey.getMaxClusterNodes();
+		}
+
+		return licenseKey.getMaxServers();
+	}
+
+	private String _getStatus(LicenseKey licenseKey) {
+		if (licenseKey.isActive()) {
+			return "Active";
+		}
+
+		return "Inactive";
+	}
+
+	private String _getSupportRegion(Account account) throws Exception {
+		if (account == null) {
+			return StringPool.BLANK;
+		}
+
+		AccountSupportInfo accountSupportInfo =
+			_commerceOrderService.getAccountSupportInfo(
+				account.getId(), account.getDefaultBillingAddressId());
+
+		if (accountSupportInfo == null) {
+			return StringPool.BLANK;
+		}
+
+		return accountSupportInfo.getSupportRegion();
+	}
+
+	private static final String _HEADER = StringBundler.concat(
+		"Project Name,Account Key,Project State,Support Region,Product ",
+		"Version,Product Name,License Key Id,IP Addresses,MAC Addresses,",
+		"Host Name,Instance Sizing,License Start Date,License Expiration ",
+		"Date,License Status,Max Servers/Cluster Nodes,Complimentary\n");
+
+	@Autowired
+	private AccountService _accountService;
+
+	@Autowired
+	private CommerceOrderService _commerceOrderService;
+
+	@Autowired
+	private EntitlementService _entitlementService;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
@@ -11,6 +11,7 @@ import com.liferay.one.model.LicenseKey;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
@@ -76,12 +77,17 @@ public class LicenseKeyCSVExporter {
 		return sb.toString();
 	}
 
+	private String _escapeCSVValue(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), CharPool.QUOTE, "\"\"");
+	}
+
 	private String _formatCSVFields(Object... objects) {
 		StringBundler sb = new StringBundler((4 * objects.length) + 1);
 
 		for (int i = 0; i < objects.length; i++) {
 			sb.append(StringPool.QUOTE);
-			sb.append(objects[i]);
+			sb.append(_escapeCSVValue(objects[i]));
 			sb.append(StringPool.QUOTE);
 
 			if (i < (objects.length - 1)) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
@@ -78,8 +78,22 @@ public class LicenseKeyCSVExporter {
 	}
 
 	private String _escapeCSVValue(Object object) {
-		return StringUtil.replace(
+		String value = StringUtil.replace(
 			String.valueOf(object), CharPool.QUOTE, "\"\"");
+
+		if (value.isEmpty()) {
+			return value;
+		}
+
+		char c = value.charAt(0);
+
+		if ((c == CharPool.AT) || (c == CharPool.DASH) ||
+			(c == CharPool.EQUAL) || (c == CharPool.PLUS)) {
+
+			return StringPool.APOSTROPHE.concat(value);
+		}
+
+		return value;
 	}
 
 	private String _formatCSVFields(Object... objects) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyCSVExporter.java
@@ -17,6 +17,8 @@ import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -36,17 +38,31 @@ public class LicenseKeyCSVExporter {
 
 		sb.append(_HEADER);
 
+		Map<Long, String> externalReferenceCodes = new HashMap<>();
+		Map<Long, String> subscriptionStates = new HashMap<>();
+		Map<Long, String> supportRegions = new HashMap<>();
+
 		for (LicenseKey licenseKey : licenseKeys) {
 			long accountEntryId = licenseKey.getAccountEntryId();
 
-			Account account = _accountService.fetchAccount(accountEntryId);
+			if (!externalReferenceCodes.containsKey(accountEntryId)) {
+				Account account = _accountService.fetchAccount(accountEntryId);
+
+				externalReferenceCodes.put(
+					accountEntryId, _getExternalReferenceCode(account));
+				supportRegions.put(accountEntryId, _getSupportRegion(account));
+
+				subscriptionStates.put(
+					accountEntryId,
+					_entitlementService.getSubscriptionState(accountEntryId));
+			}
 
 			sb.append(
 				_formatCSVFields(
 					licenseKey.getAccountName(),
-					_getExternalReferenceCode(account),
-					_entitlementService.getSubscriptionState(accountEntryId),
-					_getSupportRegion(account),
+					externalReferenceCodes.get(accountEntryId),
+					subscriptionStates.get(accountEntryId),
+					supportRegions.get(accountEntryId),
 					licenseKey.getProductVersionLabel(),
 					licenseKey.getProductName(), licenseKey.getLicenseKeyId(),
 					licenseKey.getIpAddresses(), licenseKey.getMacAddresses(),

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/license/LicenseKeyExporter.java
@@ -232,6 +232,12 @@ public class LicenseKeyExporter {
 	protected String formatFileName(String fileName) {
 		fileName = StringUtil.replace(
 			fileName, CharPool.SPACE, StringPool.BLANK);
+		fileName = StringUtil.replace(
+			fileName, CharPool.SLASH, StringPool.BLANK);
+		fileName = StringUtil.replace(
+			fileName, CharPool.BACK_SLASH, StringPool.BLANK);
+		fileName = StringUtil.replace(
+			fileName, CharPool.QUOTE, StringPool.BLANK);
 		fileName = StringUtil.toLowerCase(fileName);
 		fileName = fileName.substring(0, Math.min(fileName.length(), 251));
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -7,12 +7,14 @@ package com.liferay.one.service;
 
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.OrderItem;
+import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.exception.DuplicateEntitlementException;
 import com.liferay.one.model.Entitlement;
 import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.util.OrderItemUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -302,6 +304,24 @@ public class EntitlementService extends OneBaseService {
 			_NESTED_FIELDS_ENTITLEMENT_DEFINITION);
 	}
 
+	public String getSubscriptionState(long accountEntryId) throws Exception {
+		String state = StringPool.BLANK;
+
+		List<Entitlement> entitlements = getEntitlements(
+			"r_accountEntryToEntitlement_accountEntryId eq '" + accountEntryId +
+				"'");
+
+		for (Entitlement entitlement : entitlements) {
+			String curState = _getEntitlementState(entitlement);
+
+			if (_getStateRank(curState) > _getStateRank(state)) {
+				state = curState;
+			}
+		}
+
+		return state;
+	}
+
 	public boolean hasEntitlement(long accountId, String... entitlementNames)
 		throws Exception {
 
@@ -488,6 +508,22 @@ public class EntitlementService extends OneBaseService {
 		return new ArrayList<>(entitlementDefinitions.values());
 	}
 
+	private String _getEntitlementState(Entitlement entitlement) {
+		if (entitlement.isExpired()) {
+			return EntitlementConstants.STATE_EXPIRED;
+		}
+
+		Instant startDateInstant = entitlement.getStartDateInstant();
+
+		if ((startDateInstant != null) &&
+			startDateInstant.isAfter(Instant.now())) {
+
+			return EntitlementConstants.STATE_UNACTIVATED;
+		}
+
+		return EntitlementConstants.STATE_ACTIVE;
+	}
+
 	private Instant _getLatestInstant(
 		Instant endDateInstant, Instant startDateInstant) {
 
@@ -513,6 +549,22 @@ public class EntitlementService extends OneBaseService {
 		}
 
 		return GetterUtil.getString(customFields.get("salesforceProjectId"));
+	}
+
+	private int _getStateRank(String state) {
+		if (state.equals(EntitlementConstants.STATE_ACTIVE)) {
+			return 3;
+		}
+
+		if (state.equals(EntitlementConstants.STATE_UNACTIVATED)) {
+			return 2;
+		}
+
+		if (state.equals(EntitlementConstants.STATE_EXPIRED)) {
+			return 1;
+		}
+
+		return 0;
 	}
 
 	private boolean _hasEntitlement(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -19,6 +19,10 @@ import com.liferay.portal.ee.license.shared.LicenseConstants;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.io.ByteArrayOutputStream;
+
+import java.nio.charset.StandardCharsets;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
@@ -28,8 +32,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -417,6 +426,70 @@ public class LicenseKeyService extends OneBaseService {
 				"(active eq ", active, ") and (productName eq '",
 				_escapeODataString(productName), "') and (serverId eq '",
 				_escapeODataString(serverId), "')"));
+	}
+
+	public String getLicenseKeysDownloadFileName(List<LicenseKey> licenseKeys) {
+		Set<String> licenseKeyNames = new LinkedHashSet<>();
+		Set<String> productNames = new LinkedHashSet<>();
+
+		for (LicenseKey licenseKey : licenseKeys) {
+			licenseKeyNames.add(licenseKey.getName());
+			productNames.add(licenseKey.getProductName());
+		}
+
+		return _licenseKeyExporter.getFileName(
+			productNames.toArray(new String[0]),
+			licenseKeyNames.toArray(new String[0]));
+	}
+
+	public String getLicenseKeysDownloadXML(List<LicenseKey> licenseKeys)
+		throws Exception {
+
+		String[] xmls = new String[licenseKeys.size()];
+
+		for (int i = 0; i < licenseKeys.size(); i++) {
+			xmls[i] = getLicenseKeyDownloadXML(licenseKeys.get(i));
+		}
+
+		return _licenseKeyExporter.aggregateXMLs(xmls);
+	}
+
+	public byte[] getLicenseKeysDownloadZip(List<LicenseKey> licenseKeys)
+		throws Exception {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		Set<String> fileNames = new HashSet<>();
+
+		try (ZipOutputStream zipOutputStream = new ZipOutputStream(
+				byteArrayOutputStream)) {
+
+			for (LicenseKey licenseKey : licenseKeys) {
+				String fileName = getLicenseKeyDownloadFileName(licenseKey);
+
+				if (!fileNames.add(fileName)) {
+					fileName = StringBundler.concat(
+						licenseKey.getLicenseKeyId(), "-", fileName);
+
+					fileNames.add(fileName);
+				}
+
+				zipOutputStream.putNextEntry(new ZipEntry(fileName));
+
+				byte[] bytes = getLicenseKeyDownloadXML(
+					licenseKey
+				).getBytes(
+					StandardCharsets.UTF_8
+				);
+
+				zipOutputStream.write(bytes, 0, bytes.length);
+
+				zipOutputStream.closeEntry();
+			}
+		}
+
+		return byteArrayOutputStream.toByteArray();
 	}
 
 	public JSONObject getLicenseKeysPage(int page, int pageSize)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -31,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -419,6 +420,10 @@ public class LicenseKeyService extends OneBaseService {
 
 	public List<LicenseKey> getLicenseKeysByIds(Jwt jwt, long[] licenseKeyIds)
 		throws Exception {
+
+		if (licenseKeyIds.length == 0) {
+			return Collections.emptyList();
+		}
 
 		return getAllItems(
 			"/o/c/licensekeys", _toIdFilterString(licenseKeyIds),

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -777,13 +777,6 @@ public class LicenseKeyService extends OneBaseService {
 		return jsonObject.optInt("totalCount");
 	}
 
-	//
-
-	// The object API rejects an unquoted id with "Incompatible types", so each
-	// value is quoted. There is no in operator to lean on here.
-
-	//
-
 	private String _toIdFilterString(long[] licenseKeyIds) {
 		StringBundler sb = new StringBundler(licenseKeyIds.length * 4);
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -417,6 +417,20 @@ public class LicenseKeyService extends OneBaseService {
 				accountEntryId, "'"));
 	}
 
+	public List<LicenseKey> getLicenseKeysByIds(Jwt jwt, long[] licenseKeyIds)
+		throws Exception {
+
+		return getAllItems(
+			"/o/c/licensekeys", _toIdFilterString(licenseKeyIds),
+			LicenseKey::new, jwt);
+	}
+
+	public List<LicenseKey> getLicenseKeysByIds(long[] licenseKeyIds)
+		throws Exception {
+
+		return getLicenseKeys(_toIdFilterString(licenseKeyIds));
+	}
+
 	public List<LicenseKey> getLicenseKeysByName(
 			boolean active, String productName, String serverId)
 		throws Exception {
@@ -761,6 +775,29 @@ public class LicenseKeyService extends OneBaseService {
 		JSONObject jsonObject = new JSONObject(response);
 
 		return jsonObject.optInt("totalCount");
+	}
+
+	//
+
+	// The object API rejects an unquoted id with "Incompatible types", so each
+	// value is quoted. There is no in operator to lean on here.
+
+	//
+
+	private String _toIdFilterString(long[] licenseKeyIds) {
+		StringBundler sb = new StringBundler(licenseKeyIds.length * 4);
+
+		for (int i = 0; i < licenseKeyIds.length; i++) {
+			if (i > 0) {
+				sb.append(" or ");
+			}
+
+			sb.append("(id eq '");
+			sb.append(licenseKeyIds[i]);
+			sb.append("')");
+		}
+
+		return sb.toString();
 	}
 
 	private String _toISO8601(Date date) {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/LicenseKeyService.java
@@ -425,12 +425,6 @@ public class LicenseKeyService extends OneBaseService {
 			LicenseKey::new, jwt);
 	}
 
-	public List<LicenseKey> getLicenseKeysByIds(long[] licenseKeyIds)
-		throws Exception {
-
-		return getLicenseKeys(_toIdFilterString(licenseKeyIds));
-	}
-
 	public List<LicenseKey> getLicenseKeysByName(
 			boolean active, String productName, String serverId)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -13,6 +13,7 @@ import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
+import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.AccountInvitation;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
@@ -51,6 +52,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -354,6 +356,56 @@ public class AccountsRestControllerTest {
 			licenseKeys,
 			accountsRestController.getLicenseKeys(
 				null, _EXTERNAL_REFERENCE_CODE));
+
+		Mockito.verify(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
+	}
+
+	@Test
+	public void testGetLicenseKeysExport() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		List<LicenseKey> licenseKeys = Collections.singletonList(
+			Mockito.mock(LicenseKey.class));
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysByAccountEntryId(_ACCOUNT_ID)
+		).thenReturn(
+			licenseKeys
+		);
+
+		Mockito.when(
+			_licenseKeyCSVExporter.getFileName()
+		).thenReturn(
+			"activation-key-details.csv"
+		);
+
+		Mockito.when(
+			_licenseKeyCSVExporter.toCSV(licenseKeys)
+		).thenReturn(
+			"csv"
+		);
+
+		ResponseEntity<String> responseEntity =
+			accountsRestController.getLicenseKeysExport(
+				null, _EXTERNAL_REFERENCE_CODE);
+
+		Assertions.assertEquals("csv", responseEntity.getBody());
+
+		HttpHeaders httpHeaders = responseEntity.getHeaders();
+
+		Assertions.assertEquals(
+			"attachment; filename=\"activation-key-details.csv\"",
+			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
 
 		Mockito.verify(
 			_licenseKeyPermission
@@ -1445,6 +1497,9 @@ public class AccountsRestControllerTest {
 		ReflectionTestUtils.setField(
 			accountsRestController, "_keyedLock", new KeyedLock());
 		ReflectionTestUtils.setField(
+			accountsRestController, "_licenseKeyCSVExporter",
+			_licenseKeyCSVExporter);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_licenseKeyPermission",
 			_licenseKeyPermission);
 		ReflectionTestUtils.setField(
@@ -1587,6 +1642,8 @@ public class AccountsRestControllerTest {
 		Mockito.mock(EmailAddressValidatorService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
 		EntitlementService.class);
+	private final LicenseKeyCSVExporter _licenseKeyCSVExporter = Mockito.mock(
+		LicenseKeyCSVExporter.class);
 	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(
 		LicenseKeyPermission.class);
 	private final LicenseKeyService _licenseKeyService = Mockito.mock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -404,7 +404,7 @@ public class LicenseKeysRestControllerTest {
 		Mockito.verify(
 			_licenseKeyPermission
 		).check(
-			_ACCOUNT_ID, ActionKeys.VIEW, null
+			Mockito.any(), Mockito.eq(_ACCOUNT_ID), Mockito.eq(ActionKeys.VIEW)
 		);
 	}
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -409,6 +409,25 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysExportWhenLicenseKeyIdsExceedsTheMaximum()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysExport(
+					null, new long[101]));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyCSVExporter);
+	}
+
+	@Test
 	public void testGetLicenseKeysExportWhenLicenseKeyIdsIsEmpty()
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -312,6 +312,44 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysDownloadWhenLicenseKeyIdsExceedsTheMaximum()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysDownload(
+					null, new long[101]));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyService);
+	}
+
+	@Test
+	public void testGetLicenseKeysDownloadWhenLicenseKeyIdsIsEmpty()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysDownload(
+					null, new long[0]));
+
+		Assertions.assertEquals(
+			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyService);
+	}
+
+	@Test
 	public void testGetLicenseKeysDownloadZip() throws Exception {
 		LicenseKeysRestController licenseKeysRestController =
 			_createController();
@@ -356,6 +394,44 @@ public class LicenseKeysRestControllerTest {
 		Assertions.assertEquals(
 			"attachment; filename=\"activation-keys.zip\"",
 			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
+	}
+
+	@Test
+	public void testGetLicenseKeysDownloadZipWhenLicenseKeyIdsExceedsTheMaximum()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysDownloadZip(
+					null, new long[101]));
+
+		Assertions.assertEquals(
+			HttpStatus.BAD_REQUEST, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyService);
+	}
+
+	@Test
+	public void testGetLicenseKeysDownloadZipWhenLicenseKeyIdsIsEmpty()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysDownloadZip(
+					null, new long[0]));
+
+		Assertions.assertEquals(
+			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyService);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -22,6 +22,9 @@ import com.liferay.one.service.UserAccountService;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.json.JSONObject;
 
 import org.junit.jupiter.api.Assertions;
@@ -198,9 +201,10 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.when(
-			_licenseKeyService.getLicenseKey(Mockito.any(), Mockito.anyLong())
+			_licenseKeyService.getLicenseKeysByIds(
+				Mockito.any(), Mockito.any(long[].class))
 		).thenReturn(
-			licenseKey
+			Arrays.asList(licenseKey, licenseKey)
 		);
 
 		Mockito.when(
@@ -327,9 +331,10 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.when(
-			_licenseKeyService.getLicenseKey(Mockito.any(), Mockito.anyLong())
+			_licenseKeyService.getLicenseKeysByIds(
+				Mockito.any(), Mockito.any(long[].class))
 		).thenReturn(
-			licenseKey
+			Collections.singletonList(licenseKey)
 		);
 
 		byte[] zip = {1, 2, 3};
@@ -367,9 +372,9 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.when(
-			_licenseKeyService.getLicenseKey(1L)
+			_licenseKeyService.getLicenseKeysByIds(new long[] {1L})
 		).thenReturn(
-			licenseKey
+			Collections.singletonList(licenseKey)
 		);
 
 		Mockito.when(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -372,7 +372,8 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.when(
-			_licenseKeyService.getLicenseKeysByIds(new long[] {1L})
+			_licenseKeyService.getLicenseKeysByIds(
+				Mockito.any(), Mockito.any(long[].class))
 		).thenReturn(
 			Collections.singletonList(licenseKey)
 		);
@@ -462,7 +463,8 @@ public class LicenseKeysRestControllerTest {
 		);
 
 		Mockito.when(
-			_licenseKeyService.getLicenseKeysByIds(new long[] {1L})
+			_licenseKeyService.getLicenseKeysByIds(
+				Mockito.any(), Mockito.any(long[].class))
 		).thenReturn(
 			Collections.singletonList(licenseKey)
 		);

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -10,6 +10,7 @@ import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Account;
 import com.liferay.headless.commerce.admin.order.client.dto.v1_0.Order;
 import com.liferay.one.constants.ClassNameConstants;
 import com.liferay.one.constants.CommerceOrderConstants;
+import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.SubscriptionEntry;
 import com.liferay.one.permission.AdminPermission;
@@ -353,6 +354,75 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysExport() throws Exception {
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ID
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKey(1L)
+		).thenReturn(
+			licenseKey
+		);
+
+		Mockito.when(
+			_licenseKeyCSVExporter.getFileName()
+		).thenReturn(
+			"activation-key-details.csv"
+		);
+
+		Mockito.when(
+			_licenseKeyCSVExporter.toCSV(Mockito.anyList())
+		).thenReturn(
+			"csv"
+		);
+
+		ResponseEntity<String> responseEntity =
+			licenseKeysRestController.getLicenseKeysExport(
+				null, new long[] {1L});
+
+		Assertions.assertEquals("csv", responseEntity.getBody());
+
+		HttpHeaders httpHeaders = responseEntity.getHeaders();
+
+		Assertions.assertEquals(
+			"attachment; filename=\"activation-key-details.csv\"",
+			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
+
+		Mockito.verify(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
+	}
+
+	@Test
+	public void testGetLicenseKeysExportWhenLicenseKeyIdsIsEmpty()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> licenseKeysRestController.getLicenseKeysExport(
+					null, new long[0]));
+
+		Assertions.assertEquals(
+			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_licenseKeyCSVExporter);
+	}
+
+	@Test
 	public void testGetLicenseKeysThrowsBadRequestWhenPageSizeIsOutOfRange()
 		throws Exception {
 
@@ -660,6 +730,10 @@ public class LicenseKeysRestControllerTest {
 			_commerceOrderService);
 
 		ReflectionTestUtils.setField(
+			licenseKeysRestController, "_licenseKeyCSVExporter",
+			_licenseKeyCSVExporter);
+
+		ReflectionTestUtils.setField(
 			licenseKeysRestController, "_licenseKeyPermission",
 			_licenseKeyPermission);
 
@@ -686,6 +760,8 @@ public class LicenseKeysRestControllerTest {
 		AdminPermission.class);
 	private final CommerceOrderService _commerceOrderService = Mockito.mock(
 		CommerceOrderService.class);
+	private final LicenseKeyCSVExporter _licenseKeyCSVExporter = Mockito.mock(
+		LicenseKeyCSVExporter.class);
 	private final LicenseKeyPermission _licenseKeyPermission = Mockito.mock(
 		LicenseKeyPermission.class);
 	private final LicenseKeyService _licenseKeyService = Mockito.mock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -167,7 +167,7 @@ public class LicenseKeysRestControllerTest {
 			"attachment; filename=\"activation-key.xml\"",
 			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
 		Assertions.assertEquals(
-			MediaType.APPLICATION_XML, httpHeaders.getContentType());
+			MediaType.TEXT_XML, httpHeaders.getContentType());
 
 		Mockito.verify(
 			_licenseKeyPermission
@@ -227,7 +227,7 @@ public class LicenseKeysRestControllerTest {
 			"attachment; filename=\"activation-keys.xml\"",
 			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
 		Assertions.assertEquals(
-			MediaType.APPLICATION_XML, httpHeaders.getContentType());
+			MediaType.TEXT_XML, httpHeaders.getContentType());
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -428,6 +428,40 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysExportWhenLicenseKeyIdsRepeat()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ID
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysByIds(new long[] {1L})
+		).thenReturn(
+			Collections.singletonList(licenseKey)
+		);
+
+		Mockito.when(
+			_licenseKeyCSVExporter.toCSV(Mockito.anyList())
+		).thenReturn(
+			"csv"
+		);
+
+		ResponseEntity<String> responseEntity =
+			licenseKeysRestController.getLicenseKeysExport(
+				null, new long[] {1L, 1L});
+
+		Assertions.assertEquals("csv", responseEntity.getBody());
+	}
+
+	@Test
 	public void testGetLicenseKeysThrowsBadRequestWhenPageSizeIsOutOfRange()
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/LicenseKeysRestControllerTest.java
@@ -176,6 +176,60 @@ public class LicenseKeysRestControllerTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysDownloadAggregatesActiveKeys()
+		throws Exception {
+
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ID
+		);
+
+		Mockito.when(
+			licenseKey.isActive()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKey(Mockito.any(), Mockito.anyLong())
+		).thenReturn(
+			licenseKey
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysDownloadFileName(Mockito.anyList())
+		).thenReturn(
+			"activation-keys.xml"
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysDownloadXML(Mockito.anyList())
+		).thenReturn(
+			"<licenses/>"
+		);
+
+		ResponseEntity<String> responseEntity =
+			licenseKeysRestController.getLicenseKeysDownload(
+				null, new long[] {1L, 2L});
+
+		Assertions.assertEquals("<licenses/>", responseEntity.getBody());
+
+		HttpHeaders httpHeaders = responseEntity.getHeaders();
+
+		Assertions.assertEquals(
+			"attachment; filename=\"activation-keys.xml\"",
+			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
+		Assertions.assertEquals(
+			MediaType.APPLICATION_XML, httpHeaders.getContentType());
+	}
+
+	@Test
 	public void testGetLicenseKeysDownloadThrowsForbiddenWhenAccountNotViewable()
 		throws Exception {
 
@@ -250,6 +304,52 @@ public class LicenseKeysRestControllerTest {
 
 		Assertions.assertEquals(
 			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+	}
+
+	@Test
+	public void testGetLicenseKeysDownloadZip() throws Exception {
+		LicenseKeysRestController licenseKeysRestController =
+			_createController();
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ID
+		);
+
+		Mockito.when(
+			licenseKey.isActive()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKey(Mockito.any(), Mockito.anyLong())
+		).thenReturn(
+			licenseKey
+		);
+
+		byte[] zip = {1, 2, 3};
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysDownloadZip(Mockito.anyList())
+		).thenReturn(
+			zip
+		);
+
+		ResponseEntity<byte[]> responseEntity =
+			licenseKeysRestController.getLicenseKeysDownloadZip(
+				null, new long[] {1L});
+
+		Assertions.assertSame(zip, responseEntity.getBody());
+
+		HttpHeaders httpHeaders = responseEntity.getHeaders();
+
+		Assertions.assertEquals(
+			"attachment; filename=\"activation-keys.zip\"",
+			httpHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION));
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
@@ -103,6 +103,61 @@ public class LicenseKeyCSVExporterTest {
 	}
 
 	@Test
+	public void testToCSVResolvesEachAccountOnce() throws Exception {
+		Account account = new Account();
+
+		account.setDefaultBillingAddressId(4L);
+		account.setExternalReferenceCode("ACCNT-1");
+		account.setId(_ACCOUNT_ENTRY_ID);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(_ACCOUNT_ENTRY_ID, 4L)
+		).thenReturn(
+			new AccountSupportInfo("en_US", "US")
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			"Active"
+		);
+
+		String csv = _licenseKeyCSVExporter.toCSV(
+			List.of(
+				_createLicenseKey("enterprise"),
+				_createLicenseKey("enterprise"),
+				_createLicenseKey("enterprise")));
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(4, lines.size());
+
+		Mockito.verify(
+			_accountService, Mockito.times(1)
+		).fetchAccount(
+			_ACCOUNT_ENTRY_ID
+		);
+
+		Mockito.verify(
+			_commerceOrderService, Mockito.times(1)
+		).getAccountSupportInfo(
+			_ACCOUNT_ENTRY_ID, 4L
+		);
+
+		Mockito.verify(
+			_entitlementService, Mockito.times(1)
+		).getSubscriptionState(
+			_ACCOUNT_ENTRY_ID
+		);
+	}
+
+	@Test
 	public void testToCSVWhenAccountIsNull() throws Exception {
 		Mockito.when(
 			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
@@ -11,8 +11,10 @@ import com.liferay.one.model.LicenseKey;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.CommerceOrderService;
 import com.liferay.one.service.EntitlementService;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.ee.license.shared.LicenseConstants;
+import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Collections;
 import java.util.List;
@@ -100,6 +102,59 @@ public class LicenseKeyCSVExporterTest {
 				"\"12\",\"1.2.3.4\",\"AA:BB\",\"acme.host\",\"4\",\"null\"," +
 					"\"null\",\"Active\",\"9\",\"false\"",
 			lines.get(1));
+	}
+
+	@Test
+	public void testToCSVEscapesQuotes() throws Exception {
+		Account account = new Account();
+
+		account.setDefaultBillingAddressId(4L);
+		account.setExternalReferenceCode("ACCNT-1");
+		account.setId(_ACCOUNT_ENTRY_ID);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(_ACCOUNT_ENTRY_ID, 4L)
+		).thenReturn(
+			new AccountSupportInfo("en_US", "US")
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			"Active"
+		);
+
+		LicenseKey licenseKey = _createLicenseKey("enterprise");
+
+		Mockito.when(
+			licenseKey.getHostName()
+		).thenReturn(
+			"say \"hello\", friend"
+		);
+
+		String csv = _licenseKeyCSVExporter.toCSV(
+			Collections.singletonList(licenseKey));
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(2, lines.size());
+
+		Assertions.assertTrue(
+			lines.get(
+				1
+			).contains(
+				"\"say \"\"hello\"\", friend\""
+			),
+			lines.get(1));
+
+		Assertions.assertEquals(
+			16, StringUtil.count(lines.get(0), CharPool.COMMA) + 1);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
@@ -1,0 +1,245 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.license;
+
+import com.liferay.headless.admin.user.client.dto.v1_0.Account;
+import com.liferay.one.model.AccountSupportInfo;
+import com.liferay.one.model.LicenseKey;
+import com.liferay.one.service.AccountService;
+import com.liferay.one.service.CommerceOrderService;
+import com.liferay.one.service.EntitlementService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.ee.license.shared.LicenseConstants;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class LicenseKeyCSVExporterTest {
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		_licenseKeyCSVExporter = new LicenseKeyCSVExporter();
+
+		_accountService = Mockito.mock(AccountService.class);
+		_commerceOrderService = Mockito.mock(CommerceOrderService.class);
+		_entitlementService = Mockito.mock(EntitlementService.class);
+
+		ReflectionTestUtils.setField(
+			_licenseKeyCSVExporter, "_accountService", _accountService);
+		ReflectionTestUtils.setField(
+			_licenseKeyCSVExporter, "_commerceOrderService",
+			_commerceOrderService);
+		ReflectionTestUtils.setField(
+			_licenseKeyCSVExporter, "_entitlementService", _entitlementService);
+	}
+
+	@Test
+	public void testGetFileName() {
+		Assertions.assertEquals(
+			"activation-key-details.csv", _licenseKeyCSVExporter.getFileName());
+	}
+
+	@Test
+	public void testToCSV() throws Exception {
+		Account account = new Account();
+
+		account.setDefaultBillingAddressId(4L);
+		account.setExternalReferenceCode("ACCNT-1");
+		account.setId(_ACCOUNT_ENTRY_ID);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(_ACCOUNT_ENTRY_ID, 4L)
+		).thenReturn(
+			new AccountSupportInfo("en_US", "US")
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			"Active"
+		);
+
+		String csv = _licenseKeyCSVExporter.toCSV(
+			Collections.singletonList(_createLicenseKey("enterprise")));
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(2, lines.size());
+
+		Assertions.assertEquals(
+			StringBundler.concat(
+				"Project Name,Account Key,Project State,Support Region,",
+				"Product Version,Product Name,License Key Id,IP Addresses,",
+				"MAC Addresses,Host Name,Instance Sizing,License Start Date,",
+				"License Expiration Date,License Status,Max Servers/Cluster ",
+				"Nodes,Complimentary"),
+			lines.get(0));
+
+		Assertions.assertEquals(
+			"\"Acme\",\"ACCNT-1\",\"Active\",\"US\",\"7.4 U100\",\"DXP\"," +
+				"\"12\",\"1.2.3.4\",\"AA:BB\",\"acme.host\",\"4\",\"null\"," +
+					"\"null\",\"Active\",\"9\",\"false\"",
+			lines.get(1));
+	}
+
+	@Test
+	public void testToCSVWhenAccountIsNull() throws Exception {
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			""
+		);
+
+		String csv = _licenseKeyCSVExporter.toCSV(
+			Collections.singletonList(_createLicenseKey("enterprise")));
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(
+			"\"Acme\",\"\",\"\",\"\",\"7.4 U100\",\"DXP\",\"12\",\"1.2.3.4\"," +
+				"\"AA:BB\",\"acme.host\",\"4\",\"null\",\"null\",\"Active\"," +
+					"\"9\",\"false\"",
+			lines.get(1));
+
+		Mockito.verifyNoInteractions(_commerceOrderService);
+	}
+
+	@Test
+	public void testToCSVWhenLicenseTypeIsVirtualCluster() throws Exception {
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			null
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			""
+		);
+
+		String csv = _licenseKeyCSVExporter.toCSV(
+			Collections.singletonList(
+				_createLicenseKey(LicenseConstants.TYPE_VIRTUAL_CLUSTER)));
+
+		Assertions.assertTrue(csv.contains("\"Active\",\"3\",\"false\""));
+	}
+
+	private LicenseKey _createLicenseKey(String licenseType) {
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getAccountEntryId()
+		).thenReturn(
+			_ACCOUNT_ENTRY_ID
+		);
+
+		Mockito.when(
+			licenseKey.getAccountName()
+		).thenReturn(
+			"Acme"
+		);
+
+		Mockito.when(
+			licenseKey.getHostName()
+		).thenReturn(
+			"acme.host"
+		);
+
+		Mockito.when(
+			licenseKey.getIpAddresses()
+		).thenReturn(
+			"1.2.3.4"
+		);
+
+		Mockito.when(
+			licenseKey.getLicenseKeyId()
+		).thenReturn(
+			12L
+		);
+
+		Mockito.when(
+			licenseKey.getLicenseType()
+		).thenReturn(
+			licenseType
+		);
+
+		Mockito.when(
+			licenseKey.getMacAddresses()
+		).thenReturn(
+			"AA:BB"
+		);
+
+		Mockito.when(
+			licenseKey.getMaxClusterNodes()
+		).thenReturn(
+			3
+		);
+
+		Mockito.when(
+			licenseKey.getMaxServers()
+		).thenReturn(
+			9
+		);
+
+		Mockito.when(
+			licenseKey.getProductName()
+		).thenReturn(
+			"DXP"
+		);
+
+		Mockito.when(
+			licenseKey.getProductVersionLabel()
+		).thenReturn(
+			"7.4 U100"
+		);
+
+		Mockito.when(
+			licenseKey.getSizing()
+		).thenReturn(
+			"4"
+		);
+
+		Mockito.when(
+			licenseKey.isActive()
+		).thenReturn(
+			true
+		);
+
+		return licenseKey;
+	}
+
+	private static final long _ACCOUNT_ENTRY_ID = 55L;
+
+	private AccountService _accountService;
+	private CommerceOrderService _commerceOrderService;
+	private EntitlementService _entitlementService;
+	private LicenseKeyCSVExporter _licenseKeyCSVExporter;
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
@@ -138,6 +138,60 @@ public class LicenseKeyCSVExporterTest {
 			"say \"hello\", friend"
 		);
 
+		String csv = _licenseKeyCSVExporter.toCSV(
+			Collections.singletonList(licenseKey));
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(2, lines.size());
+
+		Assertions.assertTrue(
+			lines.get(
+				1
+			).contains(
+				"\"say \"\"hello\"\", friend\""
+			),
+			lines.get(1));
+	}
+
+	@Test
+	public void testToCSVHeaderColumnCount() throws Exception {
+		String csv = _licenseKeyCSVExporter.toCSV(Collections.emptyList());
+
+		List<String> lines = List.of(csv.split("\n"));
+
+		Assertions.assertEquals(
+			16, StringUtil.count(lines.get(0), CharPool.COMMA) + 1);
+	}
+
+	@Test
+	public void testToCSVNeutralizesFormulas() throws Exception {
+		Account account = new Account();
+
+		account.setDefaultBillingAddressId(4L);
+		account.setExternalReferenceCode("ACCNT-1");
+		account.setId(_ACCOUNT_ENTRY_ID);
+
+		Mockito.when(
+			_accountService.fetchAccount(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			account
+		);
+
+		Mockito.when(
+			_commerceOrderService.getAccountSupportInfo(_ACCOUNT_ENTRY_ID, 4L)
+		).thenReturn(
+			new AccountSupportInfo("en_US", "US")
+		);
+
+		Mockito.when(
+			_entitlementService.getSubscriptionState(_ACCOUNT_ENTRY_ID)
+		).thenReturn(
+			"Active"
+		);
+
+		LicenseKey licenseKey = _createLicenseKey("enterprise");
+
 		Mockito.when(
 			licenseKey.getIpAddresses()
 		).thenReturn(
@@ -155,20 +209,9 @@ public class LicenseKeyCSVExporterTest {
 			lines.get(
 				1
 			).contains(
-				"\"say \"\"hello\"\", friend\""
-			),
-			lines.get(1));
-
-		Assertions.assertTrue(
-			lines.get(
-				1
-			).contains(
 				"\"'=1+1\""
 			),
 			lines.get(1));
-
-		Assertions.assertEquals(
-			16, StringUtil.count(lines.get(0), CharPool.COMMA) + 1);
 	}
 
 	@Test

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyCSVExporterTest.java
@@ -138,6 +138,12 @@ public class LicenseKeyCSVExporterTest {
 			"say \"hello\", friend"
 		);
 
+		Mockito.when(
+			licenseKey.getIpAddresses()
+		).thenReturn(
+			"=1+1"
+		);
+
 		String csv = _licenseKeyCSVExporter.toCSV(
 			Collections.singletonList(licenseKey));
 
@@ -150,6 +156,14 @@ public class LicenseKeyCSVExporterTest {
 				1
 			).contains(
 				"\"say \"\"hello\"\", friend\""
+			),
+			lines.get(1));
+
+		Assertions.assertTrue(
+			lines.get(
+				1
+			).contains(
+				"\"'=1+1\""
 			),
 			lines.get(1));
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyExporterTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/license/LicenseKeyExporterTest.java
@@ -64,6 +64,21 @@ public class LicenseKeyExporterTest {
 	}
 
 	@Test
+	public void testGetFileNameStripsPathSeparators() {
+		Assertions.assertEquals(
+			"activation-key-dxp-7.4-......etccron.d.xml",
+			_licenseKeyExporter.getFileName(
+				"DXP", "7.4", "../../../etc/cron.d"));
+	}
+
+	@Test
+	public void testGetFileNameStripsQuotes() {
+		Assertions.assertEquals(
+			"activation-key-dxp-7.4-evil.xml",
+			_licenseKeyExporter.getFileName("DXP", "7.4", "ev\"il"));
+	}
+
+	@Test
 	public void testToXMLEscapesSpecialCharacters() throws Exception {
 		String xml = _licenseKeyExporter.toXML(
 			"TESTKEY", "Acme Corp", "Enterprise",

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/service/LicenseKeyServiceTest.java
@@ -240,6 +240,21 @@ public class LicenseKeyServiceTest {
 	}
 
 	@Test
+	public void testGetLicenseKeysByIdsWhenLicenseKeyIdsIsEmpty()
+		throws Exception {
+
+		Assertions.assertEquals(
+			Collections.emptyList(),
+			_licenseKeyService.getLicenseKeysByIds(null, new long[0]));
+
+		Mockito.verify(
+			_licenseKeyService, Mockito.never()
+		).getAllItems(
+			Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
 	public void testGetLicenseKeysByNameFilter() throws Exception {
 		_licenseKeyService.getLicenseKeysByName(true, "DXP", "srv-1");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91426

## What is being fixed

AC #2 of the port: the license key download, download zip, and CSV export endpoints still lived only in the legacy `osb-provisioning-rest` resource, so nothing in the client extension could serve an activation key or an export.

Porting them surfaced problems the legacy shape carried. The resource read each requested key with its own round trip and resolved the caller's user account once per key, which at a hundred keys meant a hundred sequential reads of each. The CSV quoted every value but never escaped an embedded quote, so a host name containing one produced a broken row, and a value opening with `=`, `+`, `-`, or `@` was a live formula when the file reached a spreadsheet. The download file name was concatenated into `Content-Disposition` unsanitized, so a key name carrying a path separator escaped the intended name. The XML downloads answered `application/xml` where the legacy resource answered `text/xml`.

## How it is being fixed

The requested keys are read in one filtered call rather than one call per id, and the caller's user account is resolved once and reused across the permission checks. Against a hundred keys that is one upstream read instead of a hundred: measured locally, 49.1 seconds to 0.5 seconds, because a single filtered read of a hundred keys costs about what a single-key read costs.

Requests are bounded at both ends. A list longer than a hundred ids is rejected with a 400, and an empty list is rejected with a 404 — the same status the legacy resource returned. The empty case matters more than it looks: an empty id array builds an empty filter, an empty filter is no filter, and the read would otherwise return every license key the caller could see, key material included. The service refuses to read with an empty filter as well, so the guard does not depend on a single caller getting it right.

The CSV doubles embedded quotes and prefixes a formula-leading value with an apostrophe, and the download file name is stripped of path separators and quotes. The XML downloads now answer `text/xml`, matching the legacy resource. `LicenseKey.getKey()` is annotated so key material cannot serialize into a JSON response, which the export and the model both have tests for; the XML download still carries it, since that is the license file itself.

Repeated ids no longer produce a spurious 404, and the permission check now runs before an inactive key is skipped, so an unauthorized caller cannot learn a key's state from which error it gets.
