### PR TITLE
LPD-91426 Add the license key product usage report endpoint

### DIFF
--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/AccountsRestController.java
@@ -17,6 +17,8 @@ import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.AccountInvitation;
+import com.liferay.one.model.Entitlement;
+import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
 import com.liferay.one.okta.service.OktaService;
@@ -28,6 +30,7 @@ import com.liferay.one.service.AccountInvitationEmailService;
 import com.liferay.one.service.AccountInvitationService;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
+import com.liferay.one.service.EntitlementDefinitionService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.ProjectService;
@@ -36,22 +39,26 @@ import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.FindUtil;
 import com.liferay.one.util.KeyedLock;
+import com.liferay.one.util.TermCountUtil;
 import com.liferay.one.util.UserAccountUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -230,6 +237,49 @@ public class AccountsRestController extends OneBaseRestController {
 			_licenseKeyCSVExporter.toCSV(
 				_licenseKeyService.getLicenseKeysByAccountEntryId(
 					account.getId()))
+		);
+	}
+
+	@GetMapping("/{accountKey}/products/{productExternalReferenceCode}/usage")
+	public ResponseEntity<String> getProductUsage(
+			@AuthenticationPrincipal Jwt jwt,
+			@PathVariable("accountKey") String accountKey,
+			@PathVariable("productExternalReferenceCode") String
+				productExternalReferenceCode)
+		throws Exception {
+
+		Account account = _accountService.getAccount(accountKey, jwt);
+
+		_licenseKeyPermission.check(account.getId(), ActionKeys.VIEW, jwt);
+
+		if (!ArrayUtil.contains(
+				EntitlementConstants.EXTERNAL_REFERENCE_CODES_SELF_HOSTED,
+				productExternalReferenceCode)) {
+
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		EntitlementDefinition entitlementDefinition =
+			_entitlementDefinitionService.fetchEntitlementDefinition(
+				productExternalReferenceCode);
+
+		if (entitlementDefinition == null) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		List<Entitlement> entitlements = _entitlementService.getEntitlements(
+			account.getId(),
+			entitlementDefinition.getEntitlementDefinitionId());
+
+		if (entitlements.isEmpty()) {
+			throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+		}
+
+		return ResponseEntity.ok(
+		).contentType(
+			MediaType.APPLICATION_JSON
+		).body(
+			_getProductUsageJSON(account, entitlements)
 		);
 	}
 
@@ -663,6 +713,82 @@ public class AccountsRestController extends OneBaseRestController {
 		return accountInvitation;
 	}
 
+	private String _getProductUsageJSON(
+			Account account, List<Entitlement> entitlements)
+		throws Exception {
+
+		int currentYear = TermCountUtil.getYear(Instant.now());
+
+		TreeMap<Instant, Integer> consumptionCounts = new TreeMap<>();
+		TreeMap<Instant, Integer> subscriptionCounts = new TreeMap<>();
+
+		Set<Long> entitlementIds = new HashSet<>();
+
+		for (Entitlement entitlement : entitlements) {
+			entitlementIds.add(entitlement.getEntitlementId());
+
+			Double quantity = entitlement.getQuantity();
+
+			int count = 0;
+
+			if (quantity != null) {
+				count = quantity.intValue();
+			}
+
+			TermCountUtil.consolidate(
+				subscriptionCounts, currentYear,
+				entitlement.getStartDateInstant(),
+				entitlement.getEndDateInstant(), count);
+		}
+
+		for (LicenseKey licenseKey :
+				_licenseKeyService.getLicenseKeysByAccountEntryId(
+					account.getId())) {
+
+			if (!entitlementIds.contains(licenseKey.getEntitlementId())) {
+				continue;
+			}
+
+			TermCountUtil.consolidate(
+				consumptionCounts, currentYear,
+				licenseKey.getStartDateInstant(),
+				licenseKey.getCustomExpirationDateInstant(), 1);
+		}
+
+		Map<Integer, Integer> maxConcurrentConsumptions =
+			TermCountUtil.getMaxConcurrentCounts(
+				consumptionCounts, currentYear);
+		Map<Integer, Integer> maxConcurrentQuantities =
+			TermCountUtil.getMaxConcurrentCounts(
+				subscriptionCounts, currentYear);
+
+		JSONArray jsonArray = new JSONArray();
+
+		for (int year = currentYear - 1; year <= (currentYear + 1); year++) {
+			jsonArray.put(
+				new JSONObject(
+				).put(
+					"maxConcurrentConsumption",
+					GetterUtil.getInteger(maxConcurrentConsumptions.get(year))
+				).put(
+					"maxConcurrentQuantity",
+					GetterUtil.getInteger(maxConcurrentQuantities.get(year))
+				).put(
+					"year", year
+				));
+		}
+
+		JSONObject jsonObject = new JSONObject(
+		).put(
+			"annualSubscriptions", jsonArray
+		).put(
+			"currentConsumption",
+			TermCountUtil.getCurrentCount(consumptionCounts)
+		);
+
+		return jsonObject.toString();
+	}
+
 	private String _getProjectName(String projectExternalReferenceCode)
 		throws Exception {
 
@@ -867,6 +993,9 @@ public class AccountsRestController extends OneBaseRestController {
 
 	@Autowired
 	private EmailAddressValidatorService _emailAddressValidatorService;
+
+	@Autowired
+	private EntitlementDefinitionService _entitlementDefinitionService;
 
 	@Autowired
 	private EntitlementService _entitlementService;

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementConstants.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/constants/EntitlementConstants.java
@@ -10,6 +10,19 @@ package com.liferay.one.constants;
  */
 public class EntitlementConstants {
 
+	public static final String EXTERNAL_REFERENCE_CODE_DXP = "C_ENT_DEF_DXP";
+
+	public static final String EXTERNAL_REFERENCE_CODE_PORTAL =
+		"C_ENT_DEF_PORTAL";
+
+	public static final String EXTERNAL_REFERENCE_CODE_PORTAL_EWSA =
+		"C_ENT_DEF_PORTAL_EWSA";
+
+	public static final String[] EXTERNAL_REFERENCE_CODES_SELF_HOSTED = {
+		EXTERNAL_REFERENCE_CODE_DXP, EXTERNAL_REFERENCE_CODE_PORTAL,
+		EXTERNAL_REFERENCE_CODE_PORTAL_EWSA
+	};
+
 	public static final String GRANT_TYPE_UNLIMITED = "unlimited";
 
 	public static final String NAME_1_PRODUCTION_POD = "1 Production Pod";
@@ -30,6 +43,8 @@ public class EntitlementConstants {
 	public static final String NAME_GLOBAL_24_7_SUPPORT = "Global 24/7 Support";
 
 	public static final String NAME_GOLD_SUPPORT = "Gold Support";
+
+	public static final String NAME_LICENSE_GENERATION = "licenseGeneration";
 
 	public static final String
 		NAME_LIFERAY_CLOUD_NATIVE_DIGITAL_ACCELERATOR_BUNDLE =

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementDefinitionService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementDefinitionService.java
@@ -19,6 +19,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class EntitlementDefinitionService extends OneBaseService {
 
+	public EntitlementDefinition fetchEntitlementDefinition(
+			String externalReferenceCode)
+		throws Exception {
+
+		List<EntitlementDefinition> entitlementDefinitions =
+			getEntitlementDefinitions(
+				"externalReferenceCode eq '" + externalReferenceCode + "'");
+
+		if (entitlementDefinitions.isEmpty()) {
+			return null;
+		}
+
+		return entitlementDefinitions.get(0);
+	}
+
 	public List<EntitlementDefinition> getEntitlementDefinitions(
 			String filterString)
 		throws Exception {

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/service/EntitlementService.java
@@ -296,6 +296,18 @@ public class EntitlementService extends OneBaseService {
 				commerceOrderItemId, "'"));
 	}
 
+	public List<Entitlement> getEntitlements(
+			long accountEntryId, long entitlementDefinitionId)
+		throws Exception {
+
+		return getEntitlements(
+			StringBundler.concat(
+				"(r_accountEntryToEntitlement_accountEntryId eq '",
+				accountEntryId, "') and ",
+				"(r_entitlementDefinitionToEntitlement_c_",
+				"entitlementDefinitionId eq '", entitlementDefinitionId, "')"));
+	}
+
 	public List<Entitlement> getEntitlements(String filterString)
 		throws Exception {
 

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/TermCountUtil.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/main/java/com/liferay/one/util/TermCountUtil.java
@@ -1,0 +1,158 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.util;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class TermCountUtil {
+
+	public static void consolidate(
+		TreeMap<Instant, Integer> termedCounts, int currentYear,
+		Instant startInstant, Instant endInstant, int count) {
+
+		if (startInstant == null) {
+			startInstant = getStartOfYearInstant(currentYear - 1);
+		}
+
+		if (endInstant == null) {
+			endInstant = getStartOfYearInstant(currentYear + 1);
+		}
+
+		if (endInstant.isBefore(getStartOfYearInstant(currentYear - 1))) {
+			return;
+		}
+
+		Map.Entry<Instant, Integer> previousEntry = termedCounts.floorEntry(
+			startInstant);
+		Map.Entry<Instant, Integer> nextEntry = termedCounts.higherEntry(
+			startInstant);
+
+		int previousCount = 0;
+
+		if (previousEntry != null) {
+			previousCount = previousEntry.getValue();
+		}
+
+		if (nextEntry == null) {
+			termedCounts.put(endInstant, previousCount);
+			termedCounts.put(startInstant, count + previousCount);
+
+			return;
+		}
+
+		termedCounts.put(startInstant, count + previousCount);
+
+		Instant nextInstant = nextEntry.getKey();
+
+		while (nextInstant.isBefore(endInstant)) {
+			termedCounts.put(nextInstant, nextEntry.getValue() + count);
+
+			nextEntry = termedCounts.higherEntry(nextInstant);
+
+			if (nextEntry == null) {
+				termedCounts.put(endInstant, 0);
+
+				return;
+			}
+
+			nextInstant = nextEntry.getKey();
+		}
+
+		if (!nextInstant.equals(endInstant)) {
+			previousEntry = termedCounts.floorEntry(endInstant);
+
+			termedCounts.put(endInstant, previousEntry.getValue() - count);
+		}
+	}
+
+	public static int getCurrentCount(TreeMap<Instant, Integer> termedCounts) {
+		Map.Entry<Instant, Integer> entry = termedCounts.floorEntry(
+			Instant.now());
+
+		if (entry == null) {
+			return 0;
+		}
+
+		return entry.getValue();
+	}
+
+	public static Map<Integer, Integer> getMaxConcurrentCounts(
+		TreeMap<Instant, Integer> termedCounts, int currentYear) {
+
+		if (termedCounts.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Integer, Integer> maxConcurrentCounts = new HashMap<>();
+
+		Map.Entry<Instant, Integer> previousEntry = null;
+
+		for (Map.Entry<Instant, Integer> entry : termedCounts.entrySet()) {
+			if (previousEntry != null) {
+				_putMaxConcurrentCounts(
+					currentYear, getYear(entry.getKey()), maxConcurrentCounts,
+					previousEntry);
+			}
+
+			previousEntry = entry;
+		}
+
+		_putMaxConcurrentCounts(
+			currentYear, currentYear + 1, maxConcurrentCounts, previousEntry);
+
+		return maxConcurrentCounts;
+	}
+
+	public static Instant getStartOfYearInstant(int year) {
+		LocalDate localDate = LocalDate.of(year, 1, 1);
+
+		return localDate.atStartOfDay(
+			ZoneOffset.UTC
+		).toInstant();
+	}
+
+	public static int getYear(Instant instant) {
+		LocalDate localDate = LocalDate.ofInstant(instant, ZoneOffset.UTC);
+
+		return localDate.getYear();
+	}
+
+	private static void _putMaxConcurrentCounts(
+		int currentYear, int endYear, Map<Integer, Integer> maxConcurrentCounts,
+		Map.Entry<Instant, Integer> previousEntry) {
+
+		if (endYear > (currentYear + 1)) {
+			endYear = currentYear + 1;
+		}
+
+		int year = getYear(previousEntry.getKey());
+
+		while (year <= endYear) {
+			Integer maxConcurrentCount = maxConcurrentCounts.get(year);
+
+			if ((maxConcurrentCount == null) ||
+				(maxConcurrentCount < previousEntry.getValue())) {
+
+				maxConcurrentCount = previousEntry.getValue();
+			}
+
+			maxConcurrentCounts.put(year, maxConcurrentCount);
+
+			year++;
+		}
+	}
+
+}

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/AccountsRestControllerTest.java
@@ -9,12 +9,15 @@ import com.liferay.headless.admin.user.client.dto.v1_0.Account;
 import com.liferay.headless.admin.user.client.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.RoleBrief;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
+import com.liferay.one.constants.EntitlementConstants;
 import com.liferay.one.jira.service.AccountAssetService;
 import com.liferay.one.jira.synchronizer.AccountSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountRoleSynchronizer;
 import com.liferay.one.jira.synchronizer.AccountUserAccountSynchronizer;
 import com.liferay.one.license.LicenseKeyCSVExporter;
 import com.liferay.one.model.AccountInvitation;
+import com.liferay.one.model.Entitlement;
+import com.liferay.one.model.EntitlementDefinition;
 import com.liferay.one.model.LicenseKey;
 import com.liferay.one.model.Project;
 import com.liferay.one.okta.model.OktaUser;
@@ -27,6 +30,7 @@ import com.liferay.one.service.AccountInvitationEmailService;
 import com.liferay.one.service.AccountInvitationService;
 import com.liferay.one.service.AccountService;
 import com.liferay.one.service.EmailAddressValidatorService;
+import com.liferay.one.service.EntitlementDefinitionService;
 import com.liferay.one.service.EntitlementService;
 import com.liferay.one.service.LicenseKeyService;
 import com.liferay.one.service.ProjectService;
@@ -34,11 +38,14 @@ import com.liferay.one.service.ProvisioningAssignmentService;
 import com.liferay.one.service.ProvisioningEmailService;
 import com.liferay.one.service.UserAccountService;
 import com.liferay.one.util.KeyedLock;
+import com.liferay.one.util.TermCountUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 
 import java.lang.reflect.Field;
+
+import java.time.Instant;
 
 import java.util.Collections;
 import java.util.List;
@@ -414,6 +421,159 @@ public class AccountsRestControllerTest {
 		).check(
 			_ACCOUNT_ID, ActionKeys.VIEW, null
 		);
+	}
+
+	@Test
+	public void testGetProductUsage() throws Exception {
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		EntitlementDefinition entitlementDefinition = Mockito.mock(
+			EntitlementDefinition.class);
+
+		Mockito.when(
+			entitlementDefinition.getEntitlementDefinitionId()
+		).thenReturn(
+			99L
+		);
+
+		Mockito.when(
+			_entitlementDefinitionService.fetchEntitlementDefinition(
+				EntitlementConstants.EXTERNAL_REFERENCE_CODE_DXP)
+		).thenReturn(
+			entitlementDefinition
+		);
+
+		int currentYear = TermCountUtil.getYear(Instant.now());
+
+		Instant endInstant = TermCountUtil.getStartOfYearInstant(
+			currentYear + 1);
+		Instant startInstant = TermCountUtil.getStartOfYearInstant(currentYear);
+
+		Entitlement entitlement = Mockito.mock(Entitlement.class);
+
+		Mockito.when(
+			entitlement.getEndDateInstant()
+		).thenReturn(
+			endInstant
+		);
+
+		Mockito.when(
+			entitlement.getEntitlementId()
+		).thenReturn(
+			7L
+		);
+
+		Mockito.when(
+			entitlement.getQuantity()
+		).thenReturn(
+			5.0
+		);
+
+		Mockito.when(
+			entitlement.getStartDateInstant()
+		).thenReturn(
+			startInstant
+		);
+
+		Mockito.when(
+			_entitlementService.getEntitlements(_ACCOUNT_ID, 99L)
+		).thenReturn(
+			Collections.singletonList(entitlement)
+		);
+
+		LicenseKey licenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			licenseKey.getCustomExpirationDateInstant()
+		).thenReturn(
+			endInstant
+		);
+
+		Mockito.when(
+			licenseKey.getEntitlementId()
+		).thenReturn(
+			7L
+		);
+
+		Mockito.when(
+			licenseKey.getStartDateInstant()
+		).thenReturn(
+			startInstant
+		);
+
+		LicenseKey unrelatedLicenseKey = Mockito.mock(LicenseKey.class);
+
+		Mockito.when(
+			unrelatedLicenseKey.getEntitlementId()
+		).thenReturn(
+			8L
+		);
+
+		Mockito.when(
+			_licenseKeyService.getLicenseKeysByAccountEntryId(_ACCOUNT_ID)
+		).thenReturn(
+			List.of(licenseKey, unrelatedLicenseKey)
+		);
+
+		ResponseEntity<String> responseEntity =
+			accountsRestController.getProductUsage(
+				null, _EXTERNAL_REFERENCE_CODE,
+				EntitlementConstants.EXTERNAL_REFERENCE_CODE_DXP);
+
+		JSONObject jsonObject = new JSONObject(responseEntity.getBody());
+
+		Assertions.assertEquals(1, jsonObject.getInt("currentConsumption"));
+
+		JSONArray jsonArray = jsonObject.getJSONArray("annualSubscriptions");
+
+		Assertions.assertEquals(3, jsonArray.length());
+
+		JSONObject currentYearJSONObject = jsonArray.getJSONObject(1);
+
+		Assertions.assertEquals(
+			currentYear, currentYearJSONObject.getInt("year"));
+
+		Assertions.assertEquals(
+			1, currentYearJSONObject.getInt("maxConcurrentConsumption"));
+
+		Assertions.assertEquals(
+			5, currentYearJSONObject.getInt("maxConcurrentQuantity"));
+
+		Mockito.verify(
+			_licenseKeyPermission
+		).check(
+			_ACCOUNT_ID, ActionKeys.VIEW, null
+		);
+	}
+
+	@Test
+	public void testGetProductUsageWhenProductIsNotSelfHosted()
+		throws Exception {
+
+		AccountsRestController accountsRestController = _createController();
+
+		Mockito.when(
+			_accountService.getAccount(_EXTERNAL_REFERENCE_CODE, null)
+		).thenReturn(
+			_createAccount()
+		);
+
+		ResponseStatusException responseStatusException =
+			Assertions.assertThrows(
+				ResponseStatusException.class,
+				() -> accountsRestController.getProductUsage(
+					null, _EXTERNAL_REFERENCE_CODE, "C_ENT_DEF_COMMERCE"));
+
+		Assertions.assertEquals(
+			HttpStatus.NOT_FOUND, responseStatusException.getStatusCode());
+
+		Mockito.verifyNoInteractions(_entitlementDefinitionService);
 	}
 
 	@Test
@@ -1554,6 +1714,9 @@ public class AccountsRestControllerTest {
 			accountsRestController, "_emailAddressValidatorService",
 			_emailAddressValidatorService);
 		ReflectionTestUtils.setField(
+			accountsRestController, "_entitlementDefinitionService",
+			_entitlementDefinitionService);
+		ReflectionTestUtils.setField(
 			accountsRestController, "_entitlementService", _entitlementService);
 		ReflectionTestUtils.setField(
 			accountsRestController, "_keyedLock", new KeyedLock());
@@ -1703,6 +1866,8 @@ public class AccountsRestControllerTest {
 		AdminPermission.class);
 	private final EmailAddressValidatorService _emailAddressValidatorService =
 		Mockito.mock(EmailAddressValidatorService.class);
+	private final EntitlementDefinitionService _entitlementDefinitionService =
+		Mockito.mock(EntitlementDefinitionService.class);
 	private final EntitlementService _entitlementService = Mockito.mock(
 		EntitlementService.class);
 	private final LicenseKeyCSVExporter _licenseKeyCSVExporter = Mockito.mock(

--- a/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/TermCountUtilTest.java
+++ b/workspaces/liferay-one-workspace/client-extensions/liferay-one-etc-spring-boot/src/test/java/com/liferay/one/util/TermCountUtilTest.java
@@ -1,0 +1,147 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.one.util;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Allen Ziegenfus
+ */
+public class TermCountUtilTest {
+
+	@Test
+	public void testConsolidateWhenDatesAreNull() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		TermCountUtil.consolidate(termedCounts, _CURRENT_YEAR, null, null, 2);
+
+		Map<Integer, Integer> maxConcurrentCounts =
+			TermCountUtil.getMaxConcurrentCounts(termedCounts, _CURRENT_YEAR);
+
+		Assertions.assertEquals(2, maxConcurrentCounts.get(_CURRENT_YEAR - 1));
+
+		Assertions.assertEquals(2, maxConcurrentCounts.get(_CURRENT_YEAR));
+	}
+
+	@Test
+	public void testConsolidateWhenTermEndedBeforeTheReportedYears() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR,
+			TermCountUtil.getStartOfYearInstant(_CURRENT_YEAR - 6),
+			TermCountUtil.getStartOfYearInstant(_CURRENT_YEAR - 5), 3);
+
+		Assertions.assertTrue(termedCounts.isEmpty());
+
+		Assertions.assertTrue(
+			TermCountUtil.getMaxConcurrentCounts(
+				termedCounts, _CURRENT_YEAR
+			).isEmpty());
+	}
+
+	@Test
+	public void testConsolidateWhenTermsDoNotOverlap() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		Instant startOfYearInstant = TermCountUtil.getStartOfYearInstant(
+			_CURRENT_YEAR);
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR, startOfYearInstant,
+			startOfYearInstant.plus(90, ChronoUnit.DAYS), 1);
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR,
+			startOfYearInstant.plus(180, ChronoUnit.DAYS),
+			startOfYearInstant.plus(270, ChronoUnit.DAYS), 1);
+
+		Map<Integer, Integer> maxConcurrentCounts =
+			TermCountUtil.getMaxConcurrentCounts(termedCounts, _CURRENT_YEAR);
+
+		Assertions.assertEquals(1, maxConcurrentCounts.get(_CURRENT_YEAR));
+	}
+
+	@Test
+	public void testConsolidateWhenTermsOverlap() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		Instant startOfYearInstant = TermCountUtil.getStartOfYearInstant(
+			_CURRENT_YEAR);
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR, startOfYearInstant,
+			startOfYearInstant.plus(180, ChronoUnit.DAYS), 1);
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR,
+			startOfYearInstant.plus(90, ChronoUnit.DAYS),
+			startOfYearInstant.plus(270, ChronoUnit.DAYS), 1);
+
+		Map<Integer, Integer> maxConcurrentCounts =
+			TermCountUtil.getMaxConcurrentCounts(termedCounts, _CURRENT_YEAR);
+
+		Assertions.assertEquals(2, maxConcurrentCounts.get(_CURRENT_YEAR));
+	}
+
+	@Test
+	public void testGetCurrentCount() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		Assertions.assertEquals(0, TermCountUtil.getCurrentCount(termedCounts));
+
+		Instant instant = Instant.now();
+
+		TermCountUtil.consolidate(
+			termedCounts, TermCountUtil.getYear(instant),
+			instant.minus(30, ChronoUnit.DAYS),
+			instant.plus(30, ChronoUnit.DAYS), 4);
+
+		Assertions.assertEquals(4, TermCountUtil.getCurrentCount(termedCounts));
+	}
+
+	@Test
+	public void testGetMaxConcurrentCountsIsCappedAtTheNextYear() {
+		TreeMap<Instant, Integer> termedCounts = new TreeMap<>();
+
+		TermCountUtil.consolidate(
+			termedCounts, _CURRENT_YEAR,
+			TermCountUtil.getStartOfYearInstant(_CURRENT_YEAR),
+			TermCountUtil.getStartOfYearInstant(_CURRENT_YEAR + 10), 7);
+
+		Map<Integer, Integer> maxConcurrentCounts =
+			TermCountUtil.getMaxConcurrentCounts(termedCounts, _CURRENT_YEAR);
+
+		Assertions.assertEquals(7, maxConcurrentCounts.get(_CURRENT_YEAR));
+
+		Assertions.assertEquals(7, maxConcurrentCounts.get(_CURRENT_YEAR + 1));
+
+		Assertions.assertNull(maxConcurrentCounts.get(_CURRENT_YEAR + 2));
+	}
+
+	@Test
+	public void testGetStartOfYearInstant() {
+		Assertions.assertEquals(
+			"2026-01-01T00:00:00Z",
+			String.valueOf(TermCountUtil.getStartOfYearInstant(2026)));
+	}
+
+	@Test
+	public void testGetYear() {
+		Assertions.assertEquals(
+			2026, TermCountUtil.getYear(Instant.parse("2026-06-15T12:00:00Z")));
+	}
+
+	private static final int _CURRENT_YEAR = 2026;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91426

## What is being fixed

AC #3 of the port: the license key usage report still lived only in the legacy `osb-provisioning-rest` resource, so nothing in the client extension could answer what a customer had subscribed versus what they had consumed.

The report is the part of the legacy surface where an off-by-one is expensive, because the numbers feed what a customer owes. It answers, for last year, this year, and next year, the maximum *concurrent* purchased quantity and the maximum *concurrent* consumption, plus the consumption right now. Legacy derived that from Koroneiki's `ProductPurchaseView` — product purchases weighted by quantity, product consumptions each counting one — and gated the endpoint on the product's `display-group-name` property being self-hosted or portal.

## How it is being fixed

Neither `ProductPurchase` nor `ProductConsumption` exists in the new model, so the two sides are read from what does. Subscriptions come from `Entitlement`, weighted by its `quantity` over its term. Consumptions come from the account's license keys whose `entitlementId` belongs to those entitlements, each counting one over its start date to its custom expiration date — license keys being the consumption of an entitlement. The `display-group-name` gate becomes an external-reference-code check against `EntitlementConstants.EXTERNAL_REFERENCE_CODES_SELF_HOSTED`.

Legacy skipped product purchases that were not `APPROVED`. There is no equivalent flag to check, because entitlement generation already refuses to create an entitlement for a canceled order item, so that filter is enforced upstream instead of here.

The concurrency arithmetic is ported unchanged into `TermCountUtil`, on `Instant` rather than `Date`: `consolidate` walks the term boundaries accumulating counts, and `getMaxConcurrentCounts` sweeps those boundaries for the per-year peak, still capped at the following year. Eight unit tests cover the overlapping, non-overlapping, null-dated, out-of-range, and year-cap cases.

The response envelope matches legacy field for field — `annualSubscriptions` carrying `maxConcurrentConsumption`, `maxConcurrentQuantity` and `year` for the three-year window, alongside `currentConsumption`.

## Example

| entity | values |
| --- | --- |
| account | `LPD91426_AC3` (id `43559`) |
| entitlement definition | `C_ENT_DEF_DXP` (id `43563`) |
| ent-A | `quantity 5`, `2026-01-01` -> `2026-12-31` |
| ent-B | `quantity 3`, `2026-06-01` -> `2027-06-01` |
| key-1, key-2 | `entitlementId` -> ent-A, `2026-01-01` -> `2026-12-31` |

Entitlements are the subscription side (weighted by `quantity`); license keys are the consumption side (each counts 1).

**Request**

```bash
curl -H "Authorization: Bearer ${TOKEN}" \
  "/accounts/LPD91426_AC3/products/C_ENT_DEF_DXP/usage"
```

**Response** — `200 application/json`

```json
{
  "annualSubscriptions": [
    { "year": 2025, "maxConcurrentQuantity": 0, "maxConcurrentConsumption": 0 },
    { "year": 2026, "maxConcurrentQuantity": 8, "maxConcurrentConsumption": 2 },
    { "year": 2027, "maxConcurrentQuantity": 3, "maxConcurrentConsumption": 0 }
  ],
  "currentConsumption": 2
}
```

2026 is `5 + 3` where the two terms overlap Jun–Dec; 2027 is ent-B alone, capped at `currentYear + 1`; consumption is the two keys, expiring at the end of 2026. `currentConsumption` reflects today falling inside both key terms.

`401` unauthenticated. `404` for an unknown account, a product outside the self-hosted list, or an account with no entitlements for that definition.

## Open question for review

A license key can be linked to its entitlement two ways, and they are independent: the plain `entitlementId` field, and the `r_entitlementToLicenseKey_c_entitlementId` relationship. Setting one leaves the other at `0`. This endpoint reads the plain field, so a key linked only by the relationship contributes nothing to consumption — the payload stays valid and the number is silently lower. Worth confirming which link the real data populates.
