### PR TITLE
LPD-102946 Fix the channel ERC and harden LDP provisioning

### DIFF
--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/i18n/en_US.ts
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/i18n/en_US.ts
@@ -172,6 +172,7 @@ export default {
 	'confirm-uninstall-terms': 'Confirm Uninstall Terms',
 	'congratulations': 'Congratulations',
 	'connect-anyway': 'Connect Anyway',
+	'connect-your-liferay-data-platform': 'Connect Your Liferay Data Platform',
 	'connect-your-liferay-dsr': 'Connect Your Liferay DSR',
 	'contact': 'Contact',
 	'contact-publisher': 'Contact Publisher',
@@ -819,6 +820,8 @@ export default {
 		'The cloud app is client extension based and is compatible with a customer’s self-hosted environment.',
 	'the-cloud-app-is-client-extension-based-and-is-compatible-with-liferays-self-managed-offering':
 		'The Cloud app is client extension based and is compatible with Liferay’s Self-Managed offering.',
+	'the-data-source-token-is-not-available-yet-please-try-again-in-a-few-minutes':
+		'The data source token is not available yet. Please try again in a few minutes.',
 	'the-dxp-app-is-module-based-and-is-compatible-with-7-4-builds-of-liferay-dxp':
 		'The DXP app is module-based and is compatible with 7.4 builds of Liferay DXP.',
 	'the-dxp-app-is-module-based-and-is-compatible-with-7-4-builds-of-liferay-dxp-self-managed-liferay-cloud-formerly-dxp-cloud':

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/CustomerDashboardRouter.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/CustomerDashboardRouter.tsx
@@ -26,6 +26,7 @@ import BuyLiferayTokens from './pages/LiferayProducts/BuyLiferayTokens';
 import LiferayProduct from './pages/LiferayProducts/LiferayProduct';
 import LiferayProductsOutlet from './pages/LiferayProducts/LiferayProductsOutlet';
 import DSRWorkspace from './pages/LiferayProducts/Workspace/DSRWorkspace';
+import LDPWorkspace from './pages/LiferayProducts/Workspace/LDPWorkspace';
 import LiferayProductsListView from './pages/LiferayProducts/index';
 import Solutions from './pages/Solutions';
 import Solution from './pages/Solutions/Solution';
@@ -73,6 +74,8 @@ const CustomerDashboardRouter = () => {
 					/>
 
 					<Route element={<Download />} path="download" />
+
+					<Route element={<LDPWorkspace />} path="environment" />
 
 					<Route element={<DSRWorkspace />} path="workspace" />
 				</Route>

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/components/PurchasedAppsTable.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/components/PurchasedAppsTable.tsx
@@ -64,12 +64,12 @@ const AppsTable: React.FC<AppsTableProps> = ({items}) => {
 					title: i18n.translate('name'),
 				},
 				{
-					key: 'author',
-					render: (author, {createDate}) => {
+					key: 'account',
+					render: (account, {createDate}) => {
 						return (
 							<div className="d-flex flex-column">
 								<span className="dashboard-table-row-text">
-									{author}
+									{account}
 								</span>
 
 								<span className="dashboard-table-row-purchased-date">

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/AnalyticsDetails.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/AnalyticsDetails.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import classNames from 'classnames';
 import {format} from 'date-fns';
 import {useOutletContext} from 'react-router-dom';
 
@@ -13,11 +14,13 @@ import {
 	OrderCustomFields,
 	OrderWorkflowStatusCode,
 } from '../../../../../enums/Order';
+import {SolutionTypes} from '../../../../../enums/Product';
 import i18n from '../../../../../i18n';
 import LiferayProductsAlerts from '../LiferayProductsAlerts';
+import WorkspaceInfoCard from './WorkspaceInfoCard';
 
 const AnalyticsDetails = () => {
-	const {placedOrder} = useOutletContext<any>();
+	const {marketplaceDeliveryProduct, placedOrder} = useOutletContext<any>();
 
 	const orderStatusCode = placedOrder?.orderStatusInfo
 		?.code as OrderWorkflowStatusCode;
@@ -28,16 +31,24 @@ const AnalyticsDetails = () => {
 
 	const {analyticsProject} = orderMetadata;
 
-	const allowedEmailDomains = analyticsProject?.allowedEmailDomains || [];
+	// This component is the fallback for every ADDONS order, which also covers
+	// the legacy Analytics Cloud add-on. Liferay Data Platform splits the
+	// workspace information into its own Environment tab, so only the legacy
+	// add-on keeps it alongside the details.
 
-	const incidentReportEmailAddresses =
-		analyticsProject?.incidentReportEmailAddresses || [];
+	const isLiferayDataPlatform =
+		marketplaceDeliveryProduct?.specificationValues?.SOLUTION_TYPE ===
+		SolutionTypes.LIFERAY_DATA_PLATFORM;
 
 	return (
 		<PageRenderer>
 			<LiferayProductsAlerts orderStatusCode={orderStatusCode} />
 
-			<div className="app-details-body-container">
+			<div
+				className={classNames('app-details-body-container', {
+					'mt-4': isLiferayDataPlatform,
+				})}
+			>
 				<DetailedCard
 					cardIconAltText="Details Icon"
 					cardTitle={i18n.translate('details')}
@@ -80,59 +91,9 @@ const AnalyticsDetails = () => {
 					/>
 				</DetailedCard>
 
-				<DetailedCard
-					cardIconAltText="Summary Icon"
-					cardTitle={i18n.translate('workspace-info')}
-					clayIcon="polls"
-				>
-					<QATable
-						items={[
-							{
-								title: i18n.translate('workspace-name'),
-								value: analyticsProject?.corpProjectName,
-							},
-							{
-								title: i18n.translate('workspace-owner-email'),
-								value: analyticsProject?.ownerEmailAddress,
-							},
-							{
-								title: i18n.translate('data-center-location'),
-								value: analyticsProject?.serverLocation,
-							},
-							{
-								title: i18n.translate('timezone'),
-								value: analyticsProject?.timeZone
-									?.displayTimeZone,
-							},
-							{
-								title: i18n.translate('workspace-friendly-url'),
-								value: analyticsProject?.friendlyURL,
-							},
-							{
-								title: i18n.translate('allowed-email-domains'),
-								value: allowedEmailDomains?.map(
-									(emailAddress: string) => (
-										<div key={emailAddress}>
-											{emailAddress}
-										</div>
-									)
-								),
-							},
-							{
-								title: i18n.translate(
-									'incident-report-contacts'
-								),
-								value: incidentReportEmailAddresses?.map(
-									(emailAddress: string) => (
-										<div key={emailAddress}>
-											{emailAddress}
-										</div>
-									)
-								),
-							},
-						]}
-					/>
-				</DetailedCard>
+				{!isLiferayDataPlatform && (
+					<WorkspaceInfoCard analyticsProject={analyticsProject} />
+				)}
 			</div>
 		</PageRenderer>
 	);

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/LDPTokenCard.scss
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/LDPTokenCard.scss
@@ -1,0 +1,73 @@
+.ldp-token-card {
+	.detailed-card-header {
+		margin-bottom: 16px;
+
+		.detailed-card-header-icon-container {
+			background: #e7efff;
+			color: #377cff;
+		}
+	}
+
+	.ldp-token-card-copy {
+		align-items: center;
+		background: transparent;
+		border: 0;
+		color: #999aa3;
+		cursor: pointer;
+		display: flex;
+		flex-shrink: 0;
+		padding: 0;
+
+		&:hover {
+			color: #6c6c75;
+		}
+	}
+
+	.ldp-token-card-field {
+		align-items: center;
+		background: #fff;
+		border: 1px solid #b1b2b9;
+		border-radius: 8px;
+		display: flex;
+		gap: 8px;
+		padding: 12px 16px;
+	}
+
+	.ldp-token-card-input {
+		border: 0;
+		color: #282934;
+		flex: 1;
+		font-size: 16px;
+		line-height: 24px;
+		min-width: 0;
+		opacity: 0.6;
+		outline: none;
+		overflow: hidden;
+		padding: 0;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
+
+	.ldp-token-card-label {
+		color: #282934;
+		display: block;
+		font-size: 16px;
+		font-weight: 600;
+		margin-bottom: 8px;
+	}
+
+	.ldp-token-card-message {
+		color: #6c6c75;
+		font-size: 14px;
+	}
+
+	.ldp-token-card-required {
+		color: #da1414;
+		margin-left: 4px;
+		opacity: 0.8;
+	}
+}

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/LDPTokenCard.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/LDPTokenCard.tsx
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ClayInput} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+
+import {DetailedCard} from '../../../../../components/DetailedCard/DetailedCard';
+import i18n from '../../../../../i18n';
+import {Liferay} from '../../../../../liferay/liferay';
+import {copyToClipboard} from '../../../../../utils/browser';
+
+import './LDPTokenCard.scss';
+
+type LDPTokenCardProps = {
+	dataSourceAccessToken?: string;
+	groupId?: number | string;
+};
+
+const LDPTokenCard: React.FC<LDPTokenCardProps> = ({
+	dataSourceAccessToken,
+	groupId,
+}) => {
+	// Provisioning stores the Analytics Cloud response verbatim in the
+	// order-metadata custom field, so analyticsProject.dataSourceAccessToken
+	// already carries the token and no request to Analytics Cloud is needed.
+	// The groupId only tells whether the workspace exists yet.
+
+	if (!groupId) {
+		return null;
+	}
+
+	return (
+		<DetailedCard
+			cardIconAltText="Connect Icon"
+			cardTitle={i18n.translate('connect-your-liferay-data-platform')}
+			className="ldp-token-card"
+			clayIcon="diagram"
+		>
+			<span className="ldp-token-card-label">
+				{i18n.translate('copy-this-token-to-your-liferay-dxp-instance')}
+
+				<span className="ldp-token-card-required">*</span>
+			</span>
+
+			{dataSourceAccessToken ? (
+				<div className="ldp-token-card-field">
+					<ClayInput
+						className="ldp-token-card-input"
+						readOnly
+						value={dataSourceAccessToken}
+					/>
+
+					<button
+						aria-label={i18n.translate('copy')}
+						className="ldp-token-card-copy"
+						onClick={() => {
+							copyToClipboard(dataSourceAccessToken);
+
+							Liferay.Util.openToast({
+								message: i18n.sub(
+									'copied-x-to-the-clipboard',
+									'token'
+								),
+							});
+						}}
+						type="button"
+					>
+						<ClayIcon symbol="copy" />
+					</button>
+				</div>
+			) : (
+				<p className="ldp-token-card-message m-0">
+					{i18n.translate(
+						'the-data-source-token-is-not-available-yet-please-try-again-in-a-few-minutes'
+					)}
+				</p>
+			)}
+		</DetailedCard>
+	);
+};
+
+export default LDPTokenCard;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/WorkspaceInfoCard.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Details/WorkspaceInfoCard.tsx
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {DetailedCard} from '../../../../../components/DetailedCard/DetailedCard';
+import QATable from '../../../../../components/QATable';
+import i18n from '../../../../../i18n';
+
+type WorkspaceInfoCardProps = {
+	analyticsProject?: any;
+};
+
+const WorkspaceInfoCard: React.FC<WorkspaceInfoCardProps> = ({
+	analyticsProject,
+}) => {
+	const allowedEmailDomains = analyticsProject?.allowedEmailDomains || [];
+
+	const incidentReportEmailAddresses =
+		analyticsProject?.incidentReportEmailAddresses || [];
+
+	return (
+		<DetailedCard
+			cardIconAltText="Summary Icon"
+			cardTitle={i18n.translate('workspace-info')}
+			clayIcon="polls"
+		>
+			<QATable
+				items={[
+					{
+						title: i18n.translate('workspace-name'),
+						value: analyticsProject?.corpProjectName,
+					},
+					{
+						title: i18n.translate('workspace-owner-email'),
+						value: analyticsProject?.ownerEmailAddress,
+					},
+					{
+						title: i18n.translate('data-center-location'),
+						value: analyticsProject?.serverLocation,
+					},
+					{
+						title: i18n.translate('timezone'),
+						value: analyticsProject?.timeZone?.displayTimeZone,
+					},
+					{
+						title: i18n.translate('workspace-friendly-url'),
+						value: analyticsProject?.friendlyURL,
+					},
+					{
+						title: i18n.translate('allowed-email-domains'),
+						value: allowedEmailDomains?.map(
+							(emailAddress: string) => (
+								<div key={emailAddress}>{emailAddress}</div>
+							)
+						),
+					},
+					{
+						title: i18n.translate('incident-report-contacts'),
+						value: incidentReportEmailAddresses?.map(
+							(emailAddress: string) => (
+								<div key={emailAddress}>{emailAddress}</div>
+							)
+						),
+					},
+				]}
+			/>
+		</DetailedCard>
+	);
+};
+
+export default WorkspaceInfoCard;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProductsOutlet.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/LiferayProductsOutlet.tsx
@@ -16,6 +16,7 @@ import {
 	isBetaOrder,
 	orderTypeDocumentationURL,
 } from '../../../../enums/Order';
+import {SolutionTypes} from '../../../../enums/Product';
 import useGetProductByOrderId from '../../../../hooks/useGetProductByOrderId';
 import i18n from '../../../../i18n';
 import {Liferay} from '../../../../liferay/liferay';
@@ -38,6 +39,22 @@ const getTabs = (data: ProductAndOrderPayload): NavbarProps['routes'] => {
 		)
 	) {
 		return [];
+	}
+
+	if (
+		data?.marketplaceDeliveryProduct?.specificationValues?.SOLUTION_TYPE ===
+		SolutionTypes.LIFERAY_DATA_PLATFORM
+	) {
+		return [
+			{
+				name: i18n.translate('details'),
+				path: '',
+			},
+			{
+				name: i18n.translate('environment'),
+				path: 'environment',
+			},
+		];
 	}
 
 	const isCMP = CMP_ORDER_TYPES.includes(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Workspace/LDPWorkspace.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/Workspace/LDPWorkspace.tsx
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useOutletContext} from 'react-router-dom';
+
+import {OrderCustomFields} from '../../../../../enums/Order';
+import useGetProductByOrderId from '../../../../../hooks/useGetProductByOrderId';
+import {safeJSONParse} from '../../../../../utils/util';
+import LDPTokenCard from '../Details/LDPTokenCard';
+import WorkspaceInfoCard from '../Details/WorkspaceInfoCard';
+
+type OutletContext = NonNullable<
+	ReturnType<typeof useGetProductByOrderId>['data']
+>;
+
+const LDPWorkspace = () => {
+	const {placedOrder} = useOutletContext<OutletContext>();
+
+	const orderMetadata = safeJSONParse<any>(
+		placedOrder.customFields[OrderCustomFields.ORDER_METADATA],
+		{}
+	);
+
+	const {analyticsProject} = orderMetadata;
+
+	return (
+		<div className="app-details-body-container mt-4">
+			<LDPTokenCard
+				dataSourceAccessToken={analyticsProject?.dataSourceAccessToken}
+				groupId={analyticsProject?.groupId}
+			/>
+
+			<WorkspaceInfoCard analyticsProject={analyticsProject} />
+		</div>
+	);
+};
+
+export default LDPWorkspace;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/index.tsx
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/pages/CustomerDashboard/pages/LiferayProducts/index.tsx
@@ -238,12 +238,12 @@ const LiferayProductsListView = () => {
 							},
 							{
 								clickable: true,
-								id: 'author',
+								id: 'account',
 								name: i18n.translate('purchased-by'),
-								render: (author, {createDate}) => (
+								render: (account, {createDate}) => (
 									<div className="d-flex flex-column">
 										<span className="dashboard-table-row-text">
-											{author}
+											{account}
 										</span>
 
 										<span className="dashboard-table-row-purchased-date text-black-50">

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/types/analytics.d.ts
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-custom-element/src/types/analytics.d.ts
@@ -8,6 +8,7 @@ type AnalyticsProject = {
 	accountName: string;
 	corpProjectName: string;
 	corpProjectUuid: string;
+	dataSourceAccessToken?: string;
 	faroSubscription: FaroSubscription;
 	faroSubscriptionDisplay: FaroSubscription;
 	friendlyURL: string;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceMessageReceiver.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceMessageReceiver.java
@@ -61,11 +61,12 @@ import org.springframework.http.HttpStatus;
 public class MarketplaceMessageReceiver implements MessageReceiver {
 
 	public MarketplaceMessageReceiver(
-		KoroneikiService koroneikiService,
+		KoroneikiService koroneikiService, String marketplaceChannelERC,
 		MarketplaceService marketplaceService, List<String> productKeys,
 		ProvisioningHubService provisioningHubService, String topicName) {
 
 		_koroneikiService = koroneikiService;
+		_marketplaceChannelERC = marketplaceChannelERC;
 		_marketplaceService = marketplaceService;
 		_productKeys = productKeys;
 		_provisioningHubService = provisioningHubService;
@@ -213,7 +214,7 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 			_marketplaceService.getChannelResource();
 
 		Channel channel = channelResource.getChannelByExternalReferenceCode(
-			_MARKETPLACE_CHANNEL);
+			_marketplaceChannelERC);
 
 		_channelId = channel.getId();
 
@@ -670,8 +671,6 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 		}
 	}
 
-	private static final String _MARKETPLACE_CHANNEL = "MARKETPLACE-CHANNEL";
-
 	private static final Log _log = LogFactory.getLog(
 		MarketplaceMessageReceiver.class);
 
@@ -680,6 +679,7 @@ public class MarketplaceMessageReceiver implements MessageReceiver {
 
 	private volatile Long _channelId;
 	private final KoroneikiService _koroneikiService;
+	private final String _marketplaceChannelERC;
 	private final MarketplaceService _marketplaceService;
 	private final List<String> _productKeys;
 	private final ProvisioningHubService _provisioningHubService;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/pubsub/MarketplaceTopicSubscriber.java
@@ -156,8 +156,8 @@ public class MarketplaceTopicSubscriber {
 		Subscriber subscriber = Subscriber.newBuilder(
 			subscriptionName,
 			new MarketplaceMessageReceiver(
-				_koroneikiService, _marketplaceService, _productKeys,
-				_provisioningHubService, topicName)
+				_koroneikiService, _marketplaceChannelERC, _marketplaceService,
+				_productKeys, _provisioningHubService, topicName)
 		).setCredentialsProvider(
 			credentialsProvider
 		).build();
@@ -182,6 +182,9 @@ public class MarketplaceTopicSubscriber {
 
 	@Autowired
 	private KoroneikiService _koroneikiService;
+
+	@Value("${liferay.marketplace.commerce.channel.external.reference.code}")
+	private String _marketplaceChannelERC;
 
 	@Autowired
 	private MarketplaceService _marketplaceService;

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/MarketplaceService.java
@@ -955,6 +955,19 @@ public class MarketplaceService extends BaseService {
 		orderResource.patchOrder(orderId, order);
 	}
 
+	public void updateOrderCustomFields(
+			Map<String, ?> customFields, long orderId)
+		throws Exception {
+
+		Order order = new Order();
+
+		order.setCustomFields(() -> customFields);
+
+		OrderResource orderResource = getOrderResource();
+
+		orderResource.patchOrder(orderId, order);
+	}
+
 	private CatalogResource _getCatalogResource() throws Exception {
 		return CatalogResource.builder(
 		).header(

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -210,6 +210,13 @@ public class ProvisioningHubService extends BaseService {
 		return "/" + friendlyURL;
 	}
 
+	private int _getLDPProvisioningAttempts(Order order) {
+		JSONObject orderMetadataJSONObject =
+			MarketplaceUtil.getOrderMetadataJSONObject(order);
+
+		return orderMetadataJSONObject.optInt(_LDP_PROVISIONING_ATTEMPTS);
+	}
+
 	private String _getServerLocation(String dataCenterLocation) {
 		if (Objects.equals(dataCenterLocation, "asia-south1")) {
 			return "asia-south1-ac5-c1";
@@ -393,38 +400,66 @@ public class ProvisioningHubService extends BaseService {
 			return;
 		}
 
-		String securityContactEmailAddress = properties.get(
-			"securityContactEmailAddress");
+		JSONObject analyticsProjectJSONObject =
+			_analyticsService.getCorpProjectUuidJSONObject(
+				koroneikiAccount.getKey());
 
-		JSONArray incidentReportEmailAddressesJSONArray = new JSONArray();
+		if (analyticsProjectJSONObject == null) {
+			int ldpProvisioningAttempts = _getLDPProvisioningAttempts(order);
 
-		if (Validator.isNotNull(securityContactEmailAddress)) {
-			incidentReportEmailAddressesJSONArray = new JSONArray(
-				securityContactEmailAddress.split(","));
+			if (ldpProvisioningAttempts >= _LDP_PROVISIONING_MAX_ATTEMPTS) {
+				_log.error(
+					StringBundler.concat(
+						"Unable to provision LDP for account ",
+						koroneikiAccount.getKey(), " after ",
+						ldpProvisioningAttempts, " attempts"));
+
+				return;
+			}
+
+			_updateLDPProvisioningAttempts(ldpProvisioningAttempts + 1, order);
+
+			String securityContactEmailAddress = properties.get(
+				"securityContactEmailAddress");
+
+			JSONArray incidentReportEmailAddressesJSONArray = new JSONArray();
+
+			if (Validator.isNotNull(securityContactEmailAddress)) {
+				incidentReportEmailAddressesJSONArray = new JSONArray(
+					securityContactEmailAddress.split(","));
+			}
+
+			analyticsProjectJSONObject = new JSONObject(
+				_analyticsService.provision(
+					new JSONObject(
+					).put(
+						"corpProjectName", koroneikiAccount.getName()
+					).put(
+						"corpProjectUuid", koroneikiAccount.getKey()
+					).put(
+						"friendlyURL",
+						_getFriendlyURL(properties.get("friendlyWorkspaceURL"))
+					).put(
+						"incidentReportEmailAddresses",
+						incidentReportEmailAddressesJSONArray
+					).put(
+						"name", properties.get("ldpWorkspaceName")
+					).put(
+						"ownerEmailAddress",
+						_getContactEmailAddress(
+							koroneikiAccount.getKey(),
+							securityContactEmailAddress)
+					).put(
+						"serverLocation",
+						_getServerLocation(properties.get("dataCenterLocation"))
+					)));
 		}
-
-		String analyticsProject = _analyticsService.provision(
-			new JSONObject(
-			).put(
-				"corpProjectName", koroneikiAccount.getName()
-			).put(
-				"corpProjectUuid", koroneikiAccount.getKey()
-			).put(
-				"friendlyURL",
-				_getFriendlyURL(properties.get("friendlyWorkspaceURL"))
-			).put(
-				"incidentReportEmailAddresses",
-				incidentReportEmailAddressesJSONArray
-			).put(
-				"name", properties.get("ldpWorkspaceName")
-			).put(
-				"ownerEmailAddress",
-				_getContactEmailAddress(
-					koroneikiAccount.getKey(), securityContactEmailAddress)
-			).put(
-				"serverLocation",
-				_getServerLocation(properties.get("dataCenterLocation"))
-			));
+		else if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Reusing the Analytics Cloud project already provisioned ",
+					"for account ", koroneikiAccount.getKey()));
+		}
 
 		_marketplaceService.completeOrder(
 			HashMapBuilder.put(
@@ -432,7 +467,7 @@ public class ProvisioningHubService extends BaseService {
 				MarketplaceUtil.getOrderMetadataJSONObject(
 					order
 				).put(
-					"analyticsProject", new JSONObject(analyticsProject)
+					"analyticsProject", analyticsProjectJSONObject
 				).toString()
 			).build(),
 			order.getId(), order.getPaymentStatus());
@@ -500,6 +535,27 @@ public class ProvisioningHubService extends BaseService {
 			).build(),
 			order.getId(), order.getPaymentStatus());
 	}
+
+	private void _updateLDPProvisioningAttempts(
+			int ldpProvisioningAttempts, Order order)
+		throws Exception {
+
+		_marketplaceService.updateOrderCustomFields(
+			HashMapBuilder.put(
+				"order-metadata",
+				MarketplaceUtil.getOrderMetadataJSONObject(
+					order
+				).put(
+					_LDP_PROVISIONING_ATTEMPTS, ldpProvisioningAttempts
+				).toString()
+			).build(),
+			order.getId());
+	}
+
+	private static final String _LDP_PROVISIONING_ATTEMPTS =
+		"ldpProvisioningAttempts";
+
+	private static final int _LDP_PROVISIONING_MAX_ATTEMPTS = 3;
 
 	private static final Log _log = LogFactory.getLog(
 		ProvisioningHubService.class);

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/java/com/liferay/marketplace/service/ProvisioningHubService.java
@@ -77,7 +77,8 @@ public class ProvisioningHubService extends BaseService {
 			return;
 		}
 
-		if (Objects.equals(
+		if (Objects.equals(productName, "Liferay Data Platform") ||
+			Objects.equals(
 				productName, "Liferay Data Platform (Private Beta)")) {
 
 			_provisionLDP(koroneikiAccount, order);
@@ -190,6 +191,23 @@ public class ProvisioningHubService extends BaseService {
 					"serverLocation",
 					_getServerLocation(properties.get("dataCenterLocation"))
 				)));
+	}
+
+	private String _getFriendlyURL(String friendlyURL) {
+		if (Validator.isNull(friendlyURL)) {
+			return "";
+		}
+
+		friendlyURL = friendlyURL.trim(
+		).replaceAll(
+			"^/+", ""
+		);
+
+		if (Validator.isNull(friendlyURL)) {
+			return "";
+		}
+
+		return "/" + friendlyURL;
 	}
 
 	private String _getServerLocation(String dataCenterLocation) {
@@ -391,6 +409,9 @@ public class ProvisioningHubService extends BaseService {
 				"corpProjectName", koroneikiAccount.getName()
 			).put(
 				"corpProjectUuid", koroneikiAccount.getKey()
+			).put(
+				"friendlyURL",
+				_getFriendlyURL(properties.get("friendlyWorkspaceURL"))
 			).put(
 				"incidentReportEmailAddresses",
 				incidentReportEmailAddressesJSONArray

--- a/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/resources/application-default.properties
+++ b/workspaces/liferay-marketplace-workspace/client-extensions/liferay-marketplace-etc-spring-boot/src/main/resources/application-default.properties
@@ -8,6 +8,7 @@ liferay.marketplace.analytics.auth.url=${LIFERAY_MARKETPLACE_ANALYTICS_AUTH_URL}
 liferay.marketplace.analytics.internal.auth.email.address=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_EMAIL_ADDRESS:}
 liferay.marketplace.analytics.internal.auth.password=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_PASSWORD:}
 liferay.marketplace.analytics.internal.auth.url=${LIFERAY_MARKETPLACE_ANALYTICS_INTERNAL_AUTH_URL:}
+liferay.marketplace.commerce.channel.external.reference.code=${LIFERAY_MARKETPLACE_COMMERCE_CHANNEL_EXTERNAL_REFERENCE_CODE:}
 liferay.marketplace.console.auth.email.address=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_EMAIL_ADDRESS}
 liferay.marketplace.console.auth.password=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_PASSWORD}
 liferay.marketplace.console.auth.url=${LIFERAY_MARKETPLACE_CONSOLE_AUTH_URL}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102946

## What Is Being Fixed

The Pub/Sub subscriber resolved the Commerce channel through a hardcoded `MARKETPLACE-CHANNEL` external reference code, which does not match the channel on the Marketplace production instance, so the lookup failed and incoming messages could not be processed.

Liferay Data Platform provisioning had three further problems. Only the private beta product name triggered it, so an order for the generally available product was silently skipped. A failed provisioning left the message unacknowledged, and each redelivery called Analytics Cloud again and created a duplicate workspace for the same account. The friendly workspace URL configured in Koroneiki was never sent, so every workspace was created with a generated URL.

On the dashboard, a customer who bought Liferay Data Platform had no way to reach the data source token their DXP instance needs in order to connect to the provisioned workspace, and the Purchased By column rendered the individual order author rather than the account that made the purchase.

## How It Is Being Fixed

The channel external reference code now comes from `liferay.marketplace.commerce.channel.external.reference.code`, so each environment points at its own channel.

Provisioning dispatch matches both the generally available and the private beta product names, and the payload carries the friendly URL normalized to a single leading slash. Before calling Analytics Cloud, the account is checked for an existing project and reuses it when one is found, which makes redelivery idempotent. When no project exists, the attempt count is persisted on the order metadata through a new `updateOrderCustomFields` call, and provisioning stops after three attempts instead of retrying forever.

On the frontend, Liferay Data Platform orders get a dedicated Environment tab holding the copyable data source token and the workspace information. The workspace card was extracted out of the Analytics details page so both surfaces share it, which leaves the legacy Analytics Cloud add-on rendering exactly as before. The Purchased By column reads the `account` field in both the Liferay products list and the purchased apps table.

Two things worth flagging for review. The new property defaults to an empty string, so the environment must define `LIFERAY_MARKETPLACE_COMMERCE_CHANNEL_EXTERNAL_REFERENCE_CODE` or the channel lookup fails; defaulting it to `MARKETPLACE-CHANNEL` would preserve the old behavior if that is preferred. Also, the attempt counter does not survive a successful provisioning, because `completeOrder` rebuilds the order metadata from the in memory order, which is correct for the retry cap but worth knowing.

## Why Are There No Tests?

These client extensions have no test infrastructure to add tests to. There is no test file anywhere under `workspaces/liferay-marketplace-workspace/client-extensions`, the custom element declares no `test` script and no test dependency (no Jest, Vitest, or Testing Library), and the Spring Boot extension declares no JUnit or Mockito dependency. Standing up a harness is out of scope for this fix.

## PR Check

**pr-check: SKIPPED** — The skill requires a rebase onto `upstream/master` with local `master` as the diff baseline. This branch targets `master-temp-phase-1` and sits 5,870 commits from `liferay/master`, so that rebase was not run. The validations matching this diff were run against the `master-temp-phase-1` baseline instead and all passed: Source Format (module scoped `formatSource`, clean and idempotent), Transaction Usage (no new transaction usage), and Workspace Build (`./gradlew build`, BUILD SUCCESSFUL). Service Builder matched only because the regex sees `/service/MarketplaceService.java`; there is no `service.xml` in this workspace, so it does not apply.

<!-- pr-check {"reason": "Branch targets master-temp-phase-1, not master, so the mandated rebase onto upstream/master was not applicable. Source Format, Transaction Usage and Workspace Build were run against the master-temp-phase-1 baseline and passed.", "result": "skipped", "sha": "244859e159fd410c9f6e551add107b3f9581e81c"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
